### PR TITLE
refac: Don't force push NuGet packages when building on main

### DIFF
--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -51,7 +51,9 @@ on:
 
 env:
   # Conditions
-  PUSH_PACKAGES: ${{ github.event_name != 'pull_request' }}
+  # We do't want to force-push packages in this repository, because we have two "bundles".
+  # Instead they should be pushed if their content has changed.
+  PUSH_PACKAGES: false
   # Necessary to manage Azure resources from automated tests
   AZURE_KEYVAULT_URL: ${{ vars.integration_test_azure_keyvault_url }}
   # Set value used by 'AzuriteManager'

--- a/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Client Release Notes
 
+## Version 0.15.1
+
+- No functional changes.
+
 ## Version 0.15.0
 
 - Do not allow empty string in values of the following options:

--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
+## Version 0.4.1
+
+- No functional changes.
+
 ## Version 0.4.0
 
 - Rename `StartRequestCalculatedEnergyTimeSeriesCommandV1` to `RequestCalculatedEnergyTimeSeriesCommandV1`

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Abstractions</PackageId>
-    <PackageVersion>0.15.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.15.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Client</PackageId>
-    <PackageVersion>0.15.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.15.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>0.4.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.4.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

We discovered an issue with NuGet package publishing, which this PR will (hopefully) fix. See an example of the error in this run: https://github.com/Energinet-DataHub/opengeh-process-manager/actions/runs/12598074801/job/35112217672

We have two NuGet package bundles. and currently, if one of them has changes and should be published - the workflow enforces both of them to be published. With this PR we change this so they are only published if they actually have content changes.

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
