### PR TITLE
feat: Create and enqueue RSM-009 response

### DIFF
--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
+## Version 0.6.4
+
+- Add rejected model (RSM-009) for BRS 21 named `MeteredDataForMeteringPointRejectedV1`
+
 ## Version 0.6.3
 
 - No functional changes.

--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,6 +1,6 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
-## Version 0.7.1
+## Version 0.8.0
 
 - Add rejected model (RSM-009) for BRS 21 named `MeteredDataForMeteringPointRejectedV1`
 

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>0.7.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.8.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -52,7 +52,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-      <PackageReference Include="NodaTime" Version="3.2.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -52,6 +52,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+      <PackageReference Include="NodaTime" Version="3.2.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>0.6.3$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.6.4$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>0.6.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.6.3$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeasurementPointRejectedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeasurementPointRejectedV1.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+public sealed record MeteredDataForMeasurementPointRejectedV1(
+    string EventId,
+    string BusinessReason,
+    string ReceiverId,
+    string ReceiverRole,
+    Guid ProcessId,
+    Guid ExternalId,
+    AcknowledgementV1 AcknowledgementV1);
+
+public sealed record AcknowledgementV1(
+    string TransactionId,
+    Instant? ReceivedMarketDocumentCreatedDateTime,
+    string? ReceivedMarketDocumentTransactionId,
+    string? ReceivedMarketDocumentProcessProcessType,
+    string? ReceivedMarketDocumentRevisionNumber,
+    string? ReceivedMarketDocumentTitle,
+    string? ReceivedMarketDocumentType,
+    IReadOnlyCollection<ReasonV1> Reason,
+    IReadOnlyCollection<TimePeriodV1> InErrorPeriod,
+    IReadOnlyCollection<SeriesV1> Series,
+    IReadOnlyCollection<MktActivityRecordV1> OriginalMktActivityRecord,
+    IReadOnlyCollection<TimeSeriesV1> RejectedTimeSeries);
+
+public sealed record ReasonV1(string Code, string? Text);
+
+public sealed record TimePeriodV1(Interval TimeInterval, IReadOnlyCollection<ReasonV1> Reason);
+
+public sealed record SeriesV1(string MRID, IReadOnlyCollection<ReasonV1> Reason);
+
+public sealed record MktActivityRecordV1(string MRID, IReadOnlyCollection<ReasonV1> Reason);
+
+public sealed record TimeSeriesV1(
+    string MRID,
+    string Version,
+    IReadOnlyCollection<TimePeriodV1> InErrorPeriod,
+    IReadOnlyCollection<ReasonV1> Reason);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointRejectedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointRejectedV1.cs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using NodaTime;
-
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+public readonly record struct TimeInterval(DateTimeOffset Start, DateTimeOffset End);
 
 public sealed record MeteredDataForMeteringPointRejectedV1(
     string EventId,
@@ -27,7 +27,7 @@ public sealed record MeteredDataForMeteringPointRejectedV1(
 
 public sealed record AcknowledgementV1(
     string TransactionId,
-    Instant? ReceivedMarketDocumentCreatedDateTime,
+    DateTimeOffset? ReceivedMarketDocumentCreatedDateTime,
     string? ReceivedMarketDocumentTransactionId,
     string? ReceivedMarketDocumentProcessProcessType,
     string? ReceivedMarketDocumentRevisionNumber,
@@ -41,7 +41,7 @@ public sealed record AcknowledgementV1(
 
 public sealed record ReasonV1(string Code, string? Text);
 
-public sealed record TimePeriodV1(Interval TimeInterval, IReadOnlyCollection<ReasonV1> Reason);
+public sealed record TimePeriodV1(TimeInterval TimeInterval, IReadOnlyCollection<ReasonV1> Reason);
 
 public sealed record SeriesV1(string MRID, IReadOnlyCollection<ReasonV1> Reason);
 

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointRejectedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointRejectedV1.cs
@@ -16,7 +16,7 @@ using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 
-public sealed record MeteredDataForMeasurementPointRejectedV1(
+public sealed record MeteredDataForMeteringPointRejectedV1(
     string EventId,
     string BusinessReason,
     string ReceiverId,

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointRejectedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointRejectedV1.cs
@@ -26,7 +26,6 @@ public sealed record MeteredDataForMeteringPointRejectedV1(
     AcknowledgementV1 AcknowledgementV1);
 
 public sealed record AcknowledgementV1(
-    string TransactionId,
     DateTimeOffset? ReceivedMarketDocumentCreatedDateTime,
     string? ReceivedMarketDocumentTransactionId,
     string? ReceivedMarketDocumentProcessProcessType,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -27,9 +27,9 @@ public class CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1
         var result = new ActivityOutput(
             new MeteredDataForMeteringPointRejectedV1(
                 Guid.NewGuid().ToString("N"),
-                "BusinessReason",
-                "1111111111111",
-                "DDM",
+                "E23",
+                "5790000282425",
+                "DDQ",
                 activityInput.OrchestrationInstanceId.Value,
                 Guid.NewGuid(),
                 new AcknowledgementV1(

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Activities;
+
+public class CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1
+{
+    [Function(nameof(CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1))]
+    public Task<ActivityOutput> Run(
+        [ActivityTrigger] ActivityInput activityInput)
+    {
+        var result = new ActivityOutput(
+            new MeteredDataForMeasurementPointRejectedV1(
+                Guid.NewGuid().ToString("N"),
+                "BusinessReason",
+                "1111111111111",
+                "DDM",
+                activityInput.OrchestrationInstanceId.Value,
+                Guid.NewGuid(),
+                new AcknowledgementV1(
+                    Guid.NewGuid().ToString("N"),
+                    null,
+                    activityInput.InputTransactionId,
+                    null,
+                    null,
+                    null,
+                    null,
+                    activityInput.Errors.Select(err => new ReasonV1("A22", err)).ToList(),
+                    [],
+                    [],
+                    [],
+                    [])));
+
+        return Task.FromResult(result);
+    }
+
+    public sealed record ActivityInput(
+        OrchestrationInstanceId OrchestrationInstanceId,
+        string InputTransactionId,
+        IReadOnlyCollection<string> Errors);
+
+    public sealed record ActivityOutput(MeteredDataForMeasurementPointRejectedV1 RejectMessage);
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -33,7 +33,6 @@ public class CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1
                 activityInput.OrchestrationInstanceId.Value,
                 Guid.NewGuid(),
                 new AcknowledgementV1(
-                    Guid.NewGuid().ToString("N"),
                     null,
                     activityInput.InputTransactionId,
                     null,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -25,7 +25,7 @@ public class CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1
         [ActivityTrigger] ActivityInput activityInput)
     {
         var result = new ActivityOutput(
-            new MeteredDataForMeasurementPointRejectedV1(
+            new MeteredDataForMeteringPointRejectedV1(
                 Guid.NewGuid().ToString("N"),
                 "BusinessReason",
                 "1111111111111",
@@ -54,5 +54,5 @@ public class CreateRejectMessageActivity_Brs_021_ForwardMeteredData_V1
         string InputTransactionId,
         IReadOnlyCollection<string> Errors);
 
-    public sealed record ActivityOutput(MeteredDataForMeasurementPointRejectedV1 RejectMessage);
+    public sealed record ActivityOutput(MeteredDataForMeteringPointRejectedV1 RejectMessage);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueRejectMessageActivity_Brs_021_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueRejectMessageActivity_Brs_021_V1.cs
@@ -59,5 +59,5 @@ internal class EnqueueRejectMessageActivity_Brs_021_V1(
 
     public record ActivityInput(
         OrchestrationInstanceId InstanceId,
-        MeteredDataForMeasurementPointRejectedV1 RejectMessage);
+        MeteredDataForMeteringPointRejectedV1 RejectMessage);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueRejectMessageActivity_Brs_021_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueRejectMessageActivity_Brs_021_V1.cs
@@ -14,6 +14,7 @@
 
 using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Microsoft.Azure.Functions.Worker;
 using NodaTime;
 
@@ -53,5 +54,5 @@ internal class EnqueueRejectMessageActivity_Brs_021_V1(
 
     public record ActivityInput(
         OrchestrationInstanceId InstanceId,
-        IReadOnlyCollection<string> ValidationError);
+        MeteredDataForMeasurementPointRejectedV1 RejectMessage);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueRejectMessageActivity_Brs_021_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueRejectMessageActivity_Brs_021_V1.cs
@@ -51,7 +51,7 @@ internal class EnqueueRejectMessageActivity_Brs_021_V1(
 
     private Task EnqueueRejectMessageAsync(OperatingIdentity orchestrationCreatedBy, ActivityInput input) =>
         _enqueueActorMessagesClient.Enqueue(
-            Orchestration_Brs_021_ForwardMeteredData_V1.Name,
+            Orchestration_Brs_021_ForwardMeteredData_V1.UniqueName,
             input.InstanceId.Value,
             orchestrationCreatedBy.ToDto(),
             "enqueue-" + input.InstanceId.Value,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Orchestration_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Orchestration_Brs_021_ForwardMeteredData_V1.cs
@@ -30,7 +30,7 @@ internal class Orchestration_Brs_021_ForwardMeteredData_V1
     internal const int FindReceiverStep = 3;
     internal const int EnqueueActorMessagesStep = 4;
 
-    public static readonly Brs_021_ForwardedMeteredData_V1 Name = new();
+    public static readonly Brs_021_ForwardedMeteredData_V1 UniqueName = new();
 
     private readonly TaskOptions _defaultRetryOptions;
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Orchestration_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Orchestration_Brs_021_ForwardMeteredData_V1.cs
@@ -30,6 +30,8 @@ internal class Orchestration_Brs_021_ForwardMeteredData_V1
     internal const int FindReceiverStep = 3;
     internal const int EnqueueActorMessagesStep = 4;
 
+    public static readonly Brs_021_ForwardedMeteredData_V1 Name = new();
+
     private readonly TaskOptions _defaultRetryOptions;
 
     public Orchestration_Brs_021_ForwardMeteredData_V1()

--- a/source/ProcessManager.Orchestrations/TestServices/ElectricityMarketViewsStub.cs
+++ b/source/ProcessManager.Orchestrations/TestServices/ElectricityMarketViewsStub.cs
@@ -28,6 +28,11 @@ public sealed class ElectricityMarketViewsStub : IElectricityMarketViews
         MeteringPointIdentification meteringPointId,
         Interval period)
     {
+        if (meteringPointId.Value == "NoMasterData")
+        {
+            yield break;
+        }
+
         var meteringPointMasterData =
             (MeteringPointMasterData)Activator.CreateInstance(typeof(MeteringPointMasterData))!;
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

The goal of this PR is to add a skeleton implementation that can create and enqueue an RSM-009 in case the validation of an RSM-012 fails. In particular, the following simplifications are made:
- The receiver and receiver role are hard-coded as we currently don't get those from EDI
- The business type is hard-coded as we currently don't get that from EDI either
- All errors are added using a haed-coded, randomly selected error code
- All errors are added only to the `Reason` list as we currently lack the under standing of how to accurately construct an RSM-009
- The names of the fields and structures in the AcknowlegdementV1 are taken directly from the CIM JSON schema as this makes it easier (for now) to tie everything together

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
