### PR TITLE
Run dotnet build on ubuntu-24.04 using .NET 8, featureband 8.0.100

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,7 @@ jobs:
 
   dispatch_deploment_event_core:
     if: ${{ fromJson(needs.changes.outputs.job_context).core == 'true'  }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [dotnet_promote_prerelease, changes]
     steps:
       - name: Find associated pull request
@@ -71,7 +71,7 @@ jobs:
 
   dispatch_deploment_event_orchestrations:
     if: ${{ fromJson(needs.changes.outputs.job_context).orchestrations == 'true'  }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [dotnet_promote_prerelease, changes]
     steps:
       - name: Find associated pull request
@@ -95,7 +95,7 @@ jobs:
 
   dispatch_deploment_event_dbmigrations:
     if: ${{ fromJson(needs.changes.outputs.job_context).orchestrations == 'true'  }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [dotnet_promote_prerelease, changes]
     steps:
       - name: Find associated pull request

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,7 @@ jobs:
 
   dispatch_deploment_event_core:
     if: ${{ fromJson(needs.changes.outputs.job_context).core == 'true'  }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [dotnet_promote_prerelease, changes]
     steps:
       - name: Find associated pull request
@@ -71,7 +71,7 @@ jobs:
 
   dispatch_deploment_event_orchestrations:
     if: ${{ fromJson(needs.changes.outputs.job_context).orchestrations == 'true'  }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [dotnet_promote_prerelease, changes]
     steps:
       - name: Find associated pull request
@@ -95,7 +95,7 @@ jobs:
 
   dispatch_deploment_event_dbmigrations:
     if: ${{ fromJson(needs.changes.outputs.job_context).orchestrations == 'true'  }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [dotnet_promote_prerelease, changes]
     steps:
       - name: Find associated pull request

--- a/.github/workflows/ci-dotnet-runtests.yml
+++ b/.github/workflows/ci-dotnet-runtests.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   build_matrix:
     name: Build matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix_builds: ${{ steps.set-matrix.outputs.matrix_builds }}
       matrix_tests: ${{ steps.set-matrix.outputs.matrix_tests }}
@@ -88,7 +88,7 @@ jobs:
 
   # build_tests_in_project:
   #   name: Build ${{ matrix.project.name }}
-  #   runs-on: ubuntu-22.04
+  #   runs-on: ubuntu-24.04
   #   needs: build_matrix
   #   strategy:
   #     fail-fast: false

--- a/.github/workflows/ci-dotnet-runtests.yml
+++ b/.github/workflows/ci-dotnet-runtests.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   build_matrix:
     name: Build matrix
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       matrix_builds: ${{ steps.set-matrix.outputs.matrix_builds }}
       matrix_tests: ${{ steps.set-matrix.outputs.matrix_tests }}
@@ -88,7 +88,7 @@ jobs:
 
   # build_tests_in_project:
   #   name: Build ${{ matrix.project.name }}
-  #   runs-on: ubuntu-24.04
+  #   runs-on: ubuntu-24.04  # Build on pinned version of ubuntu
   #   needs: build_matrix
   #   strategy:
   #     fail-fast: false

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   build_artifact:
     name: Build ${{ inputs.release_name }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04  # Build on pinned version of ubuntu
     env:
       RELEASE_FOLDER_PATH: ${{ github.workspace }}/output
       RELEASE_VERSION: ${{ inputs.release_name }}_${{ github.event.pull_request.number }}

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   build_artifact:
     name: Build ${{ inputs.release_name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       RELEASE_FOLDER_PATH: ${{ github.workspace }}/output
       RELEASE_VERSION: ${{ inputs.release_name }}_${{ github.event.pull_request.number }}

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -80,7 +80,7 @@ jobs:
   #
 
   allow_merge_ci_orchestrator:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs:
       [
         ci_base,

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -80,7 +80,7 @@ jobs:
   #
 
   allow_merge_ci_orchestrator:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       [
         ci_base,

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       nuget_packages: ${{ steps.filter_nuget.outputs.nuget_packages }}
       affected_changes: ${{ steps.filter.outputs.affected_changes }}

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       nuget_packages: ${{ steps.filter_nuget.outputs.nuget_packages }}
       affected_changes: ${{ steps.filter.outputs.affected_changes }}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "8.0.100", // We use .NET 8, featureband .100 --> see https://github.com/dotnet/core/discussions/9258 and https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/source/ProcessManager.Abstractions/Api/Model/OrchestrationDescription/OrchestrationDescriptionUniqueNameDto.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/OrchestrationDescription/OrchestrationDescriptionUniqueNameDto.cs
@@ -18,7 +18,7 @@ namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationD
 /// Uniquely identifies a specific implementation of the orchestration.
 /// </summary>
 /// <param name="Name">A common name to identity the orchestration.</param>
-/// <param name="Version">A version identifying a specific implementation of the orchestration</param>
+/// <param name="Version">A version identifying a specific implementation of the orchestration.</param>
 public record OrchestrationDescriptionUniqueNameDto(
     string Name,
     int Version);

--- a/source/ProcessManager.Abstractions/Api/Model/OrchestrationDescription/OrchestrationDescriptionUniqueNameDto.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/OrchestrationDescription/OrchestrationDescriptionUniqueNameDto.cs
@@ -18,7 +18,7 @@ namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationD
 /// Uniquely identifies a specific implementation of the orchestration.
 /// </summary>
 /// <param name="Name">A common name to identity the orchestration.</param>
-/// <param name="Version">A version identifying a specific implementation of the orchestration.</param>
+/// <param name="Version">A version identifying a specific implementation of the orchestration</param>
 public record OrchestrationDescriptionUniqueNameDto(
     string Name,
     int Version);


### PR DESCRIPTION
This pull request includes several changes to update the Ubuntu version used in GitHub Actions workflows and to modify the .NET SDK version in the `global.json` file.

### Updates to GitHub Actions workflows:
Use ubuntu-latest for everything but building artifacts
Use ubuntu-24.04 for building artifacts

### Update to .NET SDK version:

* [`global.json`](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL3-R3): Changed the .NET SDK version from `8.0.300` to `8.0.100`.