### PR TITLE
refac: Update script so it only add column if it was not added already

### DIFF
--- a/source/ProcessManager.DatabaseMigration/DbUpgrader.cs
+++ b/source/ProcessManager.DatabaseMigration/DbUpgrader.cs
@@ -36,6 +36,7 @@ public static class DbUpgrader
                 .SqlDatabase(connectionString)
                 .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
                 .LogToConsole()
+                .WithExecutionTimeout(TimeSpan.FromHours(1))
                 .JournalToSqlTable(schemaName, "SchemaVersions")
                 .Build();
 

--- a/source/ProcessManager.DatabaseMigration/Scripts/202501311000 Add RowVersion.sql
+++ b/source/ProcessManager.DatabaseMigration/Scripts/202501311000 Add RowVersion.sql
@@ -1,11 +1,21 @@
-﻿ALTER TABLE [pm].[OrchestrationDescription]
-    -- ROWVERSION makes Entity Framework throw an exception if trying to update a row which has already been updated (concurrency conflict)
-    -- https://learn.microsoft.com/en-us/ef/core/saving/concurrency?tabs=fluent-api
-    ADD [RowVersion] ROWVERSION NOT NULL
+﻿-- Check and add RowVersion column to OrchestrationDescription table
+IF NOT EXISTS (SELECT * FROM sys.columns
+               WHERE Name = N'RowVersion' AND Object_ID = Object_ID(N'[pm].[OrchestrationDescription]'))
+BEGIN
+    ALTER TABLE [pm].[OrchestrationDescription]
+        -- ROWVERSION makes Entity Framework throw an exception if trying to update a row which has already been updated (concurrency conflict)
+        -- https://learn.microsoft.com/en-us/ef/core/saving/concurrency?tabs=fluent-api
+        ADD [RowVersion] ROWVERSION NOT NULL
+END
 GO
 
-ALTER TABLE [pm].[OrchestrationInstance]
-    -- ROWVERSION makes Entity Framework throw an exception if trying to update a row which has already been updated (concurrency conflict)
-    -- https://learn.microsoft.com/en-us/ef/core/saving/concurrency?tabs=fluent-api
-    ADD [RowVersion] ROWVERSION NOT NULL
+-- Check and add RowVersion column to OrchestrationInstance table
+IF NOT EXISTS (SELECT * FROM sys.columns
+               WHERE Name = N'RowVersion' AND Object_ID = Object_ID(N'[pm].[OrchestrationInstance]'))
+BEGIN
+    ALTER TABLE [pm].[OrchestrationInstance]
+        -- ROWVERSION makes Entity Framework throw an exception if trying to update a row which has already been updated (concurrency conflict)
+        -- https://learn.microsoft.com/en-us/ef/core/saving/concurrency?tabs=fluent-api
+        ADD [RowVersion] ROWVERSION NOT NULL
+END
 GO


### PR DESCRIPTION
## Description

Make script idempotent.

This change is necessary because the script alters two different tables, and when DbUp runs the script it is possible that the first table was altered, but the second was not. In this case DbUp has not updated its journal over executed scripts and doesn't know that it has executed part of the script with success. So the script must be idempotent and be able to be executed again without failing.

Deployed to `dev_002`: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13109549441

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/499

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
