### PR TITLE
refac: Fix PM Client bundle publish workflow

### DIFF
--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -53,6 +53,8 @@ env:
   # Conditions
   # TRIGGERED_BY_PR_COMMIT is true if this run is automatically triggered by a commit in a Pull Request (feature branch)
   TRIGGERED_BY_PR_COMMIT: ${{ github.event_name == 'pull_request' }}
+  # BASE_SHA must be set if this run is triggered manually
+  BASE_SHA: ${{ (github.event_name == 'workflow_dispatch') && 'main' || '' }}
   # Necessary to manage Azure resources from automated tests
   AZURE_KEYVAULT_URL: ${{ vars.integration_test_azure_keyvault_url }}
   # Set value used by 'AzuriteManager'
@@ -116,7 +118,7 @@ jobs:
       #   id: changed-content-client
       #   uses: tj-actions/changed-files@v45
       #   with:
-      #     base_sha: main
+      #     base_sha: ${{ env.BASE_SHA }}
       #     files: |
       #       source/ProcessManager.Client/**/*.*
       #       source/ProcessManager.Abstractions/**/*.*
@@ -125,7 +127,7 @@ jobs:
         id: changed-content-client
         uses: tj-actions/changed-files@v45
         with:
-          base_sha: main
+          base_sha: ${{ env.BASE_SHA }}
           files: |
             source/ProcessManager.Client/**/*.*
             source/ProcessManager.Abstractions/**/*.*
@@ -163,7 +165,7 @@ jobs:
       #   id: changed-content-orchestrations
       #   uses: tj-actions/changed-files@v45
       #   with:
-      #     base_sha: main
+      #     base_sha: ${{ env.BASE_SHA }}
       #     files: |
       #       source/ProcessManager.Orchestrations.Abstractions/**/*.*
       #       source/ProcessManager.Abstractions/**/*.*
@@ -172,7 +174,7 @@ jobs:
         id: changed-content-orchestrations
         uses: tj-actions/changed-files@v45
         with:
-          base_sha: main
+          base_sha: ${{ env.BASE_SHA }}
           files: |
             source/ProcessManager.Orchestrations.Abstractions/**/*.*
             source/ProcessManager.Abstractions/**/*.*

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -53,7 +53,7 @@ env:
   # Conditions
   # TRIGGERED_BY_PR_COMMIT is true if this run is automatically triggered by a commit in a Pull Request (feature branch)
   TRIGGERED_BY_PR_COMMIT: ${{ github.event_name == 'pull_request' }}
-  # BASE_SHA must be set if this run is triggered manually
+  # BASE_SHA must be set to 'main' if this run is triggered manually; otherwise file changes will not be detected correctly
   BASE_SHA: ${{ (github.event_name == 'workflow_dispatch') && 'main' || '' }}
   # Necessary to manage Azure resources from automated tests
   AZURE_KEYVAULT_URL: ${{ vars.integration_test_azure_keyvault_url }}

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -124,6 +124,7 @@ jobs:
       - name: List all changed files for PM.Client or PM.Abstractions
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-content-client.outputs.all_changed_files }}
+        shell: bash
         run: |
           for file in "$ALL_CHANGED_FILES"; do
             echo "$file was changed"
@@ -161,6 +162,7 @@ jobs:
       - name: List all changed files for PM.Abstractions or PM.Orchestrations.Abstractions
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-content-orchestrations.outputs.all_changed_files }}
+        shell: bash
         run: |
           for file in "$ALL_CHANGED_FILES"; do
             echo "$file was changed"
@@ -173,13 +175,3 @@ jobs:
           content_changed: ${{ steps.changed-content-orchestrations.outputs.any_changed }}
           nuget_token: ${{ secrets.nuget_token }}
           nupkg_recurse_path: source/ProcessManager.Orchestrations.Abstractions
-
-      - name: Print variables
-        run: |
-          echo "TRIGGERED_BY_PR_COMMIT: ${{ env.TRIGGERED_BY_PR_COMMIT }}"
-
-          echo "ProcessManager.Client content changed: ${{ steps.changed-content-client.outputs.any_changed }}"
-          echo "ProcessManager.Client push packages: ${{ env.TRIGGERED_BY_PR_COMMIT == 'false' && steps.changed-content-client.outputs.any_changed == 'true' }}"
-
-          echo "Orchestrations.Abstractions content changed: ${{ steps.changed-content-orchestrations.outputs.any_changed }}"
-          echo "Orchestrations.Abstractions push packages: ${{ env.TRIGGERED_BY_PR_COMMIT == 'false' && steps.changed-content-orchestrations.outputs.any_changed == 'true' }}"

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -80,7 +80,18 @@ jobs:
 
     steps:
       - name: Checkout repository
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@v14
+
+      - name: Checkout repository (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Add PR base ref (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
 
       - name: Setup dotnet and tools
         uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@v14

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -80,14 +80,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@v14
-
-      - name: Checkout repository (workflow_dispatch)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup dotnet and tools
         uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@v14
@@ -123,6 +116,7 @@ jobs:
       #   id: changed-content-client
       #   uses: tj-actions/changed-files@v45
       #   with:
+      #     base_sha: 'main'
       #     files: |
       #       source/ProcessManager.Client/**/*.*
       #       source/ProcessManager.Abstractions/**/*.*
@@ -131,6 +125,7 @@ jobs:
         id: changed-content-client
         uses: tj-actions/changed-files@v45
         with:
+          base_sha: 'main'
           files: |
             source/ProcessManager.Client/**/*.*
             source/ProcessManager.Abstractions/**/*.*
@@ -168,6 +163,7 @@ jobs:
       #   id: changed-content-orchestrations
       #   uses: tj-actions/changed-files@v45
       #   with:
+      #     base_sha: 'main'
       #     files: |
       #       source/ProcessManager.Orchestrations.Abstractions/**/*.*
       #       source/ProcessManager.Abstractions/**/*.*
@@ -176,6 +172,7 @@ jobs:
         id: changed-content-orchestrations
         uses: tj-actions/changed-files@v45
         with:
+          base_sha: 'main'
           files: |
             source/ProcessManager.Orchestrations.Abstractions/**/*.*
             source/ProcessManager.Abstractions/**/*.*

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -114,15 +114,6 @@ jobs:
         with:
           project_path: ./source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
 
-      # - name: Package content or build has changed for PM.Client or PM.Abstractions
-      #   id: changed-content-client
-      #   uses: tj-actions/changed-files@v45
-      #   with:
-      #     base_sha: ${{ env.BASE_SHA }}
-      #     files: |
-      #       source/ProcessManager.Client/**/*.*
-      #       source/ProcessManager.Abstractions/**/*.*
-      #       .github/workflows/processmanager-client-bundle-publish.yml
       - name: Package content or build has changed for PM.Client or PM.Abstractions
         id: changed-content-client
         uses: tj-actions/changed-files@v45
@@ -131,6 +122,7 @@ jobs:
           files: |
             source/ProcessManager.Client/**/*.*
             source/ProcessManager.Abstractions/**/*.*
+            .github/workflows/processmanager-client-bundle-publish.yml
 
       - name: List all changed files for PM.Client or PM.Abstractions
         env:
@@ -161,15 +153,6 @@ jobs:
       # If dependency ProcessManager.Abstractions has changed then we enforce a publish as if the
       # ProcessManager.Orchestrations.Abstractions has changed, because we want to ensure the
       # version of ProcessManager.Orchestrations.Abstractions is bumped.
-      # - name: Package content, dependencies or build has changed for PM.Abstractions or PM.Orchestrations.Abstractions
-      #   id: changed-content-orchestrations
-      #   uses: tj-actions/changed-files@v45
-      #   with:
-      #     base_sha: ${{ env.BASE_SHA }}
-      #     files: |
-      #       source/ProcessManager.Orchestrations.Abstractions/**/*.*
-      #       source/ProcessManager.Abstractions/**/*.*
-      #       .github/workflows/processmanager-client-bundle-publish.yml
       - name: Package content, dependencies or build has changed for PM.Abstractions or PM.Orchestrations.Abstractions
         id: changed-content-orchestrations
         uses: tj-actions/changed-files@v45
@@ -178,6 +161,7 @@ jobs:
           files: |
             source/ProcessManager.Orchestrations.Abstractions/**/*.*
             source/ProcessManager.Abstractions/**/*.*
+            .github/workflows/processmanager-client-bundle-publish.yml
 
       - name: List all changed files for PM.Abstractions or PM.Orchestrations.Abstractions
         env:

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -116,7 +116,7 @@ jobs:
       #   id: changed-content-client
       #   uses: tj-actions/changed-files@v45
       #   with:
-      #     base_sha: 'main'
+      #     base_sha: main
       #     files: |
       #       source/ProcessManager.Client/**/*.*
       #       source/ProcessManager.Abstractions/**/*.*
@@ -125,7 +125,7 @@ jobs:
         id: changed-content-client
         uses: tj-actions/changed-files@v45
         with:
-          base_sha: 'main'
+          base_sha: main
           files: |
             source/ProcessManager.Client/**/*.*
             source/ProcessManager.Abstractions/**/*.*
@@ -163,7 +163,7 @@ jobs:
       #   id: changed-content-orchestrations
       #   uses: tj-actions/changed-files@v45
       #   with:
-      #     base_sha: 'main'
+      #     base_sha: main
       #     files: |
       #       source/ProcessManager.Orchestrations.Abstractions/**/*.*
       #       source/ProcessManager.Abstractions/**/*.*
@@ -172,7 +172,7 @@ jobs:
         id: changed-content-orchestrations
         uses: tj-actions/changed-files@v45
         with:
-          base_sha: 'main'
+          base_sha: main
           files: |
             source/ProcessManager.Orchestrations.Abstractions/**/*.*
             source/ProcessManager.Abstractions/**/*.*

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -121,6 +121,14 @@ jobs:
             source/ProcessManager.Abstractions/**/*.*
             .github/workflows/processmanager-client-bundle-publish.yml
 
+      - name: List all changed files for PM.Client or PM.Abstractions
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-content-client.outputs.all_changed_files }}
+        run: |
+          for file in "$ALL_CHANGED_FILES"; do
+            echo "$file was changed"
+          done
+
       - name: Assert version of ProcessManager.Client NuGet package and push it to NuGet.org
         uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@v14
         with:
@@ -149,6 +157,14 @@ jobs:
             source/ProcessManager.Orchestrations.Abstractions/**/*.*
             source/ProcessManager.Abstractions/**/*.*
             .github/workflows/processmanager-client-bundle-publish.yml
+
+      - name: List all changed files for PM.Abstractions or PM.Orchestrations.Abstractions
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-content-orchestrations.outputs.all_changed_files }}
+        run: |
+          for file in "$ALL_CHANGED_FILES"; do
+            echo "$file was changed"
+          done
 
       - name: Assert version of ProcessManager.Orchestrations.Abstractions NuGet package and push it to NuGet.org
         uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@v14

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -87,11 +87,11 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref_name }}
       - name: Add PR base ref (workflow_dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
+          git fetch --depth=1 origin +refs/heads/${{github.ref_name}}:refs/remotes/origin/${{github.ref_name}}
 
       - name: Setup dotnet and tools
         uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@v14

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -121,7 +121,7 @@ jobs:
 
       # - name: Package content or build has changed for PM.Client or PM.Abstractions
       #   id: changed-content-client
-      #   uses: tj-actions/changed-files@v41
+      #   uses: tj-actions/changed-files@v45
       #   with:
       #     files: |
       #       source/ProcessManager.Client/**/*.*
@@ -129,7 +129,7 @@ jobs:
       #       .github/workflows/processmanager-client-bundle-publish.yml
       - name: Package content or build has changed for PM.Client or PM.Abstractions
         id: changed-content-client
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v45
         with:
           files: |
             source/ProcessManager.Client/**/*.*
@@ -166,7 +166,7 @@ jobs:
       # version of ProcessManager.Orchestrations.Abstractions is bumped.
       # - name: Package content, dependencies or build has changed for PM.Abstractions or PM.Orchestrations.Abstractions
       #   id: changed-content-orchestrations
-      #   uses: tj-actions/changed-files@v41
+      #   uses: tj-actions/changed-files@v45
       #   with:
       #     files: |
       #       source/ProcessManager.Orchestrations.Abstractions/**/*.*
@@ -174,7 +174,7 @@ jobs:
       #       .github/workflows/processmanager-client-bundle-publish.yml
       - name: Package content, dependencies or build has changed for PM.Abstractions or PM.Orchestrations.Abstractions
         id: changed-content-orchestrations
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v45
         with:
           files: |
             source/ProcessManager.Orchestrations.Abstractions/**/*.*

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -112,6 +112,14 @@ jobs:
         with:
           project_path: ./source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
 
+      # - name: Package content or build has changed for PM.Client or PM.Abstractions
+      #   id: changed-content-client
+      #   uses: tj-actions/changed-files@v41
+      #   with:
+      #     files: |
+      #       source/ProcessManager.Client/**/*.*
+      #       source/ProcessManager.Abstractions/**/*.*
+      #       .github/workflows/processmanager-client-bundle-publish.yml
       - name: Package content or build has changed for PM.Client or PM.Abstractions
         id: changed-content-client
         uses: tj-actions/changed-files@v41
@@ -119,7 +127,6 @@ jobs:
           files: |
             source/ProcessManager.Client/**/*.*
             source/ProcessManager.Abstractions/**/*.*
-            .github/workflows/processmanager-client-bundle-publish.yml
 
       - name: List all changed files for PM.Client or PM.Abstractions
         env:
@@ -150,6 +157,14 @@ jobs:
       # If dependency ProcessManager.Abstractions has changed then we enforce a publish as if the
       # ProcessManager.Orchestrations.Abstractions has changed, because we want to ensure the
       # version of ProcessManager.Orchestrations.Abstractions is bumped.
+      # - name: Package content, dependencies or build has changed for PM.Abstractions or PM.Orchestrations.Abstractions
+      #   id: changed-content-orchestrations
+      #   uses: tj-actions/changed-files@v41
+      #   with:
+      #     files: |
+      #       source/ProcessManager.Orchestrations.Abstractions/**/*.*
+      #       source/ProcessManager.Abstractions/**/*.*
+      #       .github/workflows/processmanager-client-bundle-publish.yml
       - name: Package content, dependencies or build has changed for PM.Abstractions or PM.Orchestrations.Abstractions
         id: changed-content-orchestrations
         uses: tj-actions/changed-files@v41
@@ -157,7 +172,6 @@ jobs:
           files: |
             source/ProcessManager.Orchestrations.Abstractions/**/*.*
             source/ProcessManager.Abstractions/**/*.*
-            .github/workflows/processmanager-client-bundle-publish.yml
 
       - name: List all changed files for PM.Abstractions or PM.Orchestrations.Abstractions
         env:

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -87,11 +87,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
-      - name: Add PR base ref (workflow_dispatch)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          git fetch --depth=1 origin +refs/heads/${{github.ref_name}}:refs/remotes/origin/${{github.ref_name}}
+          fetch-depth: 0
 
       - name: Setup dotnet and tools
         uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@v14

--- a/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Client Release Notes
 
+## Version 0.15.3
+
+- No functional changes.
+
 ## Version 0.15.2
 
 - Internal refactoring.

--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
+## Version 0.4.3
+
+- No functional changes.
+
 ## Version 0.4.2
 
 - No functional changes.

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Abstractions</PackageId>
-    <PackageVersion>0.15.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.15.3$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Client</PackageId>
-    <PackageVersion>0.15.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.15.3$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>0.4.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.4.3$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
This pull request includes updates to the workflow and therefore also version bumps for the ProcessManager packages. 

The most important changes involve updating the GitHub Actions workflow to handle manual triggers correctly and adding steps to list changed files for better debugging.

Workflow configuration updates:

* Added `BASE_SHA` environment variable to handle manual triggers correctly.
* Updated `tj-actions/changed-files` action from v41 to v45 and included `base_sha` parameter.
* Added steps to list all changed files for `PM.Client` and `PM.Abstractions` for better debugging.

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
