### PR TITLE
test: Block fluentassertions v8

### DIFF
--- a/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
+++ b/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
@@ -9,6 +9,9 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\Tests\Fixtures\Extensions\ServiceCollectionExtensions.cs" Link="Fixtures\Extensions\ServiceCollectionExtensions.cs" />
+    <Compile Include="..\Shared\Tests\FluentAssertionsVersionGuard.cs">
+      <Link>FluentAssertionsVersionGuard.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
+++ b/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
@@ -10,6 +10,9 @@
   <ItemGroup>
     <Compile Include="..\Shared\Tests\Fixtures\Extensions\ServiceCollectionExtensions.cs" Link="Fixtures\Extensions\ServiceCollectionExtensions.cs" />
     <Compile Include="..\Shared\Tests\Fixtures\Extensions\DatabricksApiWireMockExtensions.cs" Link="Fixtures\Extensions\DatabricksApiWireMockExtensions.cs" />
+    <Compile Include="..\Shared\Tests\FluentAssertionsVersionGuard.cs">
+      <Link>FluentAssertionsVersionGuard.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Core.Tests/ProcessManager.Core.Tests.csproj
+++ b/source/ProcessManager.Core.Tests/ProcessManager.Core.Tests.csproj
@@ -10,6 +10,9 @@
   <ItemGroup>
     <Compile Include="..\Shared\Tests\Fixtures\ProcessManagerDatabaseManager.cs" Link="Fixtures\ProcessManagerDatabaseManager.cs" />
     <Compile Include="..\Shared\Tests\Fixtures\Extensions\ServiceCollectionExtensions.cs" Link="Fixtures\Extensions\ServiceCollectionExtensions.cs" />
+    <Compile Include="..\Shared\Tests\FluentAssertionsVersionGuard.cs">
+      <Link>FluentAssertionsVersionGuard.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/source/ProcessManager.Example.Orchestrations.Tests/ProcessManager.Example.Orchestrations.Tests.csproj
+++ b/source/ProcessManager.Example.Orchestrations.Tests/ProcessManager.Example.Orchestrations.Tests.csproj
@@ -15,6 +15,9 @@
         <Compile Include="..\Shared\Tests\Fixtures\ProcessManagerAppManager.cs" Link="Fixtures\ProcessManagerAppManager.cs" />
         <Compile Include="..\Shared\Tests\Fixtures\ProcessManagerDatabaseManager.cs" Link="Fixtures\ProcessManagerDatabaseManager.cs" />
         <Compile Include="..\Shared\Tests\Fixtures\Extensions\ServiceCollectionExtensions.cs" Link="Fixtures\Extensions\ServiceCollectionExtensions.cs" />
+        <Compile Include="..\Shared\Tests\FluentAssertionsVersionGuard.cs">
+          <Link>FluentAssertionsVersionGuard.cs</Link>
+        </Compile>
         <Compile Include="..\Shared\Tests\Models\OrchestrationHistoryItem.cs" Link="Fixtures\Models\OrchestrationHistoryItem.cs" />
     </ItemGroup>
 

--- a/source/ProcessManager.Orchestrations.Tests/ProcessManager.Orchestrations.Tests.csproj
+++ b/source/ProcessManager.Orchestrations.Tests/ProcessManager.Orchestrations.Tests.csproj
@@ -17,6 +17,9 @@
     <Compile Include="..\Shared\Tests\Fixtures\ProcessManagerAppManager.cs" Link="Fixtures\ProcessManagerAppManager.cs" />
     <Compile Include="..\Shared\Tests\Fixtures\Extensions\ServiceCollectionExtensions.cs" Link="Fixtures\Extensions\ServiceCollectionExtensions.cs" />
     <Compile Include="..\Shared\Tests\Fixtures\Extensions\DatabricksApiWireMockExtensions.cs" Link="Fixtures\Extensions\DatabricksApiWireMockExtensions.cs" />
+    <Compile Include="..\Shared\Tests\FluentAssertionsVersionGuard.cs">
+      <Link>FluentAssertionsVersionGuard.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\Tests\Models\OrchestrationHistoryItem.cs" Link="Fixtures\Models\OrchestrationHistoryItem.cs" />
   </ItemGroup>
 

--- a/source/ProcessManager.SubsystemTests/ProcessManager.SubsystemTests.csproj
+++ b/source/ProcessManager.SubsystemTests/ProcessManager.SubsystemTests.csproj
@@ -43,4 +43,10 @@
     <Folder Include="Fixtures\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Tests\FluentAssertionsVersionGuard.cs">
+      <Link>FluentAssertionsVersionGuard.cs</Link>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/source/ProcessManager.Tests/ProcessManager.Tests.csproj
+++ b/source/ProcessManager.Tests/ProcessManager.Tests.csproj
@@ -11,6 +11,9 @@
     <Compile Include="..\Shared\Tests\Fixtures\ExampleOrchestrationsAppManager.cs" Link="Fixtures\ExampleOrchestrationsAppManager.cs" />
     <Compile Include="..\Shared\Tests\Fixtures\ProcessManagerAppManager.cs" Link="Fixtures\ProcessManagerAppManager.cs" />
     <Compile Include="..\Shared\Tests\Fixtures\ProcessManagerDatabaseManager.cs" Link="Fixtures\ProcessManagerDatabaseManager.cs" />
+    <Compile Include="..\Shared\Tests\FluentAssertionsVersionGuard.cs">
+      <Link>FluentAssertionsVersionGuard.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Shared/Tests/FluentAssertionsVersionGuard.cs
+++ b/source/Shared/Tests/FluentAssertionsVersionGuard.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.ProcessManager.Tests;
+
+public class FluentAssertionsVersionGuard
+{
+    /// <summary>
+    /// FluentAssertions have from version 8 introduced a new license model.
+    /// This guard ensures that we do not use a version that is not allowed.
+    /// </summary>
+    [Fact]
+    public void ShouldHaveValidVersion()
+    {
+        var actualVersion = typeof(FluentAssertions.ObjectAssertionsExtensions).Assembly.GetName().Version;
+        var forbiddenVersion = new Version(8, 0, 0, 0);
+
+        actualVersion.Should().NotBeNull();
+        actualVersion.Should().BeLessThan(forbiddenVersion, "FluentAssertions >= 8 is not allowed.");
+    }
+}


### PR DESCRIPTION
This pull request includes the addition of a new file, `FluentAssertionsVersionGuard.cs`, across multiple test projects. This change ensures that the version of FluentAssertions used in the tests does not exceed version 8 due to licensing constraints.

Key changes include:

* Added the new file `FluentAssertionsVersionGuard.cs` with a test to ensure the version of FluentAssertions does not exceed version 8.
* Added `FluentAssertionsVersionGuard.cs` to multiple test project files to ensure compliance with FluentAssertions' licensing model:
  * `source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj`
  * `source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj`
  * `source/ProcessManager.Core.Tests/ProcessManager.Core.Tests.csproj`
  * `source/ProcessManager.Example.Orchestrations.Tests/ProcessManager.Example.Orchestrations.Tests.csproj`
  * `source/ProcessManager.Orchestrations.Tests/ProcessManager.Orchestrations.Tests.csproj`
  * `source/ProcessManager.SubsystemTests/ProcessManager.SubsystemTests.csproj`
  * `source/ProcessManager.Tests/ProcessManager.Tests.csproj`