### PR TITLE
fix: avoid return third part type to orchestration

### DIFF
--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/GetMeteringPointMasterDataActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/GetMeteringPointMasterDataActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -15,9 +15,12 @@
 using Energinet.DataHub.ElectricityMarket.Integration;
 using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects;
+using Energinet.DataHub.ProcessManager.Orchestrations.Extensions.Mapper;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Mapper;
 using Microsoft.Azure.Functions.Worker;
 using NodaTime;
+using MeteringPointType = Energinet.DataHub.ElectricityMarket.Integration.MeteringPointType;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Activities;
 
@@ -65,73 +68,10 @@ internal sealed class GetMeteringPointMasterDataActivity_Brs_021_ForwardMeteredD
             new Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointId(arg.Identification.Value),
             new Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.GridAreaCode(arg.GridAreaCode.Value),
             new Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.ActorNumber(arg.GridAccessProvider.Value),
-            MapConnectionState(arg.ConnectionState),
-            Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeteringPointType.FromName(nameof(arg.Type)),
-            MapSubType(arg.SubType),
-            MapUnit(arg.Unit));
-    }
-
-    private static MeasurementUnit MapUnit(MeasureUnit measureUnit)
-    {
-        switch (measureUnit)
-        {
-            case MeasureUnit.Ampere:
-                return MeasurementUnit.Ampere;
-            case MeasureUnit.STK:
-                return MeasurementUnit.Pieces;
-            case MeasureUnit.kVArh:
-                return MeasurementUnit.KiloVoltAmpereReactiveHour;
-            case MeasureUnit.kWh:
-                return MeasurementUnit.KilowattHour;
-            case MeasureUnit.kW:
-                return MeasurementUnit.Kilowatt;
-            case MeasureUnit.MW:
-                return MeasurementUnit.Megawatt;
-            case MeasureUnit.MWh:
-                return MeasurementUnit.MegawattHour;
-            case MeasureUnit.Tonne:
-                return MeasurementUnit.MetricTon;
-            case MeasureUnit.MVAr:
-                return MeasurementUnit.MegaVoltAmpereReactivePower;
-            case MeasureUnit.DanishTariffCode:
-                return MeasurementUnit.DanishTariffCode;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(measureUnit), measureUnit, null);
-        }
-    }
-
-    private static Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointSubType MapSubType(MeteringPointSubType meteringPointSubType)
-    {
-        switch (meteringPointSubType)
-        {
-            case MeteringPointSubType.Physical:
-                return Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointSubType.Physical;
-            case MeteringPointSubType.Virtual:
-                return Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointSubType.Virtual;
-            case MeteringPointSubType.Calculated:
-                return Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointSubType.Calculated;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(meteringPointSubType), meteringPointSubType, null);
-        }
-    }
-
-    private static Model.ConnectionState MapConnectionState(ConnectionState connectionState)
-    {
-        switch (connectionState)
-        {
-            case ConnectionState.NotUsed:
-                return Model.ConnectionState.NotUsed;
-            case ConnectionState.ClosedDown:
-                return Model.ConnectionState.ClosedDown;
-            case ConnectionState.New:
-                return Model.ConnectionState.New;
-            case ConnectionState.Connected:
-                return Model.ConnectionState.Connected;
-            case ConnectionState.Disconnected:
-                return Model.ConnectionState.Disconnected;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(connectionState), connectionState, null);
-        }
+            MeteringPointMasterDataMapper.ConnectionStateMap.Map(arg.ConnectionState),
+            MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(arg.Type),
+            MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(arg.SubType),
+            MeteringPointMasterDataMapper.MeasureUnitMap.Map(arg.Unit));
     }
 
     public sealed record ActivityInput(string? MeteringPointIdentification, string StartDateTime, string? EndDateTime);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/PerformValidationActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/PerformValidationActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -51,5 +51,5 @@ internal class PerformValidationActivity_Brs_021_ForwardMeteredData_V1(
 
     public sealed record ActivityInput(
         OrchestrationInstanceId OrchestrationInstanceId,
-        IReadOnlyCollection<MeteringPointMasterData> MeteringPointMasterData);
+        IReadOnlyCollection<Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointMasterData> MeteringPointMasterData);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Mapper/MeteringPointMasterDataMapper.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Mapper/MeteringPointMasterDataMapper.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ElectricityMarket.Integration;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Mapper;
+
+public static class MeteringPointMasterDataMapper
+{
+    public static readonly Dictionary<MeteringPointType, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeteringPointType> MeteringPointTypeMap = new()
+    {
+        { MeteringPointType.Consumption, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeteringPointType.Consumption },
+        { MeteringPointType.Production, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeteringPointType.Production },
+        { MeteringPointType.Exchange, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeteringPointType.Exchange },
+    };
+
+    public static readonly Dictionary<MeasureUnit, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit> MeasureUnitMap = new()
+    {
+        { MeasureUnit.Ampere, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.Ampere },
+        { MeasureUnit.STK, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.Pieces },
+        { MeasureUnit.kVArh, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.KiloVoltAmpereReactiveHour },
+        { MeasureUnit.kWh, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.KilowattHour },
+        { MeasureUnit.kW, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.Kilowatt },
+        { MeasureUnit.MW, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.Megawatt },
+        { MeasureUnit.MWh, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.MegawattHour },
+        { MeasureUnit.Tonne, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.MetricTon },
+        { MeasureUnit.MVAr, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.MegaVoltAmpereReactivePower },
+        { MeasureUnit.DanishTariffCode, Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects.MeasurementUnit.DanishTariffCode },
+    };
+
+    public static readonly Dictionary<MeteringPointSubType, Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointSubType> MeteringPointSubTypeMap = new()
+    {
+        { MeteringPointSubType.Physical, Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointSubType.Physical },
+        { MeteringPointSubType.Virtual, Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointSubType.Virtual },
+        { MeteringPointSubType.Calculated, Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointSubType.Calculated },
+    };
+
+    public static readonly Dictionary<ConnectionState, Model.ConnectionState> ConnectionStateMap = new()
+    {
+        { ConnectionState.NotUsed, Model.ConnectionState.NotUsed },
+        { ConnectionState.ClosedDown, Model.ConnectionState.ClosedDown },
+        { ConnectionState.New, Model.ConnectionState.New },
+        { ConnectionState.Connected, Model.ConnectionState.Connected },
+        { ConnectionState.Disconnected, Model.ConnectionState.Disconnected },
+    };
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/ConnectionState.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/ConnectionState.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+public enum ConnectionState
+{
+    NotUsed,
+    ClosedDown,
+    New,
+    Connected,
+    Disconnected,
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointMasterData.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointMasterData.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+public record MeteringPointMasterData(
+    MeteringPointId MeteringPointId,
+    GridAreaCode GridAreaCode,
+    ActorNumber GridAccessProvider,
+    ConnectionState ConnectionState,
+    MeteringPointType Type,
+    MeteringPointSubType SubType,
+    MeasurementUnit Unit);
+
+public record MeteringPointId(string Value);
+
+public record GridAreaCode(string Value);
+
+public record ActorNumber(string Value);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointMasterData.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointMasterData.cs
@@ -21,9 +21,9 @@ public record MeteringPointMasterData(
     GridAreaCode GridAreaCode,
     ActorNumber GridAccessProvider,
     ConnectionState ConnectionState,
-    MeteringPointType Type,
-    MeteringPointSubType SubType,
-    MeasurementUnit Unit);
+    MeteringPointType MeteringPointType,
+    MeteringPointSubType MeteringPointSubType,
+    MeasurementUnit MeasurementUnit);
 
 public record MeteringPointId(string Value);
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointSubType.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointSubType.cs
@@ -14,8 +14,7 @@
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
 
-// TODO: Name are being checked!
-public enum MeteringPointSubType
+public enum MeteringPointSubType // Målepunktsart, consider promoting this to a datahub ValueObject
 {
     Physical,
     Virtual,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointSubType.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointSubType.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+// TODO: Name are being checked!
+public enum MeteringPointSubType
+{
+    Physical,
+    Virtual,
+    Calculated,
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Orchestration_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Orchestration_Brs_021_ForwardMeteredData_V1.cs
@@ -187,7 +187,7 @@ internal class Orchestration_Brs_021_ForwardMeteredData_V1
     private async Task<IReadOnlyCollection<string>> PerformValidationAsync(
         TaskOrchestrationContext context,
         OrchestrationInstanceId instanceId,
-        IReadOnlyCollection<MeteringPointMasterData> meteringPointMasterData)
+        IReadOnlyCollection<Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model.MeteringPointMasterData> meteringPointMasterData)
     {
         var errors = await context.CallActivityAsync<IReadOnlyCollection<string>>(
             nameof(PerformValidationActivity_Brs_021_ForwardMeteredData_V1),


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
If the data type from a third-party package changes, then running orchestrations will not be able to hydrate the object if it has changed

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
