### PR TITLE
feat: Commands with no input

### DIFF
--- a/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # ProcessManager.Client Release Notes
 
+## Version 0.14.0
+
+- Support start/schedule orchestration instance with no input parameter.
+- Support get orchestration instance when started with no input.
+
 ## Version 0.13.1
 
 - Update dependencies.

--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,12 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
+## Version 0.1.0
+
+- Support start/schedule orchestration instance with no input parameter.
+- Support get orchestration instance when started with no input.
+- Implemented `Brs_021_ElectricalHeatingCalculation_V1`
+- Implemented `StartElectricalHeatingCalculationCommandV1`
+
 ## Version 0.0.1
 
 - First release.

--- a/source/ProcessManager.Abstractions/Api/Model/IInputParameterDto.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/IInputParameterDto.cs
@@ -15,6 +15,6 @@
 namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 
 /// <summary>
-/// Marker interface for JSON serializable input parameters to an orchestration instance.
+/// Allows for generic type constraints of JSON serializable input parameters to an orchestration instance.
 /// </summary>
 public interface IInputParameterDto;

--- a/source/ProcessManager.Abstractions/Api/Model/IOrchestrationDescriptionCommand.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/IOrchestrationDescriptionCommand.cs
@@ -17,27 +17,6 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescr
 namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 
 /// <summary>
-/// Interface for commands the require <see cref="OrchestrationDescriptionUniqueName"/>
-/// and an input parameter.
-/// Allows us the implement general handling of implementing commands.
-/// </summary>
-/// <typeparam name="TInputParameterDto">The input parameter type. Must be a JSON serializable type.</typeparam>
-public interface IOrchestrationDescriptionCommand<out TInputParameterDto>
-    where TInputParameterDto : IInputParameterDto
-{
-    /// <summary>
-    /// Uniquely identifies the orchestration description from which the
-    /// orchestration instance should be created.
-    /// </summary>
-    OrchestrationDescriptionUniqueNameDto OrchestrationDescriptionUniqueName { get; }
-
-    /// <summary>
-    /// Contains the Durable Functions orchestration input parameter value.
-    /// </summary>
-    TInputParameterDto InputParameter { get; }
-}
-
-/// <summary>
 /// Interface for commands the require <see cref="OrchestrationDescriptionUniqueName"/>.
 /// Allows us the implement general handling of implementing commands.
 /// </summary>
@@ -48,4 +27,20 @@ public interface IOrchestrationDescriptionCommand
     /// orchestration instance should be created.
     /// </summary>
     OrchestrationDescriptionUniqueNameDto OrchestrationDescriptionUniqueName { get; }
+}
+
+/// <summary>
+/// Interface for commands the require <see cref="IOrchestrationDescriptionCommand.OrchestrationDescriptionUniqueName"/>
+/// and an input parameter.
+/// Allows us the implement general handling of implementing commands.
+/// </summary>
+/// <typeparam name="TInputParameterDto">The input parameter type. Must be a JSON serializable type.</typeparam>
+public interface IOrchestrationDescriptionCommand<out TInputParameterDto>
+    : IOrchestrationDescriptionCommand
+        where TInputParameterDto : IInputParameterDto
+{
+    /// <summary>
+    /// Contains the Durable Functions orchestration input parameter value.
+    /// </summary>
+    TInputParameterDto InputParameter { get; }
 }

--- a/source/ProcessManager.Abstractions/Api/Model/IOrchestrationDescriptionCommand.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/IOrchestrationDescriptionCommand.cs
@@ -17,11 +17,12 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescr
 namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 
 /// <summary>
-/// Interface for commands the require <see cref="OrchestrationDescriptionUniqueName"/>.
+/// Interface for commands the require <see cref="OrchestrationDescriptionUniqueName"/>
+/// and an input parameter.
 /// Allows us the implement general handling of implementing commands.
 /// </summary>
 /// <typeparam name="TInputParameterDto">The input parameter type. Must be a JSON serializable type.</typeparam>
-public interface IOrchestrationDescriptionCommand<TInputParameterDto>
+public interface IOrchestrationDescriptionCommand<out TInputParameterDto>
     where TInputParameterDto : IInputParameterDto
 {
     /// <summary>
@@ -34,4 +35,17 @@ public interface IOrchestrationDescriptionCommand<TInputParameterDto>
     /// Contains the Durable Functions orchestration input parameter value.
     /// </summary>
     TInputParameterDto InputParameter { get; }
+}
+
+/// <summary>
+/// Interface for commands the require <see cref="OrchestrationDescriptionUniqueName"/>.
+/// Allows us the implement general handling of implementing commands.
+/// </summary>
+public interface IOrchestrationDescriptionCommand
+{
+    /// <summary>
+    /// Uniquely identifies the orchestration description from which the
+    /// orchestration instance should be created.
+    /// </summary>
+    OrchestrationDescriptionUniqueNameDto OrchestrationDescriptionUniqueName { get; }
 }

--- a/source/ProcessManager.Abstractions/Api/Model/OrchestrationInstanceTypedDto.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/OrchestrationInstanceTypedDto.cs
@@ -17,20 +17,79 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInsta
 namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 
 /// <summary>
+/// Contains information about an orchestration instance.
+/// Must be JSON serializable.
+/// </summary>
+public record OrchestrationInstanceTypedDto
+{
+    /// <summary>
+    /// Construct DTO.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="lifecycle">The high-level lifecycle states that all orchestration instances can go through.</param>
+    /// <param name="steps">Workflow steps the orchestration instance is going through.</param>
+    /// <param name="customState">Any custom state of the orchestration instance.</param>
+    public OrchestrationInstanceTypedDto(
+        Guid id,
+        OrchestrationInstanceLifecycleStateDto lifecycle,
+        IReadOnlyCollection<StepInstanceDto> steps,
+        string customState)
+    {
+        Id = id;
+        Lifecycle = lifecycle;
+        Steps = steps;
+        CustomState = customState;
+    }
+
+    public Guid Id { get; }
+
+    /// <summary>
+    /// The high-level lifecycle states that all orchestration instances can go through.
+    /// </summary>
+    public OrchestrationInstanceLifecycleStateDto Lifecycle { get; }
+
+    /// <summary>
+    /// Workflow steps the orchestration instance is going through.
+    /// </summary>
+    public IReadOnlyCollection<StepInstanceDto> Steps { get; }
+
+    /// <summary>
+    /// Any custom state of the orchestration instance.
+    /// </summary>
+    public string CustomState { get; }
+}
+
+/// <summary>
 /// Contains information about an orchestration instance including
 /// specific input parameter values.
 /// Must be JSON serializable.
 /// </summary>
 /// <typeparam name="TInputParameterDto">Must be a JSON serializable type.</typeparam>
-/// <param name="Id"></param>
-/// <param name="Lifecycle">The high-level lifecycle states that all orchestration instances can go through.</param>
-/// <param name="ParameterValue">Contains the Durable Functions orchestration input parameter value.</param>
-/// <param name="Steps">Workflow steps the orchestration instance is going through.</param>
-/// <param name="CustomState">Any custom state of the orchestration instance.</param>
-public record OrchestrationInstanceTypedDto<TInputParameterDto>(
-    Guid Id,
-    OrchestrationInstanceLifecycleStateDto Lifecycle,
-    TInputParameterDto ParameterValue,
-    IReadOnlyCollection<StepInstanceDto> Steps,
-    string CustomState)
-        where TInputParameterDto : IInputParameterDto;
+public record OrchestrationInstanceTypedDto<TInputParameterDto>
+    : OrchestrationInstanceTypedDto
+    where TInputParameterDto : IInputParameterDto
+{
+    /// <summary>
+    /// Construct DTO.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="lifecycle">The high-level lifecycle states that all orchestration instances can go through.</param>
+    /// <param name="steps">Workflow steps the orchestration instance is going through.</param>
+    /// <param name="customState">Any custom state of the orchestration instance.</param>
+    /// <param name="parameterValue">Contains the Durable Functions orchestration input parameter value.</param>
+    public OrchestrationInstanceTypedDto(
+        Guid id,
+        OrchestrationInstanceLifecycleStateDto lifecycle,
+        IReadOnlyCollection<StepInstanceDto> steps,
+        string customState,
+        TInputParameterDto parameterValue)
+            : base(id, lifecycle, steps, customState)
+    {
+        ParameterValue = parameterValue;
+    }
+
+    /// <summary>
+    /// Contains the Durable Functions orchestration input parameter value.
+    /// </summary>
+    public TInputParameterDto ParameterValue { get; }
+}

--- a/source/ProcessManager.Abstractions/Api/Model/ScheduleOrchestrationInstanceCommand.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/ScheduleOrchestrationInstanceCommand.cs
@@ -18,38 +18,6 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInsta
 namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 
 /// <summary>
-/// Command for scheduling an orchestration instance with an input parameter.
-/// Must be JSON serializable.
-/// </summary>
-/// <typeparam name="TInputParameterDto">Must be a JSON serializable type.</typeparam>
-public abstract record ScheduleOrchestrationInstanceCommand<TInputParameterDto>
-    : ScheduleOrchestrationInstanceCommand,
-    IOrchestrationDescriptionCommand<TInputParameterDto>
-        where TInputParameterDto : IInputParameterDto
-{
-    /// <summary>
-    /// Construct command.
-    /// </summary>
-    /// <param name="operatingIdentity">Identity of the user executing the command.</param>
-    /// <param name="orchestrationDescriptionUniqueName">Uniquely identifies the orchestration description from which the
-    /// orchestration instance should be created.</param>
-    /// <param name="runAt">The time when the orchestration instance should be executed by the Scheduler.</param>
-    /// <param name="inputParameter">Contains the Durable Functions orchestration input parameter value.</param>
-    public ScheduleOrchestrationInstanceCommand(
-        UserIdentityDto operatingIdentity,
-        OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName,
-        TInputParameterDto inputParameter,
-        DateTimeOffset runAt)
-            : base(operatingIdentity, orchestrationDescriptionUniqueName, runAt)
-    {
-        InputParameter = inputParameter;
-    }
-
-    /// <inheritdoc/>
-    public TInputParameterDto InputParameter { get; }
-}
-
-/// <summary>
 /// Command for scheduling an orchestration instance.
 /// Must be JSON serializable.
 /// </summary>
@@ -81,4 +49,36 @@ public abstract record ScheduleOrchestrationInstanceCommand
     /// The time when the orchestration instance should be executed by the Scheduler.
     /// </summary>
     public DateTimeOffset RunAt { get; }
+}
+
+/// <summary>
+/// Command for scheduling an orchestration instance with an input parameter.
+/// Must be JSON serializable.
+/// </summary>
+/// <typeparam name="TInputParameterDto">Must be a JSON serializable type.</typeparam>
+public abstract record ScheduleOrchestrationInstanceCommand<TInputParameterDto>
+    : ScheduleOrchestrationInstanceCommand,
+    IOrchestrationDescriptionCommand<TInputParameterDto>
+        where TInputParameterDto : IInputParameterDto
+{
+    /// <summary>
+    /// Construct command.
+    /// </summary>
+    /// <param name="operatingIdentity">Identity of the user executing the command.</param>
+    /// <param name="orchestrationDescriptionUniqueName">Uniquely identifies the orchestration description from which the
+    /// orchestration instance should be created.</param>
+    /// <param name="runAt">The time when the orchestration instance should be executed by the Scheduler.</param>
+    /// <param name="inputParameter">Contains the Durable Functions orchestration input parameter value.</param>
+    public ScheduleOrchestrationInstanceCommand(
+        UserIdentityDto operatingIdentity,
+        OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName,
+        TInputParameterDto inputParameter,
+        DateTimeOffset runAt)
+            : base(operatingIdentity, orchestrationDescriptionUniqueName, runAt)
+    {
+        InputParameter = inputParameter;
+    }
+
+    /// <inheritdoc/>
+    public TInputParameterDto InputParameter { get; }
 }

--- a/source/ProcessManager.Abstractions/Api/Model/ScheduleOrchestrationInstanceCommand.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/ScheduleOrchestrationInstanceCommand.cs
@@ -18,12 +18,13 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInsta
 namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 
 /// <summary>
-/// Command for scheduling an orchestration instance.
+/// Command for scheduling an orchestration instance with an input parameter.
 /// Must be JSON serializable.
 /// </summary>
 /// <typeparam name="TInputParameterDto">Must be a JSON serializable type.</typeparam>
 public abstract record ScheduleOrchestrationInstanceCommand<TInputParameterDto>
-    : StartOrchestrationInstanceCommand<UserIdentityDto, TInputParameterDto>
+    : ScheduleOrchestrationInstanceCommand,
+    IOrchestrationDescriptionCommand<TInputParameterDto>
         where TInputParameterDto : IInputParameterDto
 {
     /// <summary>
@@ -39,10 +40,42 @@ public abstract record ScheduleOrchestrationInstanceCommand<TInputParameterDto>
         OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName,
         TInputParameterDto inputParameter,
         DateTimeOffset runAt)
-            : base(operatingIdentity, orchestrationDescriptionUniqueName, inputParameter)
+            : base(operatingIdentity, orchestrationDescriptionUniqueName, runAt)
     {
+        InputParameter = inputParameter;
+    }
+
+    /// <inheritdoc/>
+    public TInputParameterDto InputParameter { get; }
+}
+
+/// <summary>
+/// Command for scheduling an orchestration instance.
+/// Must be JSON serializable.
+/// </summary>
+public abstract record ScheduleOrchestrationInstanceCommand
+    : OrchestrationInstanceRequest<UserIdentityDto>,
+    IOrchestrationDescriptionCommand
+{
+    /// <summary>
+    /// Construct command.
+    /// </summary>
+    /// <param name="operatingIdentity">Identity of the user executing the command.</param>
+    /// <param name="orchestrationDescriptionUniqueName">Uniquely identifies the orchestration description from which the
+    /// orchestration instance should be created.</param>
+    /// <param name="runAt">The time when the orchestration instance should be executed by the Scheduler.</param>
+    public ScheduleOrchestrationInstanceCommand(
+        UserIdentityDto operatingIdentity,
+        OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName,
+        DateTimeOffset runAt)
+            : base(operatingIdentity)
+    {
+        OrchestrationDescriptionUniqueName = orchestrationDescriptionUniqueName;
         RunAt = runAt;
     }
+
+    /// <inheritdoc/>
+    public OrchestrationDescriptionUniqueNameDto OrchestrationDescriptionUniqueName { get; }
 
     /// <summary>
     /// The time when the orchestration instance should be executed by the Scheduler.

--- a/source/ProcessManager.Abstractions/Api/Model/StartOrchestrationInstanceCommand.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/StartOrchestrationInstanceCommand.cs
@@ -18,6 +18,34 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInsta
 namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 
 /// <summary>
+/// Command for starting an orchestration instance.
+/// Must be JSON serializable.
+/// </summary>
+/// <typeparam name="TOperatingIdentity">The operating identity type. Must be a JSON serializable type.</typeparam>
+public abstract record StartOrchestrationInstanceCommand<TOperatingIdentity>
+    : OrchestrationInstanceRequest<TOperatingIdentity>,
+    IOrchestrationDescriptionCommand
+        where TOperatingIdentity : IOperatingIdentityDto
+{
+    /// <summary>
+    /// Construct command.
+    /// </summary>
+    /// <param name="operatingIdentity">Identity executing the command.</param>
+    /// <param name="orchestrationDescriptionUniqueName">Uniquely identifies the orchestration description from which the
+    /// orchestration instance should be created.</param>
+    public StartOrchestrationInstanceCommand(
+        TOperatingIdentity operatingIdentity,
+        OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName)
+            : base(operatingIdentity)
+    {
+        OrchestrationDescriptionUniqueName = orchestrationDescriptionUniqueName;
+    }
+
+    /// <inheritdoc/>
+    public OrchestrationDescriptionUniqueNameDto OrchestrationDescriptionUniqueName { get; }
+}
+
+/// <summary>
 /// Command for starting an orchestration instance with an input parameter.
 /// Must be JSON serializable.
 /// </summary>
@@ -47,32 +75,4 @@ public abstract record StartOrchestrationInstanceCommand<TOperatingIdentity, TIn
 
     /// <inheritdoc/>
     public TInputParameterDto InputParameter { get; }
-}
-
-/// <summary>
-/// Command for starting an orchestration instance.
-/// Must be JSON serializable.
-/// </summary>
-/// <typeparam name="TOperatingIdentity">The operating identity type. Must be a JSON serializable type.</typeparam>
-public abstract record StartOrchestrationInstanceCommand<TOperatingIdentity>
-    : OrchestrationInstanceRequest<TOperatingIdentity>,
-    IOrchestrationDescriptionCommand
-        where TOperatingIdentity : IOperatingIdentityDto
-{
-    /// <summary>
-    /// Construct command.
-    /// </summary>
-    /// <param name="operatingIdentity">Identity executing the command.</param>
-    /// <param name="orchestrationDescriptionUniqueName">Uniquely identifies the orchestration description from which the
-    /// orchestration instance should be created.</param>
-    public StartOrchestrationInstanceCommand(
-        TOperatingIdentity operatingIdentity,
-        OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName)
-            : base(operatingIdentity)
-    {
-        OrchestrationDescriptionUniqueName = orchestrationDescriptionUniqueName;
-    }
-
-    /// <inheritdoc/>
-    public OrchestrationDescriptionUniqueNameDto OrchestrationDescriptionUniqueName { get; }
 }

--- a/source/ProcessManager.Abstractions/Api/Model/StartOrchestrationInstanceCommand.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/StartOrchestrationInstanceCommand.cs
@@ -18,13 +18,13 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInsta
 namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 
 /// <summary>
-/// Command for starting an orchestration instance.
+/// Command for starting an orchestration instance with an input parameter.
 /// Must be JSON serializable.
 /// </summary>
 /// <typeparam name="TOperatingIdentity">The operating identity type. Must be a JSON serializable type.</typeparam>
 /// <typeparam name="TInputParameterDto">The input parameter type. Must be a JSON serializable type.</typeparam>
 public abstract record StartOrchestrationInstanceCommand<TOperatingIdentity, TInputParameterDto>
-    : OrchestrationInstanceRequest<TOperatingIdentity>,
+    : StartOrchestrationInstanceCommand<TOperatingIdentity>,
     IOrchestrationDescriptionCommand<TInputParameterDto>
         where TOperatingIdentity : IOperatingIdentityDto
         where TInputParameterDto : IInputParameterDto
@@ -40,15 +40,39 @@ public abstract record StartOrchestrationInstanceCommand<TOperatingIdentity, TIn
         TOperatingIdentity operatingIdentity,
         OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName,
         TInputParameterDto inputParameter)
-            : base(operatingIdentity)
+            : base(operatingIdentity, orchestrationDescriptionUniqueName)
     {
-        OrchestrationDescriptionUniqueName = orchestrationDescriptionUniqueName;
         InputParameter = inputParameter;
     }
 
     /// <inheritdoc/>
-    public OrchestrationDescriptionUniqueNameDto OrchestrationDescriptionUniqueName { get; }
+    public TInputParameterDto InputParameter { get; }
+}
+
+/// <summary>
+/// Command for starting an orchestration instance.
+/// Must be JSON serializable.
+/// </summary>
+/// <typeparam name="TOperatingIdentity">The operating identity type. Must be a JSON serializable type.</typeparam>
+public abstract record StartOrchestrationInstanceCommand<TOperatingIdentity>
+    : OrchestrationInstanceRequest<TOperatingIdentity>,
+    IOrchestrationDescriptionCommand
+        where TOperatingIdentity : IOperatingIdentityDto
+{
+    /// <summary>
+    /// Construct command.
+    /// </summary>
+    /// <param name="operatingIdentity">Identity executing the command.</param>
+    /// <param name="orchestrationDescriptionUniqueName">Uniquely identifies the orchestration description from which the
+    /// orchestration instance should be created.</param>
+    public StartOrchestrationInstanceCommand(
+        TOperatingIdentity operatingIdentity,
+        OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName)
+            : base(operatingIdentity)
+    {
+        OrchestrationDescriptionUniqueName = orchestrationDescriptionUniqueName;
+    }
 
     /// <inheritdoc/>
-    public TInputParameterDto InputParameter { get; }
+    public OrchestrationDescriptionUniqueNameDto OrchestrationDescriptionUniqueName { get; }
 }

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Abstractions</PackageId>
-    <PackageVersion>0.13.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.14.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -52,7 +52,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Google.Protobuf" Version="3.28.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.29.1" />
     <PackageReference Include="Grpc.Tools" Version="2.68.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/ProcessManager.Client.Tests/Integration/BRS_021/ElectricalHeatingCalculation/V1/MonitorCalculationUsingClientsScenario.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_021/ElectricalHeatingCalculation/V1/MonitorCalculationUsingClientsScenario.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.FunctionApp.TestCommon.FunctionAppHost;
 using Energinet.DataHub.Core.TestCommon;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -115,20 +114,20 @@ public class MonitorCalculationUsingClientsScenario : IAsyncLifetime
 
         isTerminated.Should().BeTrue("because we expects the orchestration instance can complete within given wait time");
 
-        // Step 3: General search using name and termination state
-        var orchestrationInstancesGeneralSearch = await processManagerClient
-            .SearchOrchestrationInstancesByNameAsync(
-                new SearchOrchestrationInstancesByNameQuery(
-                    userIdentity,
-                    name: new Brs_021_ElectricalHeatingCalculation_V1().Name,
-                    version: null,
-                    lifecycleState: OrchestrationInstanceLifecycleStates.Terminated,
-                    terminationState: OrchestrationInstanceTerminationStates.Succeeded,
-                    startedAtOrLater: null,
-                    terminatedAtOrEarlier: null),
-                CancellationToken.None);
+        ////// Step 3: General search using name and termination state
+        ////var orchestrationInstancesGeneralSearch = await processManagerClient
+        ////    .SearchOrchestrationInstancesByNameAsync(
+        ////        new SearchOrchestrationInstancesByNameQuery(
+        ////            userIdentity,
+        ////            name: new Brs_021_ElectricalHeatingCalculation_V1().Name,
+        ////            version: null,
+        ////            lifecycleState: OrchestrationInstanceLifecycleStates.Terminated,
+        ////            terminationState: OrchestrationInstanceTerminationStates.Succeeded,
+        ////            startedAtOrLater: null,
+        ////            terminatedAtOrEarlier: null),
+        ////        CancellationToken.None);
 
-        orchestrationInstancesGeneralSearch.Should().Contain(x => x.Id == orchestrationInstanceId);
+        ////orchestrationInstancesGeneralSearch.Should().Contain(x => x.Id == orchestrationInstanceId);
     }
 
     private IConfiguration CreateInMemoryConfigurations(Dictionary<string, string?> configurations)

--- a/source/ProcessManager.Client.Tests/Integration/BRS_021/ElectricalHeatingCalculation/V1/MonitorCalculationUsingClientsScenario.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_021/ElectricalHeatingCalculation/V1/MonitorCalculationUsingClientsScenario.cs
@@ -1,0 +1,140 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.FunctionApp.TestCommon.FunctionAppHost;
+using Energinet.DataHub.Core.TestCommon;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
+using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
+using Energinet.DataHub.ProcessManager.Client.Tests.Fixtures;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.ProcessManager.Client.Tests.Integration.BRS_021.ElectricalHeatingCalculation.V1;
+
+/// <summary>
+/// Test case where we verify the Process Manager clients can be used to start a
+/// calculation orchestration (with no input parameter) and monitor its status during its lifetime.
+/// </summary>
+[Collection(nameof(ProcessManagerClientCollection))]
+public class MonitorCalculationUsingClientsScenario : IAsyncLifetime
+{
+    public MonitorCalculationUsingClientsScenario(
+        ScenarioProcessManagerAppFixture processManagerAppFixture,
+        ScenarioOrchestrationsAppFixture orchestrationsAppFixture,
+        ITestOutputHelper testOutputHelper)
+    {
+        ProcessManagerAppFixture = processManagerAppFixture;
+        ProcessManagerAppFixture.SetTestOutputHelper(testOutputHelper);
+
+        OrchestrationsAppFixture = orchestrationsAppFixture;
+        OrchestrationsAppFixture.SetTestOutputHelper(testOutputHelper);
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => CreateInMemoryConfigurations(new Dictionary<string, string?>()
+        {
+            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                = ProcessManagerAppFixture.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                = OrchestrationsAppFixture.AppHostManager.HttpClient.BaseAddress!.ToString(),
+        }));
+        services.AddProcessManagerHttpClients();
+        ServiceProvider = services.BuildServiceProvider();
+    }
+
+    private ScenarioProcessManagerAppFixture ProcessManagerAppFixture { get; }
+
+    private ScenarioOrchestrationsAppFixture OrchestrationsAppFixture { get; }
+
+    private ServiceProvider ServiceProvider { get; }
+
+    public Task InitializeAsync()
+    {
+        ProcessManagerAppFixture.AppHostManager.ClearHostLog();
+        OrchestrationsAppFixture.AppHostManager.ClearHostLog();
+
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        ProcessManagerAppFixture.SetTestOutputHelper(null!);
+        OrchestrationsAppFixture.SetTestOutputHelper(null!);
+
+        await ServiceProvider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Calculation_WhenStarted_CanMonitorLifecycle()
+    {
+        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
+
+        var userIdentity = new UserIdentityDto(
+            UserId: Guid.NewGuid(),
+            ActorId: Guid.NewGuid());
+
+        // Step 1: Start new calculation orchestration instance
+        var orchestrationInstanceId = await processManagerClient
+            .StartNewOrchestrationInstanceAsync(
+                new StartElectricalHeatingCalculationCommandV1(
+                    userIdentity),
+                CancellationToken.None);
+
+        // Step 2: Query until terminated with succeeded
+        var isTerminated = await Awaiter.TryWaitUntilConditionAsync(
+            async () =>
+            {
+                var orchestrationInstance = await processManagerClient
+                    .GetOrchestrationInstanceByIdAsync(
+                        new GetOrchestrationInstanceByIdQuery(
+                            userIdentity,
+                            orchestrationInstanceId),
+                        CancellationToken.None);
+
+                return
+                    orchestrationInstance.Lifecycle.State == OrchestrationInstanceLifecycleStates.Terminated
+                    && orchestrationInstance.Lifecycle.TerminationState == OrchestrationInstanceTerminationStates.Succeeded;
+            },
+            timeLimit: TimeSpan.FromSeconds(60),
+            delay: TimeSpan.FromSeconds(3));
+
+        isTerminated.Should().BeTrue("because we expects the orchestration instance can complete within given wait time");
+
+        // Step 3: General search using name and termination state
+        var orchestrationInstancesGeneralSearch = await processManagerClient
+            .SearchOrchestrationInstancesByNameAsync(
+                new SearchOrchestrationInstancesByNameQuery(
+                    userIdentity,
+                    name: new Brs_021_ElectricalHeatingCalculation_V1().Name,
+                    version: null,
+                    lifecycleState: OrchestrationInstanceLifecycleStates.Terminated,
+                    terminationState: OrchestrationInstanceTerminationStates.Succeeded,
+                    startedAtOrLater: null,
+                    terminatedAtOrEarlier: null),
+                CancellationToken.None);
+
+        orchestrationInstancesGeneralSearch.Should().Contain(x => x.Id == orchestrationInstanceId);
+    }
+
+    private IConfiguration CreateInMemoryConfigurations(Dictionary<string, string?> configurations)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(configurations)
+            .Build();
+    }
+}

--- a/source/ProcessManager.Client.Tests/Integration/BRS_021/ElectricalHeatingCalculation/V1/MonitorCalculationUsingClientsScenario.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_021/ElectricalHeatingCalculation/V1/MonitorCalculationUsingClientsScenario.cs
@@ -114,20 +114,20 @@ public class MonitorCalculationUsingClientsScenario : IAsyncLifetime
 
         isTerminated.Should().BeTrue("because we expects the orchestration instance can complete within given wait time");
 
-        ////// Step 3: General search using name and termination state
-        ////var orchestrationInstancesGeneralSearch = await processManagerClient
-        ////    .SearchOrchestrationInstancesByNameAsync(
-        ////        new SearchOrchestrationInstancesByNameQuery(
-        ////            userIdentity,
-        ////            name: new Brs_021_ElectricalHeatingCalculation_V1().Name,
-        ////            version: null,
-        ////            lifecycleState: OrchestrationInstanceLifecycleStates.Terminated,
-        ////            terminationState: OrchestrationInstanceTerminationStates.Succeeded,
-        ////            startedAtOrLater: null,
-        ////            terminatedAtOrEarlier: null),
-        ////        CancellationToken.None);
+        // Step 3: General search using name and termination state
+        var orchestrationInstancesGeneralSearch = await processManagerClient
+            .SearchOrchestrationInstancesByNameAsync(
+                new SearchOrchestrationInstancesByNameQuery(
+                    userIdentity,
+                    name: new Brs_021_ElectricalHeatingCalculation_V1().Name,
+                    version: null,
+                    lifecycleState: OrchestrationInstanceLifecycleStates.Terminated,
+                    terminationState: OrchestrationInstanceTerminationStates.Succeeded,
+                    startedAtOrLater: null,
+                    terminatedAtOrEarlier: null),
+                CancellationToken.None);
 
-        ////orchestrationInstancesGeneralSearch.Should().Contain(x => x.Id == orchestrationInstanceId);
+        orchestrationInstancesGeneralSearch.Should().Contain(x => x.Id == orchestrationInstanceId);
     }
 
     private IConfiguration CreateInMemoryConfigurations(Dictionary<string, string?> configurations)

--- a/source/ProcessManager.Client.Tests/Integration/BRS_023_027/V1/MonitorCalculationUsingApiScenario.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_023_027/V1/MonitorCalculationUsingApiScenario.cs
@@ -26,7 +26,7 @@ namespace Energinet.DataHub.ProcessManager.Client.Tests.Integration.BRS_023_027.
 
 /// <summary>
 /// Test case where we verify the Process Manager clients can be used to start a
-/// calculation orchestration and monitor its status during its lifetime.
+/// calculation orchestration (with input parameter) and monitor its status during its lifetime.
 /// </summary>
 [Collection(nameof(ProcessManagerClientCollection))]
 public class MonitorCalculationUsingApiScenario : IAsyncLifetime

--- a/source/ProcessManager.Client.Tests/Integration/BRS_023_027/V1/MonitorCalculationUsingClientsScenario.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_023_027/V1/MonitorCalculationUsingClientsScenario.cs
@@ -30,7 +30,7 @@ namespace Energinet.DataHub.ProcessManager.Client.Tests.Integration.BRS_023_027.
 
 /// <summary>
 /// Test case where we verify the Process Manager clients can be used to start a
-/// calculation orchestration and monitor its status during its lifetime.
+/// calculation orchestration (with input parameter) and monitor its status during its lifetime.
 /// </summary>
 [Collection(nameof(ProcessManagerClientCollection))]
 public class MonitorCalculationUsingClientsScenario : IAsyncLifetime

--- a/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
+++ b/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
@@ -14,11 +14,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
+++ b/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
@@ -34,10 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Unit\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="functionapphost.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
+++ b/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
@@ -96,7 +96,7 @@ public static class ClientExtensions
         httpClient.BaseAddress = new Uri(baseAddress);
 
         var httpContextAccessor = sp.GetService<IHttpContextAccessor>();
-        var authorizationHeaderValue = (string?)httpContextAccessor?.HttpContext.Request.Headers["Authorization"];
+        var authorizationHeaderValue = (string?)httpContextAccessor?.HttpContext?.Request.Headers.Authorization;
         if (!string.IsNullOrWhiteSpace(authorizationHeaderValue))
             httpClient.DefaultRequestHeaders.Add("Authorization", authorizationHeaderValue);
     }

--- a/source/ProcessManager.Client/Extensions/TypeExtensions.cs
+++ b/source/ProcessManager.Client/Extensions/TypeExtensions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.ProcessManager.Client.Extensions;
+
+public static class TypeExtensions
+{
+    /// <summary>
+    /// Alternative version of <see cref="Type.IsSubclassOf"/> that supports raw generic types (generic types without
+    /// any type parameters).
+    ///
+    /// Inspired by: https://www.extensionmethod.net/csharp/type/issubclassofrawgeneric
+    /// </summary>
+    /// <param name="toCheck">To type to determine for whether it derives from <paramref name="baseType"/>.</param>
+    /// <param name="baseType">The base type class for which the check is made.</param>
+    public static bool IsSubclassOfRawGeneric(this Type toCheck, Type baseType)
+    {
+        while (toCheck != typeof(object))
+        {
+            var cur = toCheck.IsGenericType
+                ? toCheck.GetGenericTypeDefinition()
+                : toCheck;
+
+            if (baseType == cur)
+                return true;
+
+            toCheck = toCheck.BaseType!;
+        }
+
+        return false;
+    }
+}

--- a/source/ProcessManager.Client/IProcessManagerClient.cs
+++ b/source/ProcessManager.Client/IProcessManagerClient.cs
@@ -46,6 +46,13 @@ public interface IProcessManagerClient
     /// <summary>
     /// Get orchestration instance by id.
     /// </summary>
+    Task<OrchestrationInstanceTypedDto> GetOrchestrationInstanceByIdAsync(
+        GetOrchestrationInstanceByIdQuery query,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get orchestration instance by id, and cast orignal input parameter to <see cref="IInputParameterDto"/>.
+    /// </summary>
     Task<OrchestrationInstanceTypedDto<TInputParameterDto>> GetOrchestrationInstanceByIdAsync<TInputParameterDto>(
         GetOrchestrationInstanceByIdQuery query,
         CancellationToken cancellationToken)

--- a/source/ProcessManager.Client/IProcessManagerClient.cs
+++ b/source/ProcessManager.Client/IProcessManagerClient.cs
@@ -61,6 +61,16 @@ public interface IProcessManagerClient
     /// <summary>
     /// Get all orchestration instances filtered by their related orchestration definition name and version,
     /// and their lifecycle / termination states.
+    /// Returns orchestration instances.
+    /// </summary>
+    Task<IReadOnlyCollection<OrchestrationInstanceTypedDto>> SearchOrchestrationInstancesByNameAsync(
+        SearchOrchestrationInstancesByNameQuery query,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get all orchestration instances filtered by their related orchestration definition name and version,
+    /// and their lifecycle / termination states.
+    /// Returns orchestration instances including their original input parameter value.
     /// </summary>
     Task<IReadOnlyCollection<OrchestrationInstanceTypedDto<TInputParameterDto>>> SearchOrchestrationInstancesByNameAsync<TInputParameterDto>(
         SearchOrchestrationInstancesByNameQuery query,

--- a/source/ProcessManager.Client/IProcessManagerClient.cs
+++ b/source/ProcessManager.Client/IProcessManagerClient.cs
@@ -25,10 +25,9 @@ public interface IProcessManagerClient
     /// <summary>
     /// Schedule an orchestration instance and return its id.
     /// </summary>
-    Task<Guid> ScheduleNewOrchestrationInstanceAsync<TInputParameterDto>(
-        ScheduleOrchestrationInstanceCommand<TInputParameterDto> command,
-        CancellationToken cancellationToken)
-            where TInputParameterDto : IInputParameterDto;
+    Task<Guid> ScheduleNewOrchestrationInstanceAsync(
+        ScheduleOrchestrationInstanceCommand command,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Cancel a scheduled orchestration instance.
@@ -38,12 +37,11 @@ public interface IProcessManagerClient
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Start an orchestration instance and return its id.
+    /// Start an orchestration instance, and return its id.
     /// </summary>
-    Task<Guid> StartNewOrchestrationInstanceAsync<TInputParameterDto>(
-        StartOrchestrationInstanceCommand<UserIdentityDto, TInputParameterDto> command,
-        CancellationToken cancellationToken)
-            where TInputParameterDto : IInputParameterDto;
+    Task<Guid> StartNewOrchestrationInstanceAsync(
+        StartOrchestrationInstanceCommand<UserIdentityDto> command,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Get orchestration instance by id.

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -47,8 +47,8 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Client</PackageId>
-    <PackageVersion>0.13.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.14.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Client/ProcessManagerClient.cs
+++ b/source/ProcessManager.Client/ProcessManagerClient.cs
@@ -41,15 +41,15 @@ internal class ProcessManagerClient : IProcessManagerClient
     }
 
     /// <inheritdoc/>
-    public async Task<Guid> ScheduleNewOrchestrationInstanceAsync<TInputParameterDto>(
-        ScheduleOrchestrationInstanceCommand<TInputParameterDto> command,
+    public async Task<Guid> ScheduleNewOrchestrationInstanceAsync(
+        ScheduleOrchestrationInstanceCommand command,
         CancellationToken cancellationToken)
-            where TInputParameterDto : IInputParameterDto
     {
         using var request = new HttpRequestMessage(
             HttpMethod.Post,
             $"/api/orchestrationinstance/command/schedule/custom/{command.OrchestrationDescriptionUniqueName.Name}/{command.OrchestrationDescriptionUniqueName.Version}");
-        var json = JsonSerializer.Serialize(command);
+        // Ensure we serialize using the derived type and not the base type; otherwise we won't serialize all properties.
+        var json = JsonSerializer.Serialize(command, command.GetType());
         request.Content = new StringContent(
             json,
             Encoding.UTF8,
@@ -88,15 +88,15 @@ internal class ProcessManagerClient : IProcessManagerClient
     }
 
     /// <inheritdoc/>
-    public async Task<Guid> StartNewOrchestrationInstanceAsync<TInputParameterDto>(
-        StartOrchestrationInstanceCommand<UserIdentityDto, TInputParameterDto> command,
+    public async Task<Guid> StartNewOrchestrationInstanceAsync(
+        StartOrchestrationInstanceCommand<UserIdentityDto> command,
         CancellationToken cancellationToken)
-            where TInputParameterDto : IInputParameterDto
     {
         using var request = new HttpRequestMessage(
             HttpMethod.Post,
             $"/api/orchestrationinstance/command/start/custom/{command.OrchestrationDescriptionUniqueName.Name}/{command.OrchestrationDescriptionUniqueName.Version}");
-        var json = JsonSerializer.Serialize(command);
+        // Ensure we serialize using the derived type and not the base type; otherwise we won't serialize all properties.
+        var json = JsonSerializer.Serialize(command, command.GetType());
         request.Content = new StringContent(
             json,
             Encoding.UTF8,

--- a/source/ProcessManager.Client/ProcessManagerClient.cs
+++ b/source/ProcessManager.Client/ProcessManagerClient.cs
@@ -184,6 +184,31 @@ internal class ProcessManagerClient : IProcessManagerClient
         return orchestrationInstance!;
     }
 
+    public async Task<IReadOnlyCollection<OrchestrationInstanceTypedDto>> SearchOrchestrationInstancesByNameAsync(
+        SearchOrchestrationInstancesByNameQuery query,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/api/orchestrationinstance/query/name");
+        var json = JsonSerializer.Serialize(query);
+        request.Content = new StringContent(
+            json,
+            Encoding.UTF8,
+            "application/json");
+
+        using var actualResponse = await _generalApiHttpClient
+            .SendAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+        actualResponse.EnsureSuccessStatusCode();
+
+        var orchestrationInstances = await actualResponse.Content
+            .ReadFromJsonAsync<IReadOnlyCollection<OrchestrationInstanceTypedDto>>(cancellationToken)
+            .ConfigureAwait(false);
+
+        return orchestrationInstances!;
+    }
+
     /// <inheritdoc/>
     public async Task<IReadOnlyCollection<OrchestrationInstanceTypedDto<TInputParameterDto>>> SearchOrchestrationInstancesByNameAsync<TInputParameterDto>(
         SearchOrchestrationInstancesByNameQuery query,

--- a/source/ProcessManager.Core.Tests/ProcessManager.Core.Tests.csproj
+++ b/source/ProcessManager.Core.Tests/ProcessManager.Core.Tests.csproj
@@ -8,15 +8,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.1" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="8.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Core/Application/Orchestration/IStartOrchestrationInstanceCommands.cs
+++ b/source/ProcessManager.Core/Application/Orchestration/IStartOrchestrationInstanceCommands.cs
@@ -23,6 +23,14 @@ public interface IStartOrchestrationInstanceCommands
     /// <summary>
     /// Start a new instance of an orchestration.
     /// </summary>
+    Task<OrchestrationInstanceId> StartNewOrchestrationInstanceAsync(
+        OperatingIdentity identity,
+        OrchestrationDescriptionUniqueName uniqueName);
+
+    /// <summary>
+    /// Start a new instance of an orchestration with input parameter and the
+    /// possibility to skip steps.
+    /// </summary>
     Task<OrchestrationInstanceId> StartNewOrchestrationInstanceAsync<TParameter>(
         OperatingIdentity identity,
         OrchestrationDescriptionUniqueName uniqueName,
@@ -32,6 +40,15 @@ public interface IStartOrchestrationInstanceCommands
 
     /// <summary>
     /// Schedule a new instance of an orchestration.
+    /// </summary>
+    Task<OrchestrationInstanceId> ScheduleNewOrchestrationInstanceAsync(
+        UserIdentity identity,
+        OrchestrationDescriptionUniqueName uniqueName,
+        Instant runAt);
+
+    /// <summary>
+    /// Schedule a new instance of an orchestration with input parameter and the
+    /// possibility to skip steps.
     /// </summary>
     Task<OrchestrationInstanceId> ScheduleNewOrchestrationInstanceAsync<TParameter>(
         UserIdentity identity,

--- a/source/ProcessManager.Core/Domain/OrchestrationInstance/ParameterValue.cs
+++ b/source/ProcessManager.Core/Domain/OrchestrationInstance/ParameterValue.cs
@@ -27,6 +27,8 @@ public class ParameterValue
         SerializedParameterValue = string.Empty;
     }
 
+    public bool IsEmpty => SerializedParameterValue == string.Empty;
+
     /// <summary>
     /// The JSON representation of the orchestration input parameter value.
     /// </summary>
@@ -45,7 +47,11 @@ public class ParameterValue
 
     public ExpandoObject AsExpandoObject()
     {
-        return JsonSerializer.Deserialize<ExpandoObject>(SerializedParameterValue) ?? new ExpandoObject();
+        if (IsEmpty)
+            return new ExpandoObject();
+
+        return JsonSerializer.Deserialize<ExpandoObject>(SerializedParameterValue)
+            ?? new ExpandoObject();
     }
 
     public TParameter AsType<TParameter>()

--- a/source/ProcessManager.Core/ProcessManager.Core.csproj
+++ b/source/ProcessManager.Core/ProcessManager.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
     <PackageReference Include="NJsonSchema" Version="11.1.0" />
     <PackageReference Include="NodaTime" Version="3.2.0" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="8.0.1" />

--- a/source/ProcessManager.Core/ProcessManager.Core.csproj
+++ b/source/ProcessManager.Core/ProcessManager.Core.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" />
-    <PackageReference Include="NJsonSchema" Version="11.0.2" />
+    <PackageReference Include="NJsonSchema" Version="11.1.0" />
     <PackageReference Include="NodaTime" Version="3.2.0" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="8.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.0.2" />

--- a/source/ProcessManager.DatabaseMigration/ProcessManager.DatabaseMigration.csproj
+++ b/source/ProcessManager.DatabaseMigration/ProcessManager.DatabaseMigration.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="5.0.41" />
+    <PackageReference Include="dbup-sqlserver" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>0.0.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.1.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ElectricalHeatingCalculation/V1/Model/Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ElectricalHeatingCalculation/V1/Model/Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescription;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
+
+public record Brs_021_ElectricalHeatingCalculation_V1()
+    : OrchestrationDescriptionUniqueNameDto("Brs_021_ElectricalHeatingCalculation", 1);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ElectricalHeatingCalculation/V1/Model/StartElectricalHeatingCalculationCommandV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ElectricalHeatingCalculation/V1/Model/StartElectricalHeatingCalculationCommandV1.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
+
+/// <summary>
+/// Command for starting a BRS-021 electrical heating calculation.
+/// Must be JSON serializable.
+/// </summary>
+public record StartElectricalHeatingCalculationCommandV1
+    : StartOrchestrationInstanceCommand<UserIdentityDto>
+{
+    /// <summary>
+    /// Construct command.
+    /// </summary>
+    /// <param name="operatingIdentity">Identity of the user executing the command.</param>
+    public StartElectricalHeatingCalculationCommandV1(
+        UserIdentityDto operatingIdentity)
+            : base(
+                operatingIdentity,
+                orchestrationDescriptionUniqueName: new Brs_021_ElectricalHeatingCalculation_V1())
+    {
+    }
+}

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_023_027/CalculationQuery.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_023_027/CalculationQuery.cs
@@ -22,7 +22,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// Query for searching for BRS-023 or BRS-027 calculations.
 /// Must be JSON serializable.
 /// </summary>
-public record CalculationQuery
+public sealed record CalculationQuery
     : SearchOrchestrationInstancesByCustomQuery<CalculationQueryResult>
 {
     /// <summary>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_023_027/V1/Model/Brs_023_027_V1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_023_027/V1/Model/Brs_023_027_V1.cs
@@ -17,4 +17,4 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescr
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027.V1.Model;
 
 public record Brs_023_027_V1()
-    : OrchestrationDescriptionUniqueNameDto("BRS_023_027", 1);
+    : OrchestrationDescriptionUniqueNameDto("Brs_023_027", 1);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_023_027/V1/Model/ScheduleCalculationCommandV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_023_027/V1/Model/ScheduleCalculationCommandV1.cs
@@ -21,7 +21,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// Command for scheduling a BRS-023 or BRS-027 calculation.
 /// Must be JSON serializable.
 /// </summary>
-public record ScheduleCalculationCommandV1
+public sealed record ScheduleCalculationCommandV1
     : ScheduleOrchestrationInstanceCommand<CalculationInputV1>
 {
     /// <summary>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_023_027/V1/Model/StartCalculationCommandV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_023_027/V1/Model/StartCalculationCommandV1.cs
@@ -21,7 +21,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// Command for starting a BRS-023 or BRS-027 calculation.
 /// Must be JSON serializable.
 /// </summary>
-public record StartCalculationCommandV1
+public sealed record StartCalculationCommandV1
     : StartOrchestrationInstanceCommand<UserIdentityDto, CalculationInputV1>
 {
     /// <summary>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026/V1/Model/Brs_026_V1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026/V1/Model/Brs_026_V1.cs
@@ -17,4 +17,4 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescr
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026.V1.Model;
 
 public record Brs_026_V1()
-    : OrchestrationDescriptionUniqueNameDto("BRS_026", 1);
+    : OrchestrationDescriptionUniqueNameDto("Brs_026", 1);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026/V1/Model/StartRequestCalculatedEnergyTimeSeriesCommandV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026/V1/Model/StartRequestCalculatedEnergyTimeSeriesCommandV1.cs
@@ -21,7 +21,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// Command for starting a BRS-026.
 /// Must be JSON serializable.
 /// </summary>
-public record StartRequestCalculatedEnergyTimeSeriesCommandV1
+public sealed record StartRequestCalculatedEnergyTimeSeriesCommandV1
     : MessageCommand<RequestCalculatedEnergyTimeSeriesInputV1>
 {
     /// <summary>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_028/V1/Model/Brs_028_V1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_028/V1/Model/Brs_028_V1.cs
@@ -17,4 +17,4 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescr
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_028.V1.Model;
 
 public record Brs_028_V1()
-    : OrchestrationDescriptionUniqueNameDto("BRS_028", 1);
+    : OrchestrationDescriptionUniqueNameDto("Brs_028", 1);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_028/V1/Model/StartRequestCalculatedEnergyTimeSeriesCommandV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_028/V1/Model/StartRequestCalculatedEnergyTimeSeriesCommandV1.cs
@@ -21,7 +21,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// Command for starting a BRS-028.
 /// Must be JSON serializable.
 /// </summary>
-public record RequestCalculatedWholesaleServicesCommandV1
+public sealed record RequestCalculatedWholesaleServicesCommandV1
     : MessageCommand<RequestCalculatedWholesaleServicesInputV1>
 {
     /// <summary>

--- a/source/ProcessManager.Orchestrations.Tests/ProcessManager.Orchestrations.Tests.csproj
+++ b/source/ProcessManager.Orchestrations.Tests/ProcessManager.Orchestrations.Tests.csproj
@@ -13,11 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
+++ b/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="6.1.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="6.1.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="13.2.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="14.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.2.2" />
   </ItemGroup>
   <ItemGroup>

--- a/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
+++ b/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
@@ -31,7 +31,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Api\Mappers\" />
-    <Folder Include="Processes\BRS_021\" />
     <Folder Include="Processes\BRS_026\V1\Activities\" />
   </ItemGroup>
   <ItemGroup>

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/CalculationStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/CalculationStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManagement.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationInstance;
+using Microsoft.Azure.Functions.Worker;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities;
+
+internal class CalculationStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1(
+    IClock clock,
+    IOrchestrationInstanceProgressRepository progressRepository)
+    : ProgressActivityBase(
+        clock,
+        progressRepository)
+{
+    [Function(nameof(CalculationStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1))]
+    public async Task Run(
+        [ActivityTrigger] Guid orchestrationInstanceId)
+    {
+        var orchestrationInstance = await ProgressRepository
+            .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
+            .ConfigureAwait(false);
+
+        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_021_ElectricalHeatingCalculation_V1.CalculationStepSequence);
+        step.Lifecycle.TransitionToRunning(Clock);
+        await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+
+        // TODO: For demo purposes; remove when done
+        await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/CalculationStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/CalculationStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManagement.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationInstance;
+using Microsoft.Azure.Functions.Worker;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities;
+
+internal class CalculationStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1(
+    IClock clock,
+    IOrchestrationInstanceProgressRepository progressRepository)
+    : ProgressActivityBase(
+        clock,
+        progressRepository)
+{
+    [Function(nameof(CalculationStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1))]
+    public async Task Run(
+        [ActivityTrigger] Guid orchestrationInstanceId)
+    {
+        var orchestrationInstance = await ProgressRepository
+            .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
+            .ConfigureAwait(false);
+
+        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_021_ElectricalHeatingCalculation_V1.CalculationStepSequence);
+        step.Lifecycle.TransitionToTerminated(Clock, OrchestrationStepTerminationStates.Succeeded);
+        await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+
+        // TODO: For demo purposes; remove when done
+        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/EnqueueMessagesStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/EnqueueMessagesStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManagement.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationInstance;
+using Microsoft.Azure.Functions.Worker;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities;
+
+internal class EnqueueMessagesStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1(
+    IClock clock,
+    IOrchestrationInstanceProgressRepository progressRepository)
+    : ProgressActivityBase(
+        clock,
+        progressRepository)
+{
+    [Function(nameof(EnqueueMessagesStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1))]
+    public async Task Run(
+        [ActivityTrigger] Guid orchestrationInstanceId)
+    {
+        var orchestrationInstance = await ProgressRepository
+            .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
+            .ConfigureAwait(false);
+
+        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_021_ElectricalHeatingCalculation_V1.EnqueueMessagesStepSequence);
+        if (!step.IsSkipped())
+        {
+            step.Lifecycle.TransitionToRunning(Clock);
+            await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+
+            // TODO: For demo purposes; remove when done
+            await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/EnqueueMessagesStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/EnqueueMessagesStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManagement.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationInstance;
+using Microsoft.Azure.Functions.Worker;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities;
+
+internal class EnqueueMessagesStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1(
+    IClock clock,
+    IOrchestrationInstanceProgressRepository progressRepository)
+    : ProgressActivityBase(
+        clock,
+        progressRepository)
+{
+    [Function(nameof(EnqueueMessagesStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1))]
+    public async Task Run(
+        [ActivityTrigger] Guid orchestrationInstanceId)
+    {
+        var orchestrationInstance = await ProgressRepository
+            .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
+            .ConfigureAwait(false);
+
+        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_021_ElectricalHeatingCalculation_V1.EnqueueMessagesStepSequence);
+        if (!step.IsSkipped())
+        {
+            step.Lifecycle.TransitionToTerminated(Clock, OrchestrationStepTerminationStates.Succeeded);
+            await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+
+            // TODO: For demo purposes; remove when done
+            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/OrchestrationInitializeActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/OrchestrationInitializeActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManagement.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationInstance;
+using Microsoft.Azure.Functions.Worker;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities;
+
+/// <summary>
+/// The first activity in the orchestration.
+/// It is responsible for updating the status to 'Running'.
+/// </summary>
+internal class OrchestrationInitializeActivity_Brs_021_ElectricalHeatingCalculation_V1(
+    IClock clock,
+    IOrchestrationInstanceProgressRepository progressRepository)
+    : ProgressActivityBase(
+        clock,
+        progressRepository)
+{
+    [Function(nameof(OrchestrationInitializeActivity_Brs_021_ElectricalHeatingCalculation_V1))]
+    public async Task Run(
+        [ActivityTrigger] Guid orchestrationInstanceId)
+    {
+        var orchestrationInstance = await ProgressRepository
+            .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
+            .ConfigureAwait(false);
+
+        orchestrationInstance.Lifecycle.TransitionToRunning(Clock);
+        await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+
+        // TODO: For demo purposes; remove when done
+        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/OrchestrationTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/OrchestrationTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManagement.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationInstance;
+using Microsoft.Azure.Functions.Worker;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities;
+
+/// <summary>
+/// The last activity in the orchestration.
+/// It is responsible for updating the status to 'Terminated'.
+/// </summary>
+internal class OrchestrationTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1(
+    IClock clock,
+    IOrchestrationInstanceProgressRepository progressRepository)
+    : ProgressActivityBase(
+        clock,
+        progressRepository)
+{
+    [Function(nameof(OrchestrationTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1))]
+    public async Task Run(
+        [ActivityTrigger] Guid orchestrationInstanceId)
+    {
+        var orchestrationInstance = await ProgressRepository
+            .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
+            .ConfigureAwait(false);
+
+        orchestrationInstance.Lifecycle.TransitionToSucceeded(Clock);
+        await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+
+        // TODO: For demo purposes; remove when done
+        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/ProgressActivityBase.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/ProgressActivityBase.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManagement.Core.Application.Orchestration;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities;
+
+internal abstract class ProgressActivityBase(
+    IClock clock,
+    IOrchestrationInstanceProgressRepository progressRepository)
+{
+    protected IClock Clock { get; } = clock;
+
+    protected IOrchestrationInstanceProgressRepository ProgressRepository { get; } = progressRepository;
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1;
+
+// TODO: Implement according to guidelines: https://energinet.atlassian.net/wiki/spaces/D3/pages/824803345/Durable+Functions+Development+Guidelines
+internal class Orchestration_Brs_021_ElectricalHeatingCalculation_V1
+{
+    internal const int CalculationStepSequence = 1;
+    internal const int EnqueueMessagesStepSequence = 2;
+
+    [Function(nameof(Orchestration_Brs_021_ElectricalHeatingCalculation_V1))]
+    public async Task<string> Run(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var defaultRetryOptions = CreateDefaultRetryOptions();
+
+        // Initialize
+        await context.CallActivityAsync(
+            nameof(OrchestrationInitializeActivity_Brs_021_ElectricalHeatingCalculation_V1),
+            context.InstanceId,
+            defaultRetryOptions);
+
+        // Step: Calculation
+        await context.CallActivityAsync(
+            nameof(CalculationStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1),
+            context.InstanceId,
+            defaultRetryOptions);
+        await context.CallActivityAsync(
+            nameof(CalculationStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1),
+            context.InstanceId,
+            defaultRetryOptions);
+
+        // Step: Enqueue messages
+        await context.CallActivityAsync(
+            nameof(EnqueueMessagesStepStartActivity_Brs_021_ElectricalHeatingCalculation_V1),
+            context.InstanceId,
+            defaultRetryOptions);
+        await context.CallActivityAsync(
+            nameof(EnqueueMessagesStepTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1),
+            context.InstanceId,
+            defaultRetryOptions);
+
+        // Terminate
+        await context.CallActivityAsync(
+            nameof(OrchestrationTerminateActivity_Brs_021_ElectricalHeatingCalculation_V1),
+            context.InstanceId,
+            defaultRetryOptions);
+
+        return "Success";
+    }
+
+    private static TaskOptions CreateDefaultRetryOptions()
+    {
+        return TaskOptions.FromRetryPolicy(new RetryPolicy(
+            maxNumberOfAttempts: 5,
+            firstRetryInterval: TimeSpan.FromSeconds(30),
+            backoffCoefficient: 2.0));
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/CalculationStepStartActivity_Brs_023_027_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/CalculationStepStartActivity_Brs_023_027_V1.cs
@@ -19,14 +19,14 @@ using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.V1.Activities;
 
-internal class Brs023EnqueueMessagesStepStartActivityV1(
+internal class CalculationStepStartActivity_Brs_023_027_V1(
     IClock clock,
     IOrchestrationInstanceProgressRepository progressRepository)
     : ProgressActivityBase(
         clock,
         progressRepository)
 {
-    [Function(nameof(Brs023EnqueueMessagesStepStartActivityV1))]
+    [Function(nameof(CalculationStepStartActivity_Brs_023_027_V1))]
     public async Task Run(
         [ActivityTrigger] Guid orchestrationInstanceId)
     {
@@ -34,14 +34,11 @@ internal class Brs023EnqueueMessagesStepStartActivityV1(
             .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
             .ConfigureAwait(false);
 
-        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_023_027_V1.EnqueueMessagesStepSequence);
-        if (!step.IsSkipped())
-        {
-            step.Lifecycle.TransitionToRunning(Clock);
-            await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_023_027_V1.CalculationStepSequence);
+        step.Lifecycle.TransitionToRunning(Clock);
+        await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
 
-            // TODO: For demo purposes; remove when done
-            await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
-        }
+        // TODO: For demo purposes; remove when done
+        await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/CalculationStepTerminateActivity_Brs_023_027_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/CalculationStepTerminateActivity_Brs_023_027_V1.cs
@@ -19,14 +19,14 @@ using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.V1.Activities;
 
-internal class Brs023CalculationStepStartActivityV1(
+internal class CalculationStepTerminateActivity_Brs_023_027_V1(
     IClock clock,
     IOrchestrationInstanceProgressRepository progressRepository)
     : ProgressActivityBase(
         clock,
         progressRepository)
 {
-    [Function(nameof(Brs023CalculationStepStartActivityV1))]
+    [Function(nameof(CalculationStepTerminateActivity_Brs_023_027_V1))]
     public async Task Run(
         [ActivityTrigger] Guid orchestrationInstanceId)
     {
@@ -35,10 +35,10 @@ internal class Brs023CalculationStepStartActivityV1(
             .ConfigureAwait(false);
 
         var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_023_027_V1.CalculationStepSequence);
-        step.Lifecycle.TransitionToRunning(Clock);
+        step.Lifecycle.TransitionToTerminated(Clock, OrchestrationStepTerminationStates.Succeeded);
         await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
 
         // TODO: For demo purposes; remove when done
-        await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/EnqueueMessagesStepStartActivity_Brs_023_027_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/EnqueueMessagesStepStartActivity_Brs_023_027_V1.cs
@@ -19,18 +19,14 @@ using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.V1.Activities;
 
-/// <summary>
-/// The last activity in the orchestration.
-/// It is responsible for updating the status to 'Terminated'.
-/// </summary>
-internal class Brs023OrchestrationTerminateActivityV1(
+internal class EnqueueMessagesStepStartActivity_Brs_023_027_V1(
     IClock clock,
     IOrchestrationInstanceProgressRepository progressRepository)
     : ProgressActivityBase(
         clock,
         progressRepository)
 {
-    [Function(nameof(Brs023OrchestrationTerminateActivityV1))]
+    [Function(nameof(EnqueueMessagesStepStartActivity_Brs_023_027_V1))]
     public async Task Run(
         [ActivityTrigger] Guid orchestrationInstanceId)
     {
@@ -38,10 +34,14 @@ internal class Brs023OrchestrationTerminateActivityV1(
             .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
             .ConfigureAwait(false);
 
-        orchestrationInstance.Lifecycle.TransitionToSucceeded(Clock);
-        await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_023_027_V1.EnqueueMessagesStepSequence);
+        if (!step.IsSkipped())
+        {
+            step.Lifecycle.TransitionToRunning(Clock);
+            await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
 
-        // TODO: For demo purposes; remove when done
-        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+            // TODO: For demo purposes; remove when done
+            await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+        }
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/EnqueueMessagesStepTerminateActivity_Brs_023_027_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/EnqueueMessagesStepTerminateActivity_Brs_023_027_V1.cs
@@ -19,18 +19,14 @@ using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.V1.Activities;
 
-/// <summary>
-/// The first activity in the orchestration.
-/// It is responsible for updating the status to 'Running'.
-/// </summary>
-internal class Brs023OrchestrationInitializeActivityV1(
+internal class EnqueueMessagesStepTerminateActivity_Brs_023_027_V1(
     IClock clock,
     IOrchestrationInstanceProgressRepository progressRepository)
     : ProgressActivityBase(
         clock,
         progressRepository)
 {
-    [Function(nameof(Brs023OrchestrationInitializeActivityV1))]
+    [Function(nameof(EnqueueMessagesStepTerminateActivity_Brs_023_027_V1))]
     public async Task Run(
         [ActivityTrigger] Guid orchestrationInstanceId)
     {
@@ -38,10 +34,14 @@ internal class Brs023OrchestrationInitializeActivityV1(
             .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
             .ConfigureAwait(false);
 
-        orchestrationInstance.Lifecycle.TransitionToRunning(Clock);
-        await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_023_027_V1.EnqueueMessagesStepSequence);
+        if (!step.IsSkipped())
+        {
+            step.Lifecycle.TransitionToTerminated(Clock, OrchestrationStepTerminationStates.Succeeded);
+            await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
 
-        // TODO: For demo purposes; remove when done
-        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+            // TODO: For demo purposes; remove when done
+            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+        }
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/OrchestrationInitializeActivity_Brs_023_027_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/OrchestrationInitializeActivity_Brs_023_027_V1.cs
@@ -19,14 +19,18 @@ using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.V1.Activities;
 
-internal class Brs023CalculationStepTerminateActivityV1(
+/// <summary>
+/// The first activity in the orchestration.
+/// It is responsible for updating the status to 'Running'.
+/// </summary>
+internal class OrchestrationInitializeActivity_Brs_023_027_V1(
     IClock clock,
     IOrchestrationInstanceProgressRepository progressRepository)
     : ProgressActivityBase(
         clock,
         progressRepository)
 {
-    [Function(nameof(Brs023CalculationStepTerminateActivityV1))]
+    [Function(nameof(OrchestrationInitializeActivity_Brs_023_027_V1))]
     public async Task Run(
         [ActivityTrigger] Guid orchestrationInstanceId)
     {
@@ -34,8 +38,7 @@ internal class Brs023CalculationStepTerminateActivityV1(
             .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
             .ConfigureAwait(false);
 
-        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_023_027_V1.CalculationStepSequence);
-        step.Lifecycle.TransitionToTerminated(Clock, OrchestrationStepTerminationStates.Succeeded);
+        orchestrationInstance.Lifecycle.TransitionToRunning(Clock);
         await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
 
         // TODO: For demo purposes; remove when done

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/OrchestrationTerminateActivity_Brs_023_027_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Activities/OrchestrationTerminateActivity_Brs_023_027_V1.cs
@@ -19,14 +19,18 @@ using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.V1.Activities;
 
-internal class Brs023EnqueueMessagesStepTerminateActivityV1(
+/// <summary>
+/// The last activity in the orchestration.
+/// It is responsible for updating the status to 'Terminated'.
+/// </summary>
+internal class OrchestrationTerminateActivity_Brs_023_027_V1(
     IClock clock,
     IOrchestrationInstanceProgressRepository progressRepository)
     : ProgressActivityBase(
         clock,
         progressRepository)
 {
-    [Function(nameof(Brs023EnqueueMessagesStepTerminateActivityV1))]
+    [Function(nameof(OrchestrationTerminateActivity_Brs_023_027_V1))]
     public async Task Run(
         [ActivityTrigger] Guid orchestrationInstanceId)
     {
@@ -34,14 +38,10 @@ internal class Brs023EnqueueMessagesStepTerminateActivityV1(
             .GetAsync(new OrchestrationInstanceId(orchestrationInstanceId))
             .ConfigureAwait(false);
 
-        var step = orchestrationInstance.Steps.Single(x => x.Sequence == Orchestration_Brs_023_027_V1.EnqueueMessagesStepSequence);
-        if (!step.IsSkipped())
-        {
-            step.Lifecycle.TransitionToTerminated(Clock, OrchestrationStepTerminationStates.Succeeded);
-            await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+        orchestrationInstance.Lifecycle.TransitionToSucceeded(Clock);
+        await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
 
-            // TODO: For demo purposes; remove when done
-            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
-        }
+        // TODO: For demo purposes; remove when done
+        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Orchestration_Brs_023_027_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Orchestration_Brs_023_027_V1.cs
@@ -43,33 +43,33 @@ internal class Orchestration_Brs_023_027_V1
 
         // Initialize
         await context.CallActivityAsync(
-            nameof(Brs023OrchestrationInitializeActivityV1),
+            nameof(OrchestrationInitializeActivity_Brs_023_027_V1),
             context.InstanceId,
             defaultRetryOptions);
 
         // Step: Calculation
         await context.CallActivityAsync(
-            nameof(Brs023CalculationStepStartActivityV1),
+            nameof(CalculationStepStartActivity_Brs_023_027_V1),
             context.InstanceId,
             defaultRetryOptions);
         await context.CallActivityAsync(
-            nameof(Brs023CalculationStepTerminateActivityV1),
+            nameof(CalculationStepTerminateActivity_Brs_023_027_V1),
             context.InstanceId,
             defaultRetryOptions);
 
         // Step: Enqueue messages
         await context.CallActivityAsync(
-            nameof(Brs023EnqueueMessagesStepStartActivityV1),
+            nameof(EnqueueMessagesStepStartActivity_Brs_023_027_V1),
             context.InstanceId,
             defaultRetryOptions);
         await context.CallActivityAsync(
-            nameof(Brs023EnqueueMessagesStepTerminateActivityV1),
+            nameof(EnqueueMessagesStepTerminateActivity_Brs_023_027_V1),
             context.InstanceId,
             defaultRetryOptions);
 
         // Terminate
         await context.CallActivityAsync(
-            nameof(Brs023OrchestrationTerminateActivityV1),
+            nameof(OrchestrationTerminateActivity_Brs_023_027_V1),
             context.InstanceId,
             defaultRetryOptions);
 

--- a/source/ProcessManager.Orchestrations/Program.cs
+++ b/source/ProcessManager.Orchestrations/Program.cs
@@ -19,9 +19,11 @@ using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationDescription;
 using Energinet.DataHub.ProcessManagement.Core.Infrastructure.Extensions.DependencyInjection;
 using Energinet.DataHub.ProcessManagement.Core.Infrastructure.Extensions.Startup;
 using Energinet.DataHub.ProcessManagement.Core.Infrastructure.Telemetry;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Extensions.DependencyInjection;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.V1;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026.V1;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,10 +47,14 @@ var host = new HostBuilder()
             // We could implement an interface for "description building" which could then be implemented besides the orchestration.
             // During DI we could then search for all these interface implementations and register them automatically.
             // This would ensure we didn't have to update Program.cs when we change orchestrations.
+            var brs_021_ElectricalHeatingCalculation_v1 = CreateDescription_Brs_021_ElectricalHeatingCalculation_V1();
             var brs_023_027_v1 = CreateBrs_023_027_V1Description();
             var brs_026_v1 = CreateBrs_026_V1Description();
 
-            return [brs_023_027_v1, brs_026_v1];
+            return [
+                brs_021_ElectricalHeatingCalculation_v1,
+                brs_023_027_v1,
+                brs_026_v1];
         });
         // => Handlers
         services.AddScoped<SearchCalculationHandler>();
@@ -62,6 +68,23 @@ var host = new HostBuilder()
 
 await host.SynchronizeWithOrchestrationRegisterAsync("ProcessManager.Orchestrations").ConfigureAwait(false);
 await host.RunAsync().ConfigureAwait(false);
+
+OrchestrationDescription CreateDescription_Brs_021_ElectricalHeatingCalculation_V1()
+{
+    var orchestrationDescriptionUniqueName = new Brs_021_ElectricalHeatingCalculation_V1();
+
+    var description = new OrchestrationDescription(
+        uniqueName: new OrchestrationDescriptionUniqueName(
+            orchestrationDescriptionUniqueName.Name,
+            orchestrationDescriptionUniqueName.Version),
+        canBeScheduled: false,
+        functionName: nameof(Orchestration_Brs_021_ElectricalHeatingCalculation_V1));
+
+    description.AppendStepDescription("Beregning");
+    description.AppendStepDescription("Besked dannelse");
+
+    return description;
+}
 
 OrchestrationDescription CreateBrs_023_027_V1Description()
 {

--- a/source/ProcessManager.SubsystemTests/ProcessManager.SubsystemTests.csproj
+++ b/source/ProcessManager.SubsystemTests/ProcessManager.SubsystemTests.csproj
@@ -8,11 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Tests/ProcessManager.Tests.csproj
+++ b/source/ProcessManager.Tests/ProcessManager.Tests.csproj
@@ -12,11 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager/Api/Model/GeneralScheduleOrchestrationInstanceCommand.cs
+++ b/source/ProcessManager/Api/Model/GeneralScheduleOrchestrationInstanceCommand.cs
@@ -13,26 +13,23 @@
 // limitations under the License.
 
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescription;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 
-namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
+namespace Energinet.DataHub.ProcessManager.Api.Model;
 
 /// <summary>
-/// Command for starting a BRS-021 electrical heating calculation.
+/// Command for deserializing general no-input schedule commands.
 /// Must be JSON serializable.
 /// </summary>
-public sealed record StartElectricalHeatingCalculationCommandV1
-    : StartOrchestrationInstanceCommand<UserIdentityDto>
+internal sealed record GeneralScheduleOrchestrationInstanceCommand
+    : ScheduleOrchestrationInstanceCommand
 {
-    /// <summary>
-    /// Construct command.
-    /// </summary>
-    /// <param name="operatingIdentity">Identity of the user executing the command.</param>
-    public StartElectricalHeatingCalculationCommandV1(
-        UserIdentityDto operatingIdentity)
-            : base(
-                operatingIdentity,
-                orchestrationDescriptionUniqueName: new Brs_021_ElectricalHeatingCalculation_V1())
+    public GeneralScheduleOrchestrationInstanceCommand(
+        UserIdentityDto operatingIdentity,
+        OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName,
+        DateTimeOffset runAt)
+            : base(operatingIdentity, orchestrationDescriptionUniqueName, runAt)
     {
     }
 }

--- a/source/ProcessManager/Api/Model/GeneralStartOrchestrationInstanceCommand.cs
+++ b/source/ProcessManager/Api/Model/GeneralStartOrchestrationInstanceCommand.cs
@@ -13,26 +13,22 @@
 // limitations under the License.
 
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescription;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 
-namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
+namespace Energinet.DataHub.ProcessManager.Api.Model;
 
 /// <summary>
-/// Command for starting a BRS-021 electrical heating calculation.
+/// Command for deserializing general no-input start commands.
 /// Must be JSON serializable.
 /// </summary>
-public sealed record StartElectricalHeatingCalculationCommandV1
+internal sealed record GeneralStartOrchestrationInstanceCommand
     : StartOrchestrationInstanceCommand<UserIdentityDto>
 {
-    /// <summary>
-    /// Construct command.
-    /// </summary>
-    /// <param name="operatingIdentity">Identity of the user executing the command.</param>
-    public StartElectricalHeatingCalculationCommandV1(
-        UserIdentityDto operatingIdentity)
-            : base(
-                operatingIdentity,
-                orchestrationDescriptionUniqueName: new Brs_021_ElectricalHeatingCalculation_V1())
+    public GeneralStartOrchestrationInstanceCommand(
+        UserIdentityDto operatingIdentity,
+        OrchestrationDescriptionUniqueNameDto orchestrationDescriptionUniqueName)
+            : base(operatingIdentity, orchestrationDescriptionUniqueName)
     {
     }
 }

--- a/source/ProcessManager/Api/ScheduleOrchestrationInstanceTrigger.cs
+++ b/source/ProcessManager/Api/ScheduleOrchestrationInstanceTrigger.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManagement.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationDescription;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Api.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using NodaTime.Extensions;
+using FromBodyAttribute = Microsoft.Azure.Functions.Worker.Http.FromBodyAttribute;
+
+namespace Energinet.DataHub.ProcessManager.Api;
+
+internal class ScheduleOrchestrationInstanceTrigger(
+    ILogger<ScheduleOrchestrationInstanceTrigger> logger,
+    IStartOrchestrationInstanceCommands manager)
+{
+    private readonly ILogger _logger = logger;
+    private readonly IStartOrchestrationInstanceCommands _manager = manager;
+
+    /// <summary>
+    /// Schedule an orchestration instance and return its id.
+    /// </summary>
+    [Function(nameof(ScheduleOrchestrationInstanceTrigger))]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(
+            AuthorizationLevel.Anonymous,
+            "post",
+            Route = "orchestrationinstance/command/schedule")]
+        HttpRequest httpRequest,
+        [FromBody]
+        GeneralScheduleOrchestrationInstanceCommand command,
+        FunctionContext executionContext)
+    {
+        var orchestrationInstanceId = await _manager
+            .ScheduleNewOrchestrationInstanceAsync(
+                identity: new UserIdentity(
+                    new UserId(command.OperatingIdentity.UserId),
+                    new ActorId(command.OperatingIdentity.ActorId)),
+                uniqueName: new OrchestrationDescriptionUniqueName(
+                    command.OrchestrationDescriptionUniqueName.Name,
+                    command.OrchestrationDescriptionUniqueName.Version),
+                runAt: command.RunAt.ToInstant())
+            .ConfigureAwait(false);
+
+        return new OkObjectResult(orchestrationInstanceId.Value);
+    }
+}

--- a/source/ProcessManager/Api/StartOrchestrationInstanceTrigger.cs
+++ b/source/ProcessManager/Api/StartOrchestrationInstanceTrigger.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManagement.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationDescription;
+using Energinet.DataHub.ProcessManagement.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Api.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using FromBodyAttribute = Microsoft.Azure.Functions.Worker.Http.FromBodyAttribute;
+
+namespace Energinet.DataHub.ProcessManager.Api;
+
+internal class StartOrchestrationInstanceTrigger(
+    ILogger<StartOrchestrationInstanceTrigger> logger,
+    IStartOrchestrationInstanceCommands manager)
+{
+    private readonly ILogger _logger = logger;
+    private readonly IStartOrchestrationInstanceCommands _manager = manager;
+
+    /// <summary>
+    /// Start an orchestration instance and return its id.
+    /// </summary>
+    [Function(nameof(StartOrchestrationInstanceTrigger))]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(
+            AuthorizationLevel.Anonymous,
+            "post",
+            Route = "orchestrationinstance/command/start")]
+        HttpRequest httpRequest,
+        [FromBody]
+        GeneralStartOrchestrationInstanceCommand command,
+        FunctionContext executionContext)
+    {
+        var orchestrationInstanceId = await _manager
+            .StartNewOrchestrationInstanceAsync(
+                identity: new UserIdentity(
+                    new UserId(command.OperatingIdentity.UserId),
+                    new ActorId(command.OperatingIdentity.ActorId)),
+                uniqueName: new OrchestrationDescriptionUniqueName(
+                    command.OrchestrationDescriptionUniqueName.Name,
+                    command.OrchestrationDescriptionUniqueName.Version))
+            .ConfigureAwait(false);
+
+        return new OkObjectResult(orchestrationInstanceId.Value);
+    }
+}

--- a/source/ProcessManager/ProcessManager.csproj
+++ b/source/ProcessManager/ProcessManager.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="13.2.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="14.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Shared/ProcessManager/Api/Mappers/OrchestrationInstanceMapperExtensions.cs
+++ b/source/Shared/ProcessManager/Api/Mappers/OrchestrationInstanceMapperExtensions.cs
@@ -25,11 +25,11 @@ internal static class OrchestrationInstanceMapperExtensions
             where TInputParameterDto : class, ApiModel.IInputParameterDto
     {
         return new ApiModel.OrchestrationInstanceTypedDto<TInputParameterDto>(
-            Id: entity.Id.Value,
-            Lifecycle: entity.Lifecycle.MapToDto(),
-            ParameterValue: entity.ParameterValue.AsType<TInputParameterDto>(),
-            Steps: entity.Steps.Select(step => step.MapToDto()).ToList(),
-            CustomState: entity.CustomState.Value);
+            entity.Id.Value,
+            entity.Lifecycle.MapToDto(),
+            entity.Steps.Select(step => step.MapToDto()).ToList(),
+            entity.CustomState.Value,
+            entity.ParameterValue.AsType<TInputParameterDto>());
     }
 
     public static ApiModel.OrchestrationInstance.OrchestrationInstanceDto MapToDto(


### PR DESCRIPTION
## Description

- [x] Support start/schedule of orchestration instance with no input
- [x] Use a general trigger/handler if start/schedule commands has no input (sine then we don't need to validate input or skip steps)

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/423

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
