### PR TITLE
test: Add basic client test for StartRequestCalculatedEnergyTimeSeriesCommandV1

### DIFF
--- a/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Client Release Notes
 
+## Version 0.14.1
+
+- Rename service bus client options
+
 ## Version 0.14.0
 
 - Support start/schedule orchestration instance with no input parameter.

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Abstractions</PackageId>
-    <PackageVersion>0.14.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.14.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Client.Tests/Extensions/ServiceCollectionExtensions.cs
+++ b/source/ProcessManager.Client.Tests/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Energinet.DataHub.ProcessManager.Client.Tests.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddInMemoryConfiguration(
+        this IServiceCollection services,
+        Dictionary<string, string?> configurations)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurations)
+            .Build();
+
+        services.AddScoped<IConfiguration>(_ => configuration);
+
+        return services;
+    }
+}

--- a/source/ProcessManager.Client.Tests/Fixtures/ProcessManagerClientFixture.cs
+++ b/source/ProcessManager.Client.Tests/Fixtures/ProcessManagerClientFixture.cs
@@ -13,31 +13,37 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using Energinet.DataHub.Core.DurableFunctionApp.TestCommon.DurableTask;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvider;
 using Energinet.DataHub.ProcessManager.Core.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Tests.Fixtures;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Client.Tests.Fixtures;
 
 public class ProcessManagerClientFixture : IAsyncLifetime
 {
+    private const string TaskHubName = "ClientsTest01";
+
     public ProcessManagerClientFixture()
     {
-        var taskHubName = "ClientsTest01";
-
         DatabaseManager = new ProcessManagerDatabaseManager("ProcessManagerClientTests");
-        IntegrationTestConfiguration = new IntegrationTestConfiguration();
         AzuriteManager = new AzuriteManager(useOAuth: true);
+        DurableTaskManager = new DurableTaskManager(
+            "AzuriteConnectionString",
+            AzuriteManager.FullConnectionString);
+
+        IntegrationTestConfiguration = new IntegrationTestConfiguration();
 
         OrchestrationsAppManager = new OrchestrationsAppManager(
             DatabaseManager,
             IntegrationTestConfiguration,
             AzuriteManager,
-            taskHubName: taskHubName,
+            taskHubName: TaskHubName,
             appPort: 8101,
             manageDatabase: false,
             manageAzurite: false);
@@ -46,7 +52,7 @@ public class ProcessManagerClientFixture : IAsyncLifetime
             DatabaseManager,
             IntegrationTestConfiguration,
             AzuriteManager,
-            taskHubName: taskHubName,
+            taskHubName: TaskHubName,
             appPort: 8102,
             manageDatabase: false,
             manageAzurite: false);
@@ -57,18 +63,23 @@ public class ProcessManagerClientFixture : IAsyncLifetime
             IntegrationTestConfiguration.Credential);
     }
 
+    public IntegrationTestConfiguration IntegrationTestConfiguration { get; }
+
     public OrchestrationsAppManager OrchestrationsAppManager { get; }
 
     public ProcessManagerAppManager ProcessManagerAppManager { get; }
+
+    [NotNull]
+    public IDurableClient? DurableClient { get; private set; }
 
     [NotNull]
     public TopicResource? ProcessManagerTopic { get; private set; }
 
     private ProcessManagerDatabaseManager DatabaseManager { get; }
 
-    private IntegrationTestConfiguration IntegrationTestConfiguration { get; }
-
     private AzuriteManager AzuriteManager { get; }
+
+    private DurableTaskManager DurableTaskManager { get; }
 
     private ServiceBusResourceProvider ServiceBusResourceProvider { get; }
 
@@ -78,6 +89,8 @@ public class ProcessManagerClientFixture : IAsyncLifetime
         AzuriteManager.StartAzurite();
 
         await DatabaseManager.CreateDatabaseAsync();
+
+        DurableClient = DurableTaskManager.CreateClient(TaskHubName);
 
         ProcessManagerTopic = await ServiceBusResourceProvider.BuildTopic("pm-topic")
             .AddSubscription("brs-026-subscription")
@@ -92,6 +105,7 @@ public class ProcessManagerClientFixture : IAsyncLifetime
     {
         await OrchestrationsAppManager.DisposeAsync();
         await ProcessManagerAppManager.DisposeAsync();
+        await DurableTaskManager.DisposeAsync();
         await DatabaseManager.DeleteDatabaseAsync();
         AzuriteManager.Dispose();
         await ServiceBusResourceProvider.DisposeAsync();

--- a/source/ProcessManager.Client.Tests/Integration/BRS_023_027/V1/MonitorCalculationUsingClientsScenario.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_023_027/V1/MonitorCalculationUsingClientsScenario.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
 using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
+using Energinet.DataHub.ProcessManager.Client.Tests.Extensions;
 using Energinet.DataHub.ProcessManager.Client.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027.V1.Model;
@@ -43,13 +44,13 @@ public class MonitorCalculationUsingClientsScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddScoped(_ => CreateInMemoryConfigurations(new Dictionary<string, string?>()
+        services.AddInMemoryConfiguration(new Dictionary<string, string?>
         {
             [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
                 = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
             [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
                 = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        }));
+        });
         services.AddProcessManagerHttpClients();
         ServiceProvider = services.BuildServiceProvider();
     }
@@ -250,12 +251,5 @@ public class MonitorCalculationUsingClientsScenario : IAsyncLifetime
             delay: TimeSpan.FromSeconds(3));
 
         isTerminated.Should().BeTrue("because we expects the orchestration instance can complete within given wait time");
-    }
-
-    private IConfiguration CreateInMemoryConfigurations(Dictionary<string, string?> configurations)
-    {
-        return new ConfigurationBuilder()
-            .AddInMemoryCollection(configurations)
-            .Build();
     }
 }

--- a/source/ProcessManager.Client.Tests/Integration/BRS_026_028/V1/RequestCalculatedEnergyTimeSeriesTests.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_026_028/V1/RequestCalculatedEnergyTimeSeriesTests.cs
@@ -46,7 +46,7 @@ public class RequestCalculatedEnergyTimeSeriesTests : IAsyncLifetime
         var services = new ServiceCollection();
         services.AddInMemoryConfiguration(new Dictionary<string, string?>
         {
-            [$"{ProcessManagerServiceBusClientsOptions.SectionName}:{nameof(ProcessManagerServiceBusClientsOptions.TopicName)}"]
+            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.TopicName)}"]
                 = _fixture.ProcessManagerTopic.Name,
         });
         services.AddAzureClients(

--- a/source/ProcessManager.Client.Tests/Integration/BRS_026_028/V1/RequestCalculatedEnergyTimeSeriesTests.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_026_028/V1/RequestCalculatedEnergyTimeSeriesTests.cs
@@ -93,10 +93,14 @@ public class RequestCalculatedEnergyTimeSeriesTests : IAsyncLifetime
         await processManagerMessageClient.StartNewOrchestrationInstanceAsync(startRequestCommand, default);
 
         // Assert
-        var orchestration = await _fixture.DurableClient.WaitForOrchestationStartedAsync(orchestrationCreatedAfter);
+        var orchestration = await _fixture.DurableClient.WaitForOrchestationStartedAsync(
+            orchestrationCreatedAfter,
+            waitTimeLimit: TimeSpan.FromSeconds(60));
         orchestration.Input.ToString().Should().Contain(businessReason);
 
-        var completedOrchestration = await _fixture.DurableClient.WaitForInstanceCompletedAsync(orchestration.InstanceId);
+        var completedOrchestration = await _fixture.DurableClient.WaitForInstanceCompletedAsync(
+            orchestration.InstanceId,
+            waitTimeLimit: TimeSpan.FromSeconds(60));
         completedOrchestration.RuntimeStatus.Should().Be(OrchestrationRuntimeStatus.Completed);
     }
 }

--- a/source/ProcessManager.Client.Tests/Integration/BRS_026_028/V1/RequestCalculatedEnergyTimeSeriesTests.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_026_028/V1/RequestCalculatedEnergyTimeSeriesTests.cs
@@ -94,13 +94,11 @@ public class RequestCalculatedEnergyTimeSeriesTests : IAsyncLifetime
 
         // Assert
         var orchestration = await _fixture.DurableClient.WaitForOrchestationStartedAsync(
-            orchestrationCreatedAfter,
-            waitTimeLimit: TimeSpan.FromSeconds(60));
+            orchestrationCreatedAfter);
         orchestration.Input.ToString().Should().Contain(businessReason);
 
-        var completedOrchestration = await _fixture.DurableClient.WaitForInstanceCompletedAsync(
-            orchestration.InstanceId,
-            waitTimeLimit: TimeSpan.FromSeconds(60));
+        var completedOrchestration = await _fixture.DurableClient.WaitForOrchestrationCompletedAsync(
+            orchestration.InstanceId);
         completedOrchestration.RuntimeStatus.Should().Be(OrchestrationRuntimeStatus.Completed);
     }
 }

--- a/source/ProcessManager.Client.Tests/Integration/BRS_026_028/V1/RequestCalculatedEnergyTimeSeriesTests.cs
+++ b/source/ProcessManager.Client.Tests/Integration/BRS_026_028/V1/RequestCalculatedEnergyTimeSeriesTests.cs
@@ -80,12 +80,11 @@ public class RequestCalculatedEnergyTimeSeriesTests : IAsyncLifetime
     public async Task RequestCalculatedEnergyTimeSeries_WhenStarted_OrchestrationCompletesWithSuccess()
     {
         // Arrange
-        var messageId = "test-message-id";
         var businessReason = "test-business-reason";
         var startRequestCommand = new StartRequestCalculatedEnergyTimeSeriesCommandV1(
             new ActorIdentityDto(Guid.NewGuid()),
             new RequestCalculatedEnergyTimeSeriesInputV1(businessReason),
-            messageId);
+            "test-message-id");
 
         var processManagerMessageClient = ServiceProvider.GetRequiredService<IProcessManagerMessageClient>();
 

--- a/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
+++ b/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
@@ -22,14 +22,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.1.1-alpha-386" />
+    <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.1.1-alpha-387" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.1.1-alpha-387" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
+++ b/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.1.0" />
+    <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.1.1-alpha-386" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
+++ b/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
@@ -22,14 +22,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.1.1-alpha-387" />
+    <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.1.1-alpha-387" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
+++ b/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
+++ b/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
@@ -57,13 +57,13 @@ public static class ClientExtensions
 
     /// <summary>
     /// Register Process Manager message client for use in applications.
-    /// <remarks>The application must register the <see cref="ServiceBusClient"/> and contain configuration for <see cref="ProcessManagerServiceBusClientsOptions"/></remarks>
+    /// <remarks>The application must register the <see cref="ServiceBusClient"/> and contain configuration for <see cref="ProcessManagerServiceBusClientOptions"/></remarks>
     /// </summary>
     public static IServiceCollection AddProcessManagerMessageClient(this IServiceCollection services)
     {
         services
-            .AddOptions<ProcessManagerServiceBusClientsOptions>()
-            .BindConfiguration(ProcessManagerServiceBusClientsOptions.SectionName)
+            .AddOptions<ProcessManagerServiceBusClientOptions>()
+            .BindConfiguration(ProcessManagerServiceBusClientOptions.SectionName)
             .ValidateDataAnnotations();
 
         services.AddAzureClients(
@@ -72,14 +72,14 @@ public static class ClientExtensions
                 builder.AddClient<ServiceBusSender, ServiceBusClientOptions>(
                     (_, _, provider) =>
                     {
-                        var serviceBusOptions = provider.GetRequiredService<IOptions<ProcessManagerServiceBusClientsOptions>>().Value;
+                        var serviceBusOptions = provider.GetRequiredService<IOptions<ProcessManagerServiceBusClientOptions>>().Value;
                         var serviceBusSender = provider
                             .GetRequiredService<ServiceBusClient>()
                             .CreateSender(serviceBusOptions.TopicName);
 
                         return serviceBusSender;
                     })
-                    .WithName(nameof(ProcessManagerServiceBusClientsOptions.TopicName));
+                    .WithName(nameof(ProcessManagerServiceBusClientOptions.TopicName));
             });
 
         services.AddScoped<IProcessManagerMessageClient, ProcessManagerMessageClient>();

--- a/source/ProcessManager.Client/Extensions/Options/ProcessManagerServiceBusClientOptions.cs
+++ b/source/ProcessManager.Client/Extensions/Options/ProcessManagerServiceBusClientOptions.cs
@@ -20,9 +20,9 @@ namespace Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 /// <summary>
 /// Options for configuration of Process Manager Service Bus clients using the Process Manager.
 /// </summary>
-public class ProcessManagerServiceBusClientsOptions
+public class ProcessManagerServiceBusClientOptions
 {
-    public const string SectionName = "ProcessManagerServiceBusClients";
+    public const string SectionName = "ProcessManagerServiceBusClient";
 
     /// <summary>
     /// Name of the topic which the Process Manager receives service bus messages on

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Client</PackageId>
-    <PackageVersion>0.14.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.14.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Client/ProcessManagerMessageClient.cs
+++ b/source/ProcessManager.Client/ProcessManagerMessageClient.cs
@@ -26,7 +26,7 @@ public class ProcessManagerMessageClient(
     IAzureClientFactory<ServiceBusSender> serviceBusFactory)
         : IProcessManagerMessageClient
 {
-    private readonly ServiceBusSender _serviceBusSender = serviceBusFactory.CreateClient(nameof(ProcessManagerServiceBusClientsOptions.TopicName));
+    private readonly ServiceBusSender _serviceBusSender = serviceBusFactory.CreateClient(nameof(ProcessManagerServiceBusClientOptions.TopicName));
 
     public Task StartNewOrchestrationInstanceAsync<TInputParameterDto>(
         MessageCommand<TInputParameterDto> command,

--- a/source/ProcessManager.Core.Tests/ProcessManager.Core.Tests.csproj
+++ b/source/ProcessManager.Core.Tests/ProcessManager.Core.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.1.1" />
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="8.0.1" />

--- a/source/ProcessManager.Orchestrations.Tests/ProcessManager.Orchestrations.Tests.csproj
+++ b/source/ProcessManager.Orchestrations.Tests/ProcessManager.Orchestrations.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
@@ -25,7 +25,7 @@ public static class ProcessManagerTopicExtensions
     public static IServiceCollection AddProcessManagerTopic(this IServiceCollection services)
     {
         services
-            .AddOptionsWithValidateOnStart<ProcessManagerTopicOptions>()
+            .AddOptions<ProcessManagerTopicOptions>()
             .BindConfiguration(ProcessManagerTopicOptions.SectionName)
             .ValidateDataAnnotations();
 

--- a/source/ProcessManager.Orchestrations/Extensions/Options/ProcessManagerTopicOptions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/Options/ProcessManagerTopicOptions.cs
@@ -31,12 +31,12 @@ public class ProcessManagerTopicOptions
     /// <summary>
     /// Name of the ProcessManager Service Bus topic
     /// </summary>
-    //[Required] // TODO: Removed required for now since tests cannot be run (yet)
+    [Required]
     public string TopicName { get; } = string.Empty;
 
     /// <summary>
     /// Name of the subscription for BRS026 to the ProcessManager Service Bus topic
     /// </summary>
-    //[Required] // TODO: Removed required for now since tests cannot be run (yet)
+    [Required]
     public string Brs026SubscriptionName { get; } = string.Empty;
 }

--- a/source/ProcessManager.Orchestrations/Program.cs
+++ b/source/ProcessManager.Orchestrations/Program.cs
@@ -59,6 +59,7 @@ var host = new HostBuilder()
         // => Handlers
         services.AddScoped<SearchCalculationHandler>();
         services.AddScoped<StartCalculationHandlerV1>();
+        services.AddScoped<RequestCalculatedEnergyTimeSeriesHandler>();
     })
     .ConfigureLogging((hostingContext, logging) =>
     {

--- a/source/ProcessManager.SubsystemTests/ProcessManager.SubsystemTests.csproj
+++ b/source/ProcessManager.SubsystemTests/ProcessManager.SubsystemTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Tests/ProcessManager.Tests.csproj
+++ b/source/ProcessManager.Tests/ProcessManager.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.5" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Add first Service Bus Topic test by testing the `StartRequestCalculatedEnergyTimeSeriesCommandV1`

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/370

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/370
