### PR TITLE
2660: add PR number to dotnet publish

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -52,6 +52,7 @@ jobs:
           dotnet publish \
             '${{ inputs.project_file }}' \
             --configuration Release \
+            -p:SourceRevisionId=PR_${{ github.event.number }}+SHA_${{ github.sha }} \
             --output '${{ env.RELEASE_FOLDER_PATH }}'
 
       - name: Zip files for prerelease

--- a/source/ProcessManager.Orchestrations/Program.cs
+++ b/source/ProcessManager.Orchestrations/Program.cs
@@ -38,7 +38,7 @@ var host = new HostBuilder()
         services.AddHealthChecksForIsolatedWorker();
         services.AddNodaTimeForApplication();
 
-        // Databricks workspaces
+        // Databricks Workspaces
         services.AddDatabricksJobs(DatabricksWorkspaceNames.Wholesale);
         services.AddDatabricksJobs(DatabricksWorkspaceNames.Measurements);
 


### PR DESCRIPTION
This pull request includes changes to the CI workflow configuration and a minor comment correction in the `ProcessManager.Orchestrations` project.

https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/2660

Improvements to CI workflow:

* [`.github/workflows/ci-dotnet.yml`](diffhunk://#diff-9f761b9e8edbe9c2db37b8ef3863ecc6318bc1930386c72585733ae09ae9016fR55): Added a parameter to the `dotnet publish` command to include the source revision ID and SHA of the pull request.

Minor code comment correction made for testing the build