### PR TITLE
feat: Update BRS-026 and BRS-028 rejected data types

### DIFF
--- a/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Client Release Notes
 
+## Version 0.26.1
+
+- Update `EnqueueActorMessagesV1` with `BuildServiceBusMessageSubject()` method.
+
 ## Version 0.26.0
 
 - Throw exception in `EnqueueActorMessagesV1.ParseData<TData>()` if parsing incorrect `DataType`.

--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
+## Version 0.18.2
+
+- Update `RequestCalculatedEnergyTimeSeriesRejectedV1` with missing properties.
+- Update `RequestCalculatedWholesaleServicesRejectedV1` with missing properties.
+
 ## Version 0.18.1
 
 - Update `RequestCalculatedEnergyTimeSeriesInputV1` with "requested by actor" properties.

--- a/source/ProcessManager.Abstractions/Contracts/EnqueueActorMessagesV1.cs
+++ b/source/ProcessManager.Abstractions/Contracts/EnqueueActorMessagesV1.cs
@@ -13,12 +13,23 @@
 // limitations under the License.
 
 using System.Text.Json;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescription;
 
 namespace Energinet.DataHub.ProcessManager.Abstractions.Contracts;
 
 public partial class EnqueueActorMessagesV1
 {
     public const string MajorVersion = nameof(EnqueueActorMessagesV1);
+
+    /// <summary>
+    /// Build the service bus message subject using the provided orchestration unique name.
+    /// </summary>
+    public static string BuildServiceBusMessageSubject(string orchestrationUniqueName) => $"Enqueue_{orchestrationUniqueName.ToLower()}";
+
+    /// <summary>
+    /// Build the service bus message subject using the provided orchestration unique name.
+    /// </summary>
+    public static string BuildServiceBusMessageSubject(OrchestrationDescriptionUniqueNameDto uniqueName) => BuildServiceBusMessageSubject(uniqueName.Name);
 
     public void SetData<TData>(TData data)
         where TData : class

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Abstractions</PackageId>
-    <PackageVersion>0.26.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.26.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Client</PackageId>
-    <PackageVersion>0.26.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.26.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Components/EnqueueActorMessages/EnqueueActorMessagesClient.cs
+++ b/source/ProcessManager.Components/EnqueueActorMessages/EnqueueActorMessagesClient.cs
@@ -59,7 +59,7 @@ public class EnqueueActorMessagesClient(
             enqueueActorMessages.OrchestrationStartedByUserId = startedByUserId.ToString();
 
         var serviceBusMessage = enqueueActorMessages.ToServiceBusMessage(
-            subject: "Enqueue_" + orchestration.Name.ToLower(),
+            subject: EnqueueActorMessagesV1.BuildServiceBusMessageSubject(orchestration.Name),
             idempotencyKey: idempotencyKey.ToString());
 
         await _serviceBusSender.SendMessageAsync(serviceBusMessage)

--- a/source/ProcessManager.Example.Orchestrations.Tests/Fixtures/ExampleConsumerAppManager.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Fixtures/ExampleConsumerAppManager.cs
@@ -21,6 +21,8 @@ using Energinet.DataHub.Core.FunctionApp.TestCommon.FunctionAppHost;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvider;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Options;
 using Energinet.DataHub.Core.TestCommon.Diagnostics;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescription;
+using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
 using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Example.Consumer.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Abstractions.Processes.BRS_X03_ActorRequestProcessExample;
@@ -253,7 +255,7 @@ public class ExampleConsumerAppManager : IAsyncDisposable
         {
             builder
                 .AddSubscription(EnqueueBrsX03SubscriptionName)
-                    .AddSubjectFilter($"Enqueue_{Brs_X03.Name.ToLower()}");
+                    .AddSubjectFilter(EnqueueActorMessagesV1.BuildServiceBusMessageSubject(Brs_X03.V1));
 
             return builder;
         }

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>0.18.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.18.2$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026_028/BRS_026/V1/Model/RequestCalculatedEnergyTimeSeriesAcceptedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026_028/BRS_026/V1/Model/RequestCalculatedEnergyTimeSeriesAcceptedV1.cs
@@ -21,7 +21,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// A model containing the data for an accepted request for calculated energy time series
 /// </summary>
 public record RequestCalculatedEnergyTimeSeriesAcceptedV1(
-    string OriginalMessageId,
+    string OriginalActorMessageId,
     string OriginalTransactionId,
     ActorNumber RequestedForActorNumber,
     ActorRole RequestedForActorRole,

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026_028/BRS_026/V1/Model/RequestCalculatedEnergyTimeSeriesRejectedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026_028/BRS_026/V1/Model/RequestCalculatedEnergyTimeSeriesRejectedV1.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.ProcessManager.Abstractions.Components.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
 
@@ -20,4 +21,11 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// A model containing the validation errors if an energy time series request is rejected.
 /// </summary>
 public record RequestCalculatedEnergyTimeSeriesRejectedV1(
+    string OriginalMessageId,
+    string OriginalTransactionId,
+    ActorNumber RequestedForActorNumber,
+    ActorRole RequestedForActorRole,
+    ActorNumber RequestedByActorNumber,
+    ActorRole RequestedByActorRole,
+    BusinessReason BusinessReason,
     List<ValidationErrorDto> ValidationErrors);

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026_028/BRS_028/V1/Model/RequestCalculatedWholesaleServicesAcceptedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026_028/BRS_028/V1/Model/RequestCalculatedWholesaleServicesAcceptedV1.cs
@@ -20,7 +20,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// A model containing the data for an accepted request for calculated energy time series
 /// </summary>
 public record RequestCalculatedWholesaleServicesAcceptedV1(
-    string OriginalMessageId,
+    string OriginalActorMessageId,
     string OriginalTransactionId,
     ActorNumber RequestedForActorNumber,
     ActorRole RequestedForActorRole,

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026_028/BRS_028/V1/Model/RequestCalculatedWholesaleServicesRejectedV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_026_028/BRS_028/V1/Model/RequestCalculatedWholesaleServicesRejectedV1.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.ProcessManager.Abstractions.Components.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
 
@@ -20,4 +21,11 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 /// A model containing the validation errors if a wholesale services request is rejected.
 /// </summary>
 public record RequestCalculatedWholesaleServicesRejectedV1(
+    string OriginalMessageId,
+    string OriginalTransactionId,
+    ActorNumber RequestedForActorNumber,
+    ActorRole RequestedForActorRole,
+    ActorNumber RequestedByActorNumber,
+    ActorRole RequestedByActorRole,
+    BusinessReason BusinessReason,
     List<ValidationErrorDto> ValidationErrors);

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ServiceBusReceivedMessageExtensions.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ServiceBusReceivedMessageExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+
+public static class ServiceBusReceivedMessageExtensions
+{
+    public static bool TryParseAsEnqueueActorMessages(
+        this ServiceBusReceivedMessage message,
+        string orchestrationUniqueName,
+        out EnqueueActorMessagesV1 enqueueActorMessagesV1)
+    {
+        enqueueActorMessagesV1 = new EnqueueActorMessagesV1();
+        if (message.Subject != $"Enqueue_{orchestrationUniqueName.ToLower()}")
+            return false;
+
+        var majorVersion = message.ApplicationProperties["MajorVersion"].ToString();
+        if (majorVersion != nameof(EnqueueActorMessagesV1))
+        {
+            return false;
+        }
+
+        var messageBody = message.Body.ToString();
+        enqueueActorMessagesV1 = EnqueueActorMessagesV1.Parser.ParseJson(messageBody);
+        if (enqueueActorMessagesV1 == null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ServiceBusReceivedMessageExtensions.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ServiceBusReceivedMessageExtensions.cs
@@ -35,7 +35,7 @@ public static class ServiceBusReceivedMessageExtensions
         out EnqueueActorMessagesV1 enqueueActorMessagesV1)
     {
         enqueueActorMessagesV1 = new EnqueueActorMessagesV1();
-        if (message.Subject != $"Enqueue_{orchestrationUniqueName.ToLower()}")
+        if (message.Subject != EnqueueActorMessagesV1.BuildServiceBusMessageSubject(orchestrationUniqueName))
             return false;
 
         var majorVersion = message.ApplicationProperties["MajorVersion"].ToString();

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ServiceBusReceivedMessageExtensions.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ServiceBusReceivedMessageExtensions.cs
@@ -19,6 +19,16 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensi
 
 public static class ServiceBusReceivedMessageExtensions
 {
+    /// <summary>
+    /// Try to parse the received service bus message as a EnqueueActorMessagesV1 message.
+    /// <remarks>
+    /// If the major version isn't correct then the method will return false.
+    /// </remarks>
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="orchestrationUniqueName">The name of the orchestration that is enqueued for, used to verify the message subject.</param>
+    /// <param name="enqueueActorMessagesV1">The parsed <see cref="EnqueueActorMessagesV1"/>. Will have default value if parsing fails (and false will be returned).</param>
+    /// <returns>Returns true if succeeded, else false.</returns>
     public static bool TryParseAsEnqueueActorMessages(
         this ServiceBusReceivedMessage message,
         string orchestrationUniqueName,

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/ServiceBusResponseMocking.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/ServiceBusResponseMocking.cs
@@ -15,6 +15,7 @@
 using System.Text.Json;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
+using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
 using Energinet.DataHub.ProcessManager.Client;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027.V1.Model;
@@ -33,10 +34,10 @@ public static class ServiceBusResponseMocking
             .When(
                 message =>
                 {
-                    if (message.Subject != $"Enqueue_{Brs_023_027.Name.ToLower()}")
+                    if (message.Subject != EnqueueActorMessagesV1.BuildServiceBusMessageSubject(Brs_023_027.V1))
                         return false;
 
-                    var body = Energinet.DataHub.ProcessManager.Abstractions.Contracts.EnqueueActorMessagesV1
+                    var body = EnqueueActorMessagesV1
                         .Parser.ParseJson(message.Body.ToString())!;
 
                     var calculationCompleted = JsonSerializer.Deserialize<CalculationEnqueueActorMessagesV1>(body.Data);

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
 using Energinet.DataHub.ProcessManager.Client;
 using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
 using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
@@ -43,14 +41,12 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {
     private readonly OrchestrationsAppFixture _fixture;
-    private readonly ITestOutputHelper _testOutputHelper;
 
     public MonitorOrchestrationUsingClientsScenario(
         OrchestrationsAppFixture fixture,
         ITestOutputHelper testOutputHelper)
     {
         _fixture = fixture;
-        _testOutputHelper = testOutputHelper;
         _fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -24,8 +25,10 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
@@ -88,19 +91,173 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     }
 
     /// <summary>
-    /// Showing how we can orchestrate and monitor an orchestration instance only using clients.
+    /// Tests the BRS-026 orchestration instance when the request is valid and actor messages should be enqueued.
     /// </summary>
     [Fact]
-    public async Task RequestCalculatedWholesaleServices_WhenStarted_CanMonitorLifecycle()
+    public async Task Given_ValidRequestCalculatedWholesaleServices_When_Started_Then_OrchestrationInstanceTerminatesWithSuccess()
     {
         var processManagerMessageClient = ServiceProvider.GetRequiredService<IProcessManagerMessageClient>();
         var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
 
         // Step 1: Start new orchestration instance
+        var requestCommand = GivenRequestCalculatedWholesaleServices();
+
+        await processManagerMessageClient.StartNewOrchestrationInstanceAsync(
+            requestCommand,
+            CancellationToken.None);
+
+        // Step 2a: Query until waiting for EnqueueActorMessagesCompleted notify event
+        var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
+            .WaitForStepToBeRunning<RequestCalculatedWholesaleServicesInputV1>(
+                idempotencyKey: requestCommand.IdempotencyKey,
+                stepSequence: Orchestration_Brs_028_V1.EnqueueActorMessagesStepSequence);
+
+        isWaitingForNotify.Should()
+            .BeTrue("because the orchestration instance should wait for a EnqueueActorMessagesCompleted notify event");
+
+        // Step 2b: Verify an enqueue actor messages event is sent on the service bus
+        var verifyEnqueueActorMessagesEvent = await _fixture.EnqueueBrs028ServiceBusListener.When(
+                (message) =>
+                {
+                    if (!message.TryParseAsEnqueueActorMessages(Brs_028.Name, out var enqueueActorMessagesV1))
+                        return false;
+
+                    var requestAcceptedV1 = enqueueActorMessagesV1.ParseData<RequestCalculatedWholesaleServicesAcceptedV1>();
+                    return requestAcceptedV1.OriginalTransactionId == requestCommand.IdempotencyKey;
+                })
+            .VerifyCountAsync(1);
+
+        var enqueueMessageFound = verifyEnqueueActorMessagesEvent.Wait(TimeSpan.FromSeconds(30));
+        enqueueMessageFound.Should().BeTrue($"because a {nameof(RequestCalculatedWholesaleServicesAcceptedV1)} service bus message should have been sent");
+
+        // Step 3: Send EnqueueActorMessagesCompleted event
+        await processManagerMessageClient.NotifyOrchestrationInstanceAsync(
+            new NotifyOrchestrationInstanceEvent(
+                OrchestrationInstanceId: orchestrationInstance!.Id.ToString(),
+                EventName: RequestCalculatedWholesaleServicesNotifyEventsV1.EnqueueActorMessagesCompleted),
+            CancellationToken.None);
+
+        // Step 4: Query until terminated with succeeded
+        var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await processManagerClient
+            .WaitForOrchestrationInstanceTerminated<RequestCalculatedWholesaleServicesInputV1>(
+                idempotencyKey: requestCommand.IdempotencyKey,
+                terminationState: OrchestrationInstanceTerminationState.Succeeded);
+
+        orchestrationTerminatedWithSucceeded.Should().BeTrue("because the orchestration instance should complete within given wait time");
+
+        // Orchestration instance and all steps should be Succeeded
+        using var assertionScope = new AssertionScope();
+        terminatedOrchestrationInstance!.Lifecycle.TerminationState.Should()
+            .NotBeNull()
+            .And.Be(OrchestrationInstanceTerminationState.Succeeded);
+
+        terminatedOrchestrationInstance.Steps.Should()
+            .AllSatisfy(
+                s =>
+                {
+                    s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
+                    s.Lifecycle.TerminationState.Should()
+                        .NotBeNull()
+                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                });
+    }
+
+    /// <summary>
+    /// Tests the BRS-028 orchestration instance when the request is invalid and rejected actor messages should be enqueued.
+    /// </summary>
+    [Fact]
+    public async Task Given_InvalidRequestCalculatedWholesaleServices_When_Started_Then_OrchestrationInstanceTerminatesWithFailed_AndThen_BusinessValidationStepFailed()
+    {
+        var processManagerMessageClient = ServiceProvider.GetRequiredService<IProcessManagerMessageClient>();
+        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
+
+        // Step 1: Start new orchestration instance
+        var invalidRequestCommand = GivenRequestCalculatedWholesaleServices(shouldFailBusinessValidation: true);
+
+        await processManagerMessageClient.StartNewOrchestrationInstanceAsync(
+            invalidRequestCommand,
+            CancellationToken.None);
+
+        // Step 2a: Query until waiting for EnqueueActorMessagesCompleted notify event
+        var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
+            .WaitForStepToBeRunning<RequestCalculatedWholesaleServicesInputV1>(
+                idempotencyKey: invalidRequestCommand.IdempotencyKey,
+                stepSequence: Orchestration_Brs_028_V1.EnqueueActorMessagesStepSequence);
+
+        isWaitingForNotify.Should()
+            .BeTrue("because the orchestration instance should wait for a EnqueueActorMessagesCompleted notify event");
+
+        // Step 2b: Verify an enqueue actor messages event is sent on the service bus
+        var verifyEnqueueRejectedActorMessagesEvent = await _fixture.EnqueueBrs026ServiceBusListener.When(
+                (message) =>
+                {
+                    if (!message.TryParseAsEnqueueActorMessages(Brs_028.Name, out var enqueueActorMessagesV1))
+                        return false;
+
+                    var requestAcceptedV1 = enqueueActorMessagesV1.ParseData<RequestCalculatedWholesaleServicesRejectedV1>();
+
+                    requestAcceptedV1.ValidationErrors.Should()
+                        .HaveCount(1)
+                        .And.ContainSingle(
+                            (e) => e.Message.Contains(
+                                "Feltet EnergySupplier skal være udfyldt med et valid GLN/EIC nummer når en elleverandør anmoder om data"));
+                    return requestAcceptedV1.OriginalTransactionId == invalidRequestCommand.InputParameter.TransactionId;
+                })
+            .VerifyCountAsync(1);
+
+        var enqueueMessageFound = verifyEnqueueRejectedActorMessagesEvent.Wait(TimeSpan.FromSeconds(30));
+        enqueueMessageFound.Should().BeTrue($"because a {nameof(RequestCalculatedWholesaleServicesInputV1)} service bus message should have been sent");
+
+        // Step 3: Send EnqueueActorMessagesCompleted event
+        await processManagerMessageClient.NotifyOrchestrationInstanceAsync(
+            new NotifyOrchestrationInstanceEvent(
+                OrchestrationInstanceId: orchestrationInstance!.Id.ToString(),
+                EventName: RequestCalculatedWholesaleServicesNotifyEventsV1.EnqueueActorMessagesCompleted),
+            CancellationToken.None);
+
+        // Step 4: Query until terminated with failed
+        var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await processManagerClient
+            .WaitForOrchestrationInstanceTerminated<RequestCalculatedWholesaleServicesInputV1>(
+                idempotencyKey: invalidRequestCommand.IdempotencyKey,
+                terminationState: OrchestrationInstanceTerminationState.Failed);
+
+        orchestrationTerminatedWithSucceeded.Should().BeTrue(
+            "because the orchestration instance should be failed within the given wait time");
+
+        // Orchestration instance and validation steps should be Failed
+        using var assertionScope = new AssertionScope();
+        terminatedOrchestrationInstance!.Lifecycle.TerminationState.Should()
+            .NotBeNull()
+            .And.Be(OrchestrationInstanceTerminationState.Failed);
+
+        terminatedOrchestrationInstance.Steps.OrderBy(s => s.Sequence).Should()
+            .SatisfyRespectively(
+                s =>
+                {
+                    // Validation step should be failed
+                    s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
+                    s.Lifecycle.TerminationState.Should()
+                        .NotBeNull()
+                        .And.Be(OrchestrationStepTerminationState.Failed);
+                },
+                s =>
+                {
+                    // Enqueue rejected messages step should be succeeded
+                    s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
+                    s.Lifecycle.TerminationState.Should()
+                        .NotBeNull()
+                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                });
+    }
+
+    private static RequestCalculatedWholesaleServicesCommandV1 GivenRequestCalculatedWholesaleServices(
+        bool shouldFailBusinessValidation = false)
+    {
         var businessReason = BusinessReason.WholesaleFixing.Name;
         const string energySupplierNumber = "1111111111111";
         var transactionId = Guid.NewGuid().ToString();
-        var startRequestCommand = new RequestCalculatedWholesaleServicesCommandV1(
+
+        return new RequestCalculatedWholesaleServicesCommandV1(
             new ActorIdentityDto(Guid.NewGuid()),
             new RequestCalculatedWholesaleServicesInputV1(
                 ActorMessageId: Guid.NewGuid().ToString(),
@@ -113,100 +270,12 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                 PeriodStart: "2024-12-31T23:00:00Z",
                 PeriodEnd: "2025-01-31T23:00:00Z",
                 Resolution: null,
-                EnergySupplierNumber: energySupplierNumber,
+                // EnergySupplierNumber is required when RequestedByActorRole is EnergySupplier, so the request will fail if not provided.
+                EnergySupplierNumber: !shouldFailBusinessValidation ? energySupplierNumber : null,
                 ChargeOwnerNumber: null,
                 GridAreas: ["804"],
                 SettlementVersion: null,
                 ChargeTypes: null),
             idempotencyKey: Guid.NewGuid().ToString());
-
-        await processManagerMessageClient.StartNewOrchestrationInstanceAsync(
-            startRequestCommand,
-            CancellationToken.None);
-
-        // Step 2a: Query until waiting for EnqueueActorMessagesCompleted notify event
-        var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
-            .TryWaitForOrchestrationInstance<RequestCalculatedWholesaleServicesInputV1>(
-                idempotencyKey: startRequestCommand.IdempotencyKey,
-                comparer: (oi) =>
-                {
-                    var enqueueActorMessagesStep = oi.Steps
-                        .Single(s => s.Sequence == Orchestration_Brs_028_V1.EnqueueActorMessagesStepSequence);
-
-                    return enqueueActorMessagesStep.Lifecycle.State == StepInstanceLifecycleState.Running;
-                });
-
-        isWaitingForNotify.Should()
-            .BeTrue("because the orchestration instance should wait for a EnqueueActorMessagesCompleted notify event");
-
-        if (orchestrationInstance is null)
-            ArgumentNullException.ThrowIfNull(orchestrationInstance, nameof(orchestrationInstance));
-
-        // Step 2b: Verify an enqueue actor messages event is sent on the service bus
-        var verifyEnqueueActorMessagesEvent = await _fixture.EnqueueBrs028ServiceBusListener.When(
-                (message) =>
-                {
-                    if (message.Subject != $"Enqueue_{Brs_028.Name.ToLower()}")
-                        return false;
-
-                    var majorVersion = message.ApplicationProperties["MajorVersion"].ToString();
-                    if (majorVersion != nameof(EnqueueActorMessagesV1))
-                    {
-                        _testOutputHelper.WriteLine("Unexpected major version: {0}", majorVersion);
-                        return false;
-                    }
-
-                    var messageBody = message.Body.ToString();
-                    var enqueueActorMessagesV1 = EnqueueActorMessagesV1.Parser.ParseJson(messageBody);
-                    if (enqueueActorMessagesV1 == null)
-                    {
-                        _testOutputHelper.WriteLine("Unable to parse EnqueueActorMessagesV1 body: {0}", messageBody);
-                        return false;
-                    }
-
-                    var requestAcceptedV1 = enqueueActorMessagesV1.ParseData<RequestCalculatedWholesaleServicesAcceptedV1>();
-
-                    return requestAcceptedV1.OriginalTransactionId == transactionId;
-                })
-            .VerifyCountAsync(1);
-
-        var enqueueMessageFound = verifyEnqueueActorMessagesEvent.Wait(TimeSpan.FromSeconds(30));
-        enqueueMessageFound.Should().BeTrue($"because a {nameof(RequestCalculatedWholesaleServicesAcceptedV1)} service bus message should have been sent");
-
-        // Step 3: Send EnqueueActorMessagesCompleted event
-        await processManagerMessageClient.NotifyOrchestrationInstanceAsync(
-            new NotifyOrchestrationInstanceEvent(
-                OrchestrationInstanceId: orchestrationInstance.Id.ToString(),
-                EventName: RequestCalculatedWholesaleServicesNotifyEventsV1.EnqueueActorMessagesCompleted),
-            CancellationToken.None);
-
-        // Step 4: Query until terminated with succeeded
-        var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await processManagerClient
-            .TryWaitForOrchestrationInstance<RequestCalculatedWholesaleServicesInputV1>(
-                idempotencyKey: startRequestCommand.IdempotencyKey,
-                (oi) => oi is
-                {
-                    Lifecycle:
-                    {
-                        State: OrchestrationInstanceLifecycleState.Terminated,
-                        TerminationState: OrchestrationInstanceTerminationState.Succeeded,
-                    },
-                });
-
-        orchestrationTerminatedWithSucceeded.Should().BeTrue("because the orchestration instance should complete within given wait time");
-
-        // If isTerminated is true then terminatedOrchestrationInstance should never be null
-        ArgumentNullException.ThrowIfNull(terminatedOrchestrationInstance);
-
-        // All steps should be Succeeded
-        terminatedOrchestrationInstance.Steps.Should()
-            .AllSatisfy(
-                s =>
-                {
-                    s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
-                    s.Lifecycle.TerminationState.Should()
-                        .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
-                });
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Activities/EnqueueActorMessagesActivity_Brs_026_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Activities/EnqueueActorMessagesActivity_Brs_026_V1.cs
@@ -64,7 +64,7 @@ internal class EnqueueActorMessagesActivity_Brs_026_V1(
             : null;
 
         var acceptedData = new RequestCalculatedEnergyTimeSeriesAcceptedV1(
-            OriginalMessageId: requestInput.ActorMessageId,
+            OriginalActorMessageId: requestInput.ActorMessageId,
             OriginalTransactionId: requestInput.TransactionId,
             RequestedForActorNumber: ActorNumber.Create(requestInput.RequestedForActorNumber),
             RequestedForActorRole: ActorRole.FromName(requestInput.RequestedForActorRole),

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Activities/EnqueueRejectMessageActivity_Brs_026_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Activities/EnqueueRejectMessageActivity_Brs_026_V1.cs
@@ -17,6 +17,7 @@ using Energinet.DataHub.ProcessManager.Components.BusinessValidation;
 using Energinet.DataHub.ProcessManager.Components.EnqueueActorMessages;
 using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
 using Microsoft.Azure.Functions.Worker;
 
@@ -45,7 +46,15 @@ internal class EnqueueRejectMessageActivity_Brs_026_V1(
 
     private Task EnqueueRejectMessageAsync(OperatingIdentity orchestrationCreatedBy, ActivityInput input)
     {
+        var requestInput = input.RequestInput;
         var rejectedMessage = new RequestCalculatedEnergyTimeSeriesRejectedV1(
+            OriginalMessageId: requestInput.ActorMessageId,
+            OriginalTransactionId: requestInput.TransactionId,
+            RequestedForActorNumber: ActorNumber.Create(requestInput.RequestedForActorNumber),
+            RequestedForActorRole: ActorRole.FromName(requestInput.RequestedForActorRole),
+            RequestedByActorNumber: ActorNumber.Create(requestInput.RequestedByActorNumber),
+            RequestedByActorRole: ActorRole.FromName(requestInput.RequestedByActorRole),
+            BusinessReason: BusinessReason.FromName(requestInput.BusinessReason),
             ValidationErrors: input.ValidationErrors
                 .Select(e => new ValidationErrorDto(
                     Message: e.Message,
@@ -62,6 +71,7 @@ internal class EnqueueRejectMessageActivity_Brs_026_V1(
 
     public record ActivityInput(
         OrchestrationInstanceId InstanceId,
+        RequestCalculatedEnergyTimeSeriesInputV1 RequestInput,
         IReadOnlyCollection<ValidationError> ValidationErrors,
         Guid IdempotencyKey);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration_Brs_026_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration_Brs_026_V1.cs
@@ -152,6 +152,7 @@ internal class Orchestration_Brs_026_V1
                 nameof(EnqueueRejectMessageActivity_Brs_026_V1),
                 new EnqueueRejectMessageActivity_Brs_026_V1.ActivityInput(
                     instanceId,
+                    input,
                     validationResult.ValidationErrors,
                     idempotencyKey),
                 _defaultRetryOptions);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration_Brs_026_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration_Brs_026_V1.cs
@@ -48,7 +48,7 @@ internal class Orchestration_Brs_026_V1
 
         var orchestrationInstanceContext = await InitializeOrchestrationAsync(context);
 
-        var validationResult = await PerformAsynchronousValidationAsync(context, orchestrationInstanceContext.Id, input);
+        var validationResult = await PerformBusinessValidationAsync(context, orchestrationInstanceContext.Id, input);
         await EnqueueActorMessagesInEdiAsync(context, orchestrationInstanceContext.Id, input, validationResult);
 
         var wasMessagesEnqueued = await WaitForEnqueueActorMessagesResponseFromEdiAsync(
@@ -56,7 +56,12 @@ internal class Orchestration_Brs_026_V1
             orchestrationInstanceContext.Options.EnqueueActorMessagesTimeout,
             orchestrationInstanceContext.Id);
 
-        return await TerminateOrchestrationAsync(context, orchestrationInstanceContext.Id, input, wasMessagesEnqueued);
+        return await TerminateOrchestrationAsync(
+            context: context,
+            instanceId: orchestrationInstanceContext.Id,
+            input: input,
+            wasMessagesEnqueued: wasMessagesEnqueued,
+            failedBusinessValidation: !validationResult.IsValid);
     }
 
     private static TaskOptions CreateDefaultRetryOptions()
@@ -86,7 +91,7 @@ internal class Orchestration_Brs_026_V1
         return orchestrationInstanceContext;
     }
 
-    private async Task<PerformBusinessValidationActivity_Brs_026_V1.ActivityOutput> PerformAsynchronousValidationAsync(
+    private async Task<PerformBusinessValidationActivity_Brs_026_V1.ActivityOutput> PerformBusinessValidationAsync(
         TaskOrchestrationContext context,
         OrchestrationInstanceId instanceId,
         RequestCalculatedEnergyTimeSeriesInputV1 input)
@@ -204,9 +209,10 @@ internal class Orchestration_Brs_026_V1
         TaskOrchestrationContext context,
         OrchestrationInstanceId instanceId,
         RequestCalculatedEnergyTimeSeriesInputV1 input,
-        bool wasMessagesEnqueued)
+        bool wasMessagesEnqueued,
+        bool failedBusinessValidation)
     {
-        var orchestrationTerminationState = wasMessagesEnqueued
+        var orchestrationTerminationState = wasMessagesEnqueued && !failedBusinessValidation
             ? OrchestrationInstanceTerminationState.Succeeded
             : OrchestrationInstanceTerminationState.Failed;
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Activities/EnqueueActorMessagesActivity_Brs_028_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Activities/EnqueueActorMessagesActivity_Brs_028_V1.cs
@@ -61,8 +61,8 @@ internal class EnqueueActorMessagesActivity_Brs_028_V1(
             : null;
 
         var acceptedData = new RequestCalculatedWholesaleServicesAcceptedV1(
+            OriginalActorMessageId: requestInput.ActorMessageId,
             OriginalTransactionId: requestInput.TransactionId,
-            OriginalMessageId: requestInput.ActorMessageId,
             RequestedForActorNumber: ActorNumber.Create(requestInput.RequestedForActorNumber),
             RequestedForActorRole: ActorRole.FromName(requestInput.RequestedForActorRole),
             RequestedByActorNumber: ActorNumber.Create(requestInput.RequestedByActorNumber),

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Activities/EnqueueRejectMessageActivity_Brs_028_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Activities/EnqueueRejectMessageActivity_Brs_028_V1.cs
@@ -17,6 +17,7 @@ using Energinet.DataHub.ProcessManager.Components.BusinessValidation;
 using Energinet.DataHub.ProcessManager.Components.EnqueueActorMessages;
 using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Components.Datahub.ValueObjects;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
 using Microsoft.Azure.Functions.Worker;
 using NodaTime;
@@ -46,7 +47,15 @@ internal class EnqueueRejectMessageActivity_Brs_028_V1(
 
     private Task EnqueueRejectMessageAsync(OperatingIdentity orchestrationCreatedBy, ActivityInput input)
     {
+        var requestInput = input.RequestInput;
         var rejectedMessage = new RequestCalculatedWholesaleServicesRejectedV1(
+            OriginalTransactionId: requestInput.TransactionId,
+            OriginalMessageId: requestInput.ActorMessageId,
+            RequestedForActorNumber: ActorNumber.Create(requestInput.RequestedForActorNumber),
+            RequestedForActorRole: ActorRole.FromName(requestInput.RequestedForActorRole),
+            RequestedByActorNumber: ActorNumber.Create(requestInput.RequestedByActorNumber),
+            RequestedByActorRole: ActorRole.FromName(requestInput.RequestedByActorRole),
+            BusinessReason: BusinessReason.FromName(requestInput.BusinessReason),
             ValidationErrors: input.ValidationErrors
                 .Select(e => new ValidationErrorDto(
                     Message: e.Message,
@@ -63,6 +72,7 @@ internal class EnqueueRejectMessageActivity_Brs_028_V1(
 
     public record ActivityInput(
         OrchestrationInstanceId InstanceId,
+        RequestCalculatedWholesaleServicesInputV1 RequestInput,
         IReadOnlyCollection<ValidationError> ValidationErrors,
         Guid IdempotencyKey);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/OrchestrationDescriptionBuilder.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/OrchestrationDescriptionBuilder.cs
@@ -29,7 +29,7 @@ internal class OrchestrationDescriptionBuilder : IOrchestrationDescriptionBuilde
 
         description.ParameterDefinition.SetFromType<RequestCalculatedWholesaleServicesInputV1>();
 
-        description.AppendStepDescription("Asynkron validering");
+        description.AppendStepDescription("Forretningsvalidering");
         description.AppendStepDescription("Udsend beskeder");
 
         return description;

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration_Brs_028_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration_Brs_028_V1.cs
@@ -49,7 +49,7 @@ internal class Orchestration_Brs_028_V1
 
         var (instanceId, options) = await InitializeOrchestrationAsync(context);
 
-        var validationResult = await PerformAsynchronousValidationAsync(context, instanceId, input);
+        var validationResult = await PerformBusinessValidationAsync(context, instanceId, input);
         await EnqueueActorMessagesInEdiAsync(context, instanceId, input, validationResult);
 
         var wasMessagesEnqueued = await WaitForEnqueueActorMessagesResponseFromEdiAsync(
@@ -57,7 +57,12 @@ internal class Orchestration_Brs_028_V1
             options.EnqueueActorMessagesTimeout,
             instanceId);
 
-        return await TerminateOrchestrationAsync(context, instanceId, input, wasMessagesEnqueued);
+        return await TerminateOrchestrationAsync(
+            context: context,
+            instanceId: instanceId,
+            input: input,
+            wasMessagesEnqueued: wasMessagesEnqueued,
+            failedBusinessValidation: !validationResult.IsValid);
     }
 
     private static TaskOptions CreateDefaultRetryOptions()
@@ -87,7 +92,7 @@ internal class Orchestration_Brs_028_V1
         return orchestrationInstanceContext;
     }
 
-    private async Task<PerformBusinessValidationActivity_Brs_028_V1.ActivityOutput> PerformAsynchronousValidationAsync(
+    private async Task<PerformBusinessValidationActivity_Brs_028_V1.ActivityOutput> PerformBusinessValidationAsync(
         TaskOrchestrationContext context,
         OrchestrationInstanceId instanceId,
         RequestCalculatedWholesaleServicesInputV1 input)
@@ -205,9 +210,10 @@ internal class Orchestration_Brs_028_V1
         TaskOrchestrationContext context,
         OrchestrationInstanceId instanceId,
         RequestCalculatedWholesaleServicesInputV1 input,
-        bool wasMessagesEnqueued)
+        bool wasMessagesEnqueued,
+        bool failedBusinessValidation)
     {
-        var orchestrationTerminationState = wasMessagesEnqueued
+        var orchestrationTerminationState = wasMessagesEnqueued && !failedBusinessValidation
             ? OrchestrationInstanceTerminationState.Succeeded
             : OrchestrationInstanceTerminationState.Failed;
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration_Brs_028_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration_Brs_028_V1.cs
@@ -153,6 +153,7 @@ internal class Orchestration_Brs_028_V1
                 nameof(EnqueueRejectMessageActivity_Brs_028_V1),
                 new EnqueueRejectMessageActivity_Brs_028_V1.ActivityInput(
                     instanceId,
+                    input,
                     validationResult.ValidationErrors,
                     idempotencyKey),
                 _defaultRetryOptions);

--- a/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
+++ b/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
@@ -62,7 +62,7 @@ public static class ProcessManagerClientExtensions
     }
 
     /// <summary>
-    /// Wait for an orchestration instance to be terminated with the given <see cref="terminationState"/>.
+    /// Wait for an orchestration instance to be terminated with the given <paramref name="terminationState"/>.
     /// <remarks>Returns false if not resolved in <see cref="TimeLimitInSeconds"/> seconds.</remarks>
     /// </summary>
     /// <param name="client"></param>

--- a/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
+++ b/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
@@ -21,6 +21,15 @@ namespace Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 
 public static class ProcessManagerClientExtensions
 {
+    private const int TimeLimitInSeconds = 60;
+
+    /// <summary>
+    /// Wait for an orchestration instance, resolving true/false by using the given <paramref name="comparer"/> function.
+    /// <remarks>Returns false if an orchestration instance isn't found in <see cref="TimeLimitInSeconds"/> seconds.</remarks>
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="idempotencyKey">The idempotency key of the orchestration instance, used to find the correct orchestration instance.</param>
+    /// <param name="comparer">The comparer method used to determine whether the orchestration instance is in a correct state.</param>
     public static async Task<(bool Succes, OrchestrationInstanceTypedDto<TInput>? OrchestrationInstance)>
         TryWaitForOrchestrationInstance<TInput>(
             this IProcessManagerClient client,
@@ -46,12 +55,19 @@ public static class ProcessManagerClientExtensions
 
                 return comparer(orchestrationInstance);
             },
-            timeLimit: TimeSpan.FromSeconds(60),
+            timeLimit: TimeSpan.FromSeconds(TimeLimitInSeconds),
             delay: TimeSpan.FromSeconds(1));
 
         return (success, orchestrationInstance);
     }
 
+    /// <summary>
+    /// Wait for an orchestration instance to be terminated with the given <see cref="terminationState"/>.
+    /// <remarks>Returns false if not resolved in <see cref="TimeLimitInSeconds"/> seconds.</remarks>
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="idempotencyKey">The idempotency key of the orchestration instance, used to find the correct orchestration instance.</param>
+    /// <param name="terminationState">The termination state the orchestration instance should be in.</param>
     public static Task<(bool Succes, OrchestrationInstanceTypedDto<TInput>? OrchestrationInstance)> WaitForOrchestrationInstanceTerminated<TInput>(
         this IProcessManagerClient client,
         string idempotencyKey,
@@ -65,6 +81,13 @@ public static class ProcessManagerClientExtensions
                 && orchestrationInstance.Lifecycle.TerminationState == terminationState);
     }
 
+    /// <summary>
+    /// Wait for an orchestration instance step to be in the <see cref="StepInstanceLifecycleState.Running"/> state.
+    /// <remarks>Returns false if not resolved in <see cref="TimeLimitInSeconds"/> seconds.</remarks>
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="idempotencyKey">The idempotency key of the orchestration instance, used to find the correct orchestration instance.</param>
+    /// <param name="stepSequence">The sequence number of the step that should be in the <see cref="StepInstanceLifecycleState.Running"/> state.</param>
     public static Task<(bool Succes, OrchestrationInstanceTypedDto<TInput>? OrchestrationInstance)> WaitForStepToBeRunning<TInput>(
         this IProcessManagerClient client,
         string idempotencyKey,

--- a/source/Shared/Tests/Fixtures/OrchestrationsAppManager.cs
+++ b/source/Shared/Tests/Fixtures/OrchestrationsAppManager.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.Core.FunctionApp.TestCommon.FunctionAppHost;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvider;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Options;
 using Energinet.DataHub.Core.TestCommon.Diagnostics;
+using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
 using Energinet.DataHub.ProcessManager.Components.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Core.Infrastructure.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData;
@@ -485,11 +486,11 @@ public class OrchestrationsAppManager : IAsyncDisposable
         {
             builder
                 .AddSubscription(EnqueueBrs023027SubscriptionName)
-                    .AddSubjectFilter($"Enqueue_{Brs_023_027.Name.ToLower()}")
+                    .AddSubjectFilter(EnqueueActorMessagesV1.BuildServiceBusMessageSubject(Brs_023_027.V1))
                 .AddSubscription(EnqueueBrs026SubscriptionName)
-                    .AddSubjectFilter($"Enqueue_{Brs_026.Name.ToLower()}")
+                    .AddSubjectFilter(EnqueueActorMessagesV1.BuildServiceBusMessageSubject(Brs_026.V1))
                 .AddSubscription(EnqueueBrs028SubscriptionName)
-                    .AddSubjectFilter($"Enqueue_{Brs_028.Name.ToLower()}");
+                    .AddSubjectFilter(EnqueueActorMessagesV1.BuildServiceBusMessageSubject(Brs_028.V1));
 
             return builder;
         }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Copilot summary
This pull request includes updates to the `ProcessManager.Orchestrations.Abstractions` package, focusing on adding missing properties to certain request models, updating the package version, and enhancing test scenarios for orchestration processes. The most important changes are summarized below:

### Model Updates:
* Added missing properties to `RequestCalculatedEnergyTimeSeriesRejectedV1` and `RequestCalculatedWholesaleServicesRejectedV1` models. [[1]](diffhunk://#diff-4cf4c34e84b6a312de9ecfec1739c8257021145e1d8f942c0d23e2ee50b329f3R16-R30) [[2]](diffhunk://#diff-d53ee1c35234459075038ffc6064e6784c6ddef73b9ba5b8c7beb52ef84aa1dcR16-R30)

### Version Update:
* Updated the package version to `0.18.2` in the `ProcessManager.Orchestrations.Abstractions.csproj` file.

### Test Enhancements:
* Added a new extension method `TryParseAsEnqueueActorMessages` to `ServiceBusReceivedMessageExtensions` for better message parsing in tests.
* Enhanced `MonitorOrchestrationUsingClientsScenario` to include new test cases for valid and invalid request scenarios, ensuring comprehensive validation and error handling. [[1]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005R15) [[2]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005R28-R31) [[3]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005L91-R127) [[4]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005L179-L202) [[5]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005R166-R281)
* Included necessary `using` statements for `Azure.Messaging.ServiceBus` and other dependencies in relevant test files. [[1]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005R15) [[2]](diffhunk://#diff-802c1bbeb26b186e07acff027f896bbb32c5dc95eee3d42c907b15296cfb187cR15) [[3]](diffhunk://#diff-802c1bbeb26b186e07acff027f896bbb32c5dc95eee3d42c907b15296cfb187cR28-R31)

### Documentation Update:
* Added release notes for version `0.18.2`, detailing the updates to the request models.

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/374

## Checklist

- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task
