### PR TITLE
feat: PM -> EDI send RSM-012

### DIFF
--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -2,6 +2,10 @@
 
 ## Version 0.11.0
 
+- Add accept model (RSM-012) for BRS 21 named `MeteredDataForMeteringPointAcceptedV1`
+
+## Version 0.11.0
+
 - Add rejected model (RSM-009) for BRS 21 named `MeteredDataForMeteringPointRejectedV1`
 
 ## Version 0.10.0

--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,6 +1,6 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
-## Version 0.11.0
+## Version 0.12.0
 
 - Add accept model (RSM-012) for BRS 21 named `MeteredDataForMeteringPointAcceptedV1`
 

--- a/source/ProcessManager.Components/Datahub/ValueObjects/ActorRole.cs
+++ b/source/ProcessManager.Components/Datahub/ValueObjects/ActorRole.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json.Serialization;
+
+namespace Energinet.DataHub.ProcessManager.Components.Datahub.ValueObjects;
+
+[Serializable]
+public class ActorRole : DataHubType<ActorRole>
+{
+    public static readonly ActorRole MeteringPointAdministrator = new("MeteringPointAdministrator", "DDZ");
+    public static readonly ActorRole EnergySupplier = new("EnergySupplier", "DDQ");
+    public static readonly ActorRole GridAccessProvider = new("GridAccessProvider", "DDM");
+    public static readonly ActorRole MeteredDataAdministrator = new("MeteredDataAdministrator", "DGL");
+    public static readonly ActorRole MeteredDataResponsible = new("MeteredDataResponsible", "MDR");
+    public static readonly ActorRole BalanceResponsibleParty = new("BalanceResponsibleParty", "DDK");
+    public static readonly ActorRole ImbalanceSettlementResponsible = new("ImbalanceSettlementResponsible", "DDX");
+    public static readonly ActorRole SystemOperator = new("SystemOperator", "EZ");
+    public static readonly ActorRole DanishEnergyAgency = new("DanishEnergyAgency", "STS");
+    public static readonly ActorRole Delegated = new("Delegated", "DEL");
+    public static readonly ActorRole DataHubAdministrator = new("DataHubAdministrator", string.Empty);
+
+    [JsonConstructor]
+    private ActorRole(string name, string code)
+        : base(name, code)
+    {
+    }
+}

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -52,10 +52,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NodaTime" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ProcessManager.Abstractions\ProcessManager.Abstractions.csproj" />
+    <ProjectReference Include="..\ProcessManager.Components\ProcessManager.Components.csproj" />
   </ItemGroup>
 
 </Project>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>0.11.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.12.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/AcceptedEnergyObservation.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/AcceptedEnergyObservation.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Components.Datahub.ValueObjects;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+public record AcceptedEnergyObservation(
+    int Position,
+    decimal? EnergyQuantity,
+    Quality? QuantityQuality);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/EnergyObservation.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/EnergyObservation.cs
@@ -15,6 +15,6 @@
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 
 public record EnergyObservation(
-    string? Position,
+    string? Position, // should have been an int? LRN
     string? EnergyQuantity,
     string? QuantityQuality);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/EnergyObservation.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/EnergyObservation.cs
@@ -15,6 +15,6 @@
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 
 public record EnergyObservation(
-    string? Position, // should have been an int? LRN
+    string? Position,
     string? EnergyQuantity,
     string? QuantityQuality);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MarketActorRecipient.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MarketActorRecipient.cs
@@ -1,4 +1,4 @@
-// Copyright 2020 Energinet DataHub A/S
+﻿// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MarketActorRecipient.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MarketActorRecipient.cs
@@ -1,0 +1,19 @@
+// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Components.Datahub.ValueObjects;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+public sealed record MarketActorRecipient(string ActorId, ActorRole ActorRole);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointAcceptedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointAcceptedV1.cs
@@ -22,7 +22,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// A model containing the data required for notifying market actors when new metered data has been accepted.
 /// </summary>
 public record MeteredDataForMeteringPointAcceptedV1(
-    string MeteringPointId, // Should PM know if the value is actually an GLN?
+    string MeteringPointId,
     MeteringPointType MeteringPointType,
     string OriginalTransactionId, // What term is used in PM to describe this?
     string Product, // Do we need to pass this along?

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointAcceptedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointAcceptedV1.cs
@@ -29,8 +29,8 @@ public record MeteredDataForMeteringPointAcceptedV1(
     MeasurementUnit MeasureUnit,
     Instant RegistrationDateTime,
     Resolution Resolution,
-    Instant StartDateTime,
-    Instant EndDateTime,
+    DateTimeOffset StartDateTime,
+    DateTimeOffset EndDateTime,
     IReadOnlyCollection<AcceptedEnergyObservation> AcceptedEnergyObservations,
     IReadOnlyCollection<MarketActorRecipient> MarketActorRecipients)
     : IInputParameterDto;

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointAcceptedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointAcceptedV1.cs
@@ -24,13 +24,13 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 public record MeteredDataForMeteringPointAcceptedV1(
     string MeteringPointId,
     MeteringPointType MeteringPointType,
-    string OriginalTransactionId, // What term is used in PM to describe this?
-    string Product, // Do we need to pass this along?
+    string OriginalTransactionId,
+    string ProductNumber,
     MeasurementUnit MeasureUnit,
     Instant RegistrationDateTime,
     Resolution Resolution,
     Instant StartDateTime,
     Instant EndDateTime,
     IReadOnlyCollection<AcceptedEnergyObservation> AcceptedEnergyObservations,
-    IReadOnlyCollection<MarketActorRecipient> MarketActorRecipients) // List of market actors who should be informed of the new metered data.
+    IReadOnlyCollection<MarketActorRecipient> MarketActorRecipients)
     : IInputParameterDto;

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointAcceptedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteredDataForMeteringPointAcceptedV1.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
+using Energinet.DataHub.ProcessManager.Components.Datahub.ValueObjects;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+/// <summary>
+/// A model containing the data required for notifying market actors when new metered data has been accepted.
+/// </summary>
+public record MeteredDataForMeteringPointAcceptedV1(
+    string MeteringPointId, // Should PM know if the value is actually an GLN?
+    MeteringPointType MeteringPointType,
+    string OriginalTransactionId, // What term is used in PM to describe this?
+    string Product, // Do we need to pass this along?
+    MeasurementUnit MeasureUnit,
+    Instant RegistrationDateTime,
+    Resolution Resolution,
+    Instant StartDateTime,
+    Instant EndDateTime,
+    IReadOnlyCollection<AcceptedEnergyObservation> AcceptedEnergyObservations,
+    IReadOnlyCollection<MarketActorRecipient> MarketActorRecipients) // List of market actors who should be informed of the new metered data.
+    : IInputParameterDto;

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -78,7 +78,7 @@ internal class EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1(
             MarketActorRecipients: [receiver]);
 
         await _enqueueActorMessagesClient.Enqueue(
-            new Brs_021_ForwardedMeteredData_V1(),
+            Orchestration_Brs_021_ForwardMeteredData_V1.UniqueName,
             activityInput.OrchestrationInstanceId.Value,
             orchestrationInstance.Lifecycle.CreatedBy.Value.ToDto(),
             "enqueue-" + activityInput.OrchestrationInstanceId.Value,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -12,20 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.ProcessManager.Components.Datahub.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.EnqueueActorMessages;
 using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Extensions;
 using Microsoft.Azure.Functions.Worker;
 using NodaTime;
+using MeteringPointType = Energinet.DataHub.ProcessManager.Components.Datahub.ValueObjects.MeteringPointType;
+using Resolution = Energinet.DataHub.ProcessManager.Components.Datahub.ValueObjects.Resolution;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Activities;
 
 internal class EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1(
     IClock clock,
-    IOrchestrationInstanceProgressRepository progressRepository)
+    IOrchestrationInstanceProgressRepository progressRepository,
+    IEnqueueActorMessagesClient enqueueActorMessagesClient)
     : ProgressActivityBase(
         clock,
         progressRepository)
 {
+    private readonly IEnqueueActorMessagesClient _enqueueActorMessagesClient = enqueueActorMessagesClient;
+
     [Function(nameof(EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1))]
     public async Task Run(
         [ActivityTrigger] ActivityInput activityInput)
@@ -39,9 +48,40 @@ internal class EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1(
                 orchestrationInstance)
             .ConfigureAwait(false);
 
-        // TODO: For demo purposes; remove when done
-        await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+        var messageInput = activityInput.MeteredDataForMeteringPointMessageInputV1;
+        var acceptedEnergyObservations = messageInput.EnergyObservations
+            .Select(
+                x => new AcceptedEnergyObservation(
+                    int.Parse(x.Position!),
+                    decimal.Parse(x.EnergyQuantity!),
+                    Quality.Adjusted))
+            .OrderBy(x => x.Position)
+            .ToList();
+
+        var data = new MeteredDataForMeteringPointAcceptedV1(
+            MeteringPointId: messageInput.MeteringPointId!,
+            MeteringPointType: (MeteringPointType)Enum.Parse(typeof(MeteringPointType), messageInput.MeteringPointType!),
+            activityInput.MeteredDataForMeteringPointMessageInputV1.TransactionId,
+            Product: messageInput.ProductNumber!,
+            MeasureUnit: (MeasurementUnit)Enum.Parse(typeof(MeasurementUnit), messageInput.MeasureUnit!),
+            RegistrationDateTime: InstantPatternWithOptionalSeconds.Parse(messageInput.RegistrationDateTime).Value,
+            Resolution: (Resolution)Enum.Parse(typeof(Resolution), messageInput.Resolution!),
+            StartDateTime: InstantPatternWithOptionalSeconds.Parse(messageInput.StartDateTime).Value,
+            EndDateTime: InstantPatternWithOptionalSeconds.Parse(messageInput.EndDateTime!).Value, // end always set?
+            AcceptedEnergyObservations: acceptedEnergyObservations,
+            MarketActorRecipients: [new MarketActorRecipient("8100000000115", ActorRole.EnergySupplier)]);
+
+        await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+
+        await _enqueueActorMessagesClient.Enqueue(
+            new Brs_021_ForwardedMeteredData_V1(),
+            activityInput.OrchestrationInstanceId.Value,
+            orchestrationInstance.Lifecycle.CreatedBy.Value.ToDto(),
+            "enqueue-" + activityInput.OrchestrationInstanceId.Value,
+            data).ConfigureAwait(false);
     }
 
-    public sealed record ActivityInput(OrchestrationInstanceId OrchestrationInstanceId);
+    public sealed record ActivityInput(
+        OrchestrationInstanceId OrchestrationInstanceId,
+        MeteredDataForMeteringPointMessageInputV1 MeteredDataForMeteringPointMessageInputV1);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -68,7 +68,7 @@ internal class EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1(
             MeteringPointId: messageInput.MeteringPointId!,
             MeteringPointType: MeteringPointType.FromCode(messageInput.MeteringPointType!),
             activityInput.MeteredDataForMeteringPointMessageInputV1.TransactionId,
-            Product: messageInput.ProductNumber!,
+            ProductNumber: messageInput.ProductNumber!,
             MeasureUnit: MeasurementUnit.FromCode(messageInput.MeasureUnit!),
             RegistrationDateTime: InstantPatternWithOptionalSeconds.Parse(messageInput.RegistrationDateTime).Value,
             Resolution: Resolution.FromCode(messageInput.Resolution!),

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -57,7 +57,7 @@ internal class EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1(
                 x => new AcceptedEnergyObservation(
                     int.Parse(x.Position!),
                     decimal.Parse(x.EnergyQuantity!),
-                    Quality.Adjusted))
+                    Quality.FromCode(x.QuantityQuality!)))
             .ToList();
 
         var receiver = activityInput.MeteredDataForMeteringPointMessageInputV1.TransactionId.Contains("perf_test")

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -72,8 +72,8 @@ internal class EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1(
             MeasureUnit: MeasurementUnit.FromCode(messageInput.MeasureUnit!),
             RegistrationDateTime: InstantPatternWithOptionalSeconds.Parse(messageInput.RegistrationDateTime).Value,
             Resolution: Resolution.FromCode(messageInput.Resolution!),
-            StartDateTime: InstantPatternWithOptionalSeconds.Parse(messageInput.StartDateTime).Value,
-            EndDateTime: InstantPatternWithOptionalSeconds.Parse(messageInput.EndDateTime!).Value,
+            StartDateTime: InstantPatternWithOptionalSeconds.Parse(messageInput.StartDateTime).Value.ToDateTimeOffset(),
+            EndDateTime: InstantPatternWithOptionalSeconds.Parse(messageInput.EndDateTime!).Value.ToDateTimeOffset(),
             AcceptedEnergyObservations: acceptedEnergyObservations,
             MarketActorRecipients: [receiver]);
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Orchestration_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Orchestration_Brs_021_ForwardMeteredData_V1.cs
@@ -17,7 +17,6 @@ using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Core.Infrastructure.Extensions.DurableTask;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Activities;
-using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026.V1.Activities;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.DurableTask;
 
@@ -29,7 +28,6 @@ internal class Orchestration_Brs_021_ForwardMeteredData_V1
     internal const int StoringMeteredDataStep = 2;
     internal const int FindReceiverStep = 3;
     internal const int EnqueueActorMessagesStep = 4;
-
     private readonly TaskOptions _defaultRetryOptions;
 
     public Orchestration_Brs_021_ForwardMeteredData_V1()
@@ -98,7 +96,7 @@ internal class Orchestration_Brs_021_ForwardMeteredData_V1
         // Step: Enqueueing
         await context.CallActivityAsync(
             nameof(EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1),
-            new EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.ActivityInput(instanceId),
+            new EnqueueActorMessagesActivity_Brs_021_ForwardMeteredData_V1.ActivityInput(instanceId, input),
             _defaultRetryOptions);
         //await context.WaitForExternalEvent<string>("EDI_Notification");
         await context.CallActivityAsync(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
This PR will enable the BRS_21_ForwardMeteredData process to send a message to EDI enqueue a RSM-012 for a accepted metered data series.

There is no test included in this PR for now. Testing the activity in use will be testet in an upcoming PR.

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/420
Link to assignment:

## Checklist

- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task
