### PR TITLE
feat: Update BRS-026 and 028 to handle errors by using step executor

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -135,14 +135,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                 EventName: RequestCalculatedEnergyTimeSeriesNotifyEventsV1.EnqueueActorMessagesCompleted),
             CancellationToken.None);
 
-        // Step 4: Query until terminated with succeeded
-        var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await processManagerClient
+        // Step 4: Query until terminated
+        var (orchestrationTerminated, terminatedOrchestrationInstance) = await processManagerClient
             .WaitForOrchestrationInstanceTerminated<RequestCalculatedEnergyTimeSeriesInputV1>(
-                requestCommand.IdempotencyKey,
-                terminationState: OrchestrationInstanceTerminationState.Succeeded);
+                requestCommand.IdempotencyKey);
 
-        orchestrationTerminatedWithSucceeded.Should().BeTrue(
-            "because the orchestration instance should be succeeded within the given wait time");
+        orchestrationTerminated.Should().BeTrue(
+            "because the orchestration instance should be terminated within the given wait time");
 
         // Orchestration instance and all steps should be Succeeded
         using var assertionScope = new AssertionScope();
@@ -214,14 +213,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                 EventName: RequestCalculatedEnergyTimeSeriesNotifyEventsV1.EnqueueActorMessagesCompleted),
             CancellationToken.None);
 
-        // Step 4: Query until terminated with failed
+        // Step 4: Query until terminated
         var (orchestrationWasTerminated, terminatedOrchestrationInstance) = await processManagerClient
             .WaitForOrchestrationInstanceTerminated<RequestCalculatedEnergyTimeSeriesInputV1>(
-                idempotencyKey: invalidRequestCommand.IdempotencyKey,
-                terminationState: OrchestrationInstanceTerminationState.Failed);
+                idempotencyKey: invalidRequestCommand.IdempotencyKey);
 
         orchestrationWasTerminated.Should().BeTrue(
-            "because the orchestration instance should be failed within the given wait time");
+            "because the orchestration instance should be terminated within the given wait time");
 
         // Orchestration instance and validation steps should be Failed
         using var assertionScope = new AssertionScope();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Steps;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
@@ -106,7 +107,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
             .WaitForStepToBeRunning<RequestCalculatedEnergyTimeSeriesInputV1>(
                 requestCommand.IdempotencyKey,
-                Orchestration_Brs_026_V1.EnqueueActorMessagesStepSequence);
+                EnqueueActorMessagesStep.StepSequence);
 
         isWaitingForNotify.Should()
             .BeTrue("because the orchestration instance should wait for a EnqueueActorMessagesCompleted notify event");
@@ -180,7 +181,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
             .WaitForStepToBeRunning<RequestCalculatedEnergyTimeSeriesInputV1>(
                 idempotencyKey: invalidRequestCommand.IdempotencyKey,
-                stepSequence: Orchestration_Brs_026_V1.EnqueueActorMessagesStepSequence);
+                stepSequence: EnqueueActorMessagesStep.StepSequence);
 
         isWaitingForNotify.Should()
             .BeTrue("because the orchestration instance should wait for a EnqueueActorMessagesCompleted notify event");
@@ -214,12 +215,12 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             CancellationToken.None);
 
         // Step 4: Query until terminated with failed
-        var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await processManagerClient
+        var (orchestrationWasTerminated, terminatedOrchestrationInstance) = await processManagerClient
             .WaitForOrchestrationInstanceTerminated<RequestCalculatedEnergyTimeSeriesInputV1>(
                 idempotencyKey: invalidRequestCommand.IdempotencyKey,
                 terminationState: OrchestrationInstanceTerminationState.Failed);
 
-        orchestrationTerminatedWithSucceeded.Should().BeTrue(
+        orchestrationWasTerminated.Should().BeTrue(
             "because the orchestration instance should be failed within the given wait time");
 
         // Orchestration instance and validation steps should be Failed

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -134,13 +134,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                 EventName: RequestCalculatedWholesaleServicesNotifyEventsV1.EnqueueActorMessagesCompleted),
             CancellationToken.None);
 
-        // Step 4: Query until terminated with succeeded
+        // Step 4: Query until terminated
         var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await processManagerClient
             .WaitForOrchestrationInstanceTerminated<RequestCalculatedWholesaleServicesInputV1>(
-                idempotencyKey: requestCommand.IdempotencyKey,
-                terminationState: OrchestrationInstanceTerminationState.Succeeded);
+                idempotencyKey: requestCommand.IdempotencyKey);
 
-        orchestrationTerminatedWithSucceeded.Should().BeTrue("because the orchestration instance should complete within given wait time");
+        orchestrationTerminatedWithSucceeded.Should().BeTrue(
+            "because the orchestration instance should be terminated within given wait time");
 
         // Orchestration instance and all steps should be Succeeded
         using var assertionScope = new AssertionScope();
@@ -212,14 +212,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                 EventName: RequestCalculatedWholesaleServicesNotifyEventsV1.EnqueueActorMessagesCompleted),
             CancellationToken.None);
 
-        // Step 4: Query until terminated with failed
+        // Step 4: Query until terminated
         var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await processManagerClient
             .WaitForOrchestrationInstanceTerminated<RequestCalculatedWholesaleServicesInputV1>(
-                idempotencyKey: invalidRequestCommand.IdempotencyKey,
-                terminationState: OrchestrationInstanceTerminationState.Failed);
+                idempotencyKey: invalidRequestCommand.IdempotencyKey);
 
         orchestrationTerminatedWithSucceeded.Should().BeTrue(
-            "because the orchestration instance should be failed within the given wait time");
+            "because the orchestration instance should be terminated within the given wait time");
 
         // Orchestration instance and validation steps should be Failed
         using var assertionScope = new AssertionScope();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Steps;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
@@ -106,7 +107,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
             .WaitForStepToBeRunning<RequestCalculatedWholesaleServicesInputV1>(
                 idempotencyKey: requestCommand.IdempotencyKey,
-                stepSequence: Orchestration_Brs_028_V1.EnqueueActorMessagesStepSequence);
+                stepSequence: EnqueueActorMessagesStep.StepSequence);
 
         isWaitingForNotify.Should()
             .BeTrue("because the orchestration instance should wait for a EnqueueActorMessagesCompleted notify event");
@@ -178,7 +179,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
             .WaitForStepToBeRunning<RequestCalculatedWholesaleServicesInputV1>(
                 idempotencyKey: invalidRequestCommand.IdempotencyKey,
-                stepSequence: Orchestration_Brs_028_V1.EnqueueActorMessagesStepSequence);
+                stepSequence: EnqueueActorMessagesStep.StepSequence);
 
         isWaitingForNotify.Should()
             .BeTrue("because the orchestration instance should wait for a EnqueueActorMessagesCompleted notify event");

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/OrchestrationDescriptionBuilder.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/OrchestrationDescriptionBuilder.cs
@@ -15,6 +15,7 @@
 using Energinet.DataHub.ProcessManager.Core.Application.Registration;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationDescription;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Steps;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1;
 
@@ -29,8 +30,8 @@ internal class OrchestrationDescriptionBuilder : IOrchestrationDescriptionBuilde
 
         description.ParameterDefinition.SetFromType<RequestCalculatedEnergyTimeSeriesInputV1>();
 
-        description.AppendStepDescription("Forretningsvalidering");
-        description.AppendStepDescription("Udsend beskeder");
+        description.AppendStepDescription(BusinessValidationStep.StepDescription);
+        description.AppendStepDescription(EnqueueActorMessagesStep.StepDescription);
 
         return description;
     }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration_Brs_026_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration_Brs_026_V1.cs
@@ -15,28 +15,28 @@
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationDescription;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026;
-using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Activities;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Models;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Steps;
 using Energinet.DataHub.ProcessManager.Shared.Processes.Activities;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.DurableTask;
-using Microsoft.Extensions.Logging;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1;
 
 internal class Orchestration_Brs_026_V1
 {
-    public const int BusinessValidationStepSequence = 1;
-    public const int EnqueueActorMessagesStepSequence = 2;
-
     public static readonly OrchestrationDescriptionUniqueNameDto UniqueName = Brs_026.V1;
 
-    private readonly TaskOptions _defaultRetryOptions;
+    private readonly TaskRetryOptions _defaultRetryOptions;
 
     public Orchestration_Brs_026_V1()
     {
-        _defaultRetryOptions = CreateDefaultRetryOptions();
+        _defaultRetryOptions = TaskRetryOptions.FromRetryPolicy(
+            new RetryPolicy(
+                maxNumberOfAttempts: 5,
+                firstRetryInterval: TimeSpan.FromSeconds(30),
+                backoffCoefficient: 2.0));
     }
 
     [Function(nameof(Orchestration_Brs_026_V1))]
@@ -45,27 +45,24 @@ internal class Orchestration_Brs_026_V1
     {
         var orchestrationInstanceContext = await InitializeOrchestrationAsync(context);
 
-        var validationResult = await PerformBusinessValidationAsync(context, orchestrationInstanceContext.Id);
-        await EnqueueActorMessagesInEdiAsync(context, orchestrationInstanceContext.Id, validationResult);
+        var validationResult = await new BusinessValidationStep(
+                context,
+                _defaultRetryOptions,
+                orchestrationInstanceContext.Id)
+            .ExecuteAsync();
 
-        var wasMessagesEnqueued = await WaitForEnqueueActorMessagesResponseFromEdiAsync(
-            context,
-            orchestrationInstanceContext.Options.EnqueueActorMessagesTimeout,
-            orchestrationInstanceContext.Id);
+        await new EnqueueActorMessagesStep(
+                context,
+                _defaultRetryOptions,
+                orchestrationInstanceContext.Id,
+                validationResult,
+                orchestrationInstanceContext.Options.EnqueueActorMessagesTimeout)
+            .ExecuteAsync();
 
         return await TerminateOrchestrationAsync(
             context: context,
             instanceId: orchestrationInstanceContext.Id,
-            wasMessagesEnqueued: wasMessagesEnqueued,
-            failedBusinessValidation: !validationResult.IsValid);
-    }
-
-    private static TaskOptions CreateDefaultRetryOptions()
-    {
-        return TaskOptions.FromRetryPolicy(new RetryPolicy(
-            maxNumberOfAttempts: 5,
-            firstRetryInterval: TimeSpan.FromSeconds(30),
-            backoffCoefficient: 2.0));
+            businessValidationSuccess: validationResult.IsValid);
     }
 
     private async Task<OrchestrationInstanceContext> InitializeOrchestrationAsync(TaskOrchestrationContext context)
@@ -76,133 +73,23 @@ internal class Orchestration_Brs_026_V1
             nameof(TransitionOrchestrationToRunningActivity_V1),
             new TransitionOrchestrationToRunningActivity_V1.ActivityInput(
                 instanceId),
-            _defaultRetryOptions);
+            new TaskOptions(_defaultRetryOptions));
 
         var orchestrationInstanceContext = await context.CallActivityAsync<OrchestrationInstanceContext>(
             nameof(GetOrchestrationInstanceContextActivity_Brs_026_V1),
             new GetOrchestrationInstanceContextActivity_Brs_026_V1.ActivityInput(
                 instanceId),
-            _defaultRetryOptions);
+            new TaskOptions(_defaultRetryOptions));
 
         return orchestrationInstanceContext;
-    }
-
-    private async Task<PerformBusinessValidationActivity_Brs_026_V1.ActivityOutput> PerformBusinessValidationAsync(
-        TaskOrchestrationContext context,
-        OrchestrationInstanceId instanceId)
-    {
-        await context.CallActivityAsync(
-            nameof(TransitionStepToRunningActivity_V1),
-            new TransitionStepToRunningActivity_V1.ActivityInput(
-                instanceId,
-                BusinessValidationStepSequence),
-            _defaultRetryOptions);
-
-        var validationResult = await context.CallActivityAsync<PerformBusinessValidationActivity_Brs_026_V1.ActivityOutput>(
-            nameof(PerformBusinessValidationActivity_Brs_026_V1),
-            new PerformBusinessValidationActivity_Brs_026_V1.ActivityInput(
-                instanceId,
-                BusinessValidationStepSequence),
-            _defaultRetryOptions);
-
-        var asyncValidationTerminationState = validationResult.IsValid
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
-        await context.CallActivityAsync(
-            nameof(TransitionStepToTerminatedActivity_V1),
-            new TransitionStepToTerminatedActivity_V1.ActivityInput(
-                instanceId,
-                BusinessValidationStepSequence,
-                asyncValidationTerminationState),
-            _defaultRetryOptions);
-
-        return validationResult;
-    }
-
-    private async Task EnqueueActorMessagesInEdiAsync(
-        TaskOrchestrationContext context,
-        OrchestrationInstanceId instanceId,
-        PerformBusinessValidationActivity_Brs_026_V1.ActivityOutput validationResult)
-    {
-        await context.CallActivityAsync(
-            nameof(TransitionStepToRunningActivity_V1),
-            new TransitionStepToRunningActivity_V1.ActivityInput(
-                instanceId,
-                EnqueueActorMessagesStepSequence),
-            _defaultRetryOptions);
-
-        var idempotencyKey = context.NewGuid();
-        if (validationResult.IsValid)
-        {
-            await context.CallActivityAsync(
-                nameof(EnqueueActorMessagesActivity_Brs_026_V1),
-                new EnqueueActorMessagesActivity_Brs_026_V1.ActivityInput(
-                    instanceId,
-                    idempotencyKey),
-                _defaultRetryOptions);
-        }
-        else
-        {
-            ArgumentNullException.ThrowIfNull(validationResult.ValidationErrors);
-
-            await context.CallActivityAsync(
-                nameof(EnqueueRejectMessageActivity_Brs_026_V1),
-                new EnqueueRejectMessageActivity_Brs_026_V1.ActivityInput(
-                    instanceId,
-                    validationResult.ValidationErrors,
-                    idempotencyKey),
-                _defaultRetryOptions);
-        }
-    }
-
-    /// <summary>
-    /// Pattern #5: Human interaction - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview?tabs=isolated-process#human
-    /// </summary>
-    private async Task<bool> WaitForEnqueueActorMessagesResponseFromEdiAsync(
-        TaskOrchestrationContext context,
-        TimeSpan actorMessagesEnqueuedTimeout,
-        OrchestrationInstanceId instanceId)
-    {
-        bool wasMessagesEnqueued;
-        try
-        {
-            await context.WaitForExternalEvent<int?>(
-                eventName: RequestCalculatedEnergyTimeSeriesNotifyEventsV1.EnqueueActorMessagesCompleted,
-                timeout: actorMessagesEnqueuedTimeout);
-            wasMessagesEnqueued = true;
-        }
-        catch (TaskCanceledException)
-        {
-            var logger = context.CreateReplaySafeLogger<Orchestration_Brs_026_V1>();
-            logger.Log(
-                LogLevel.Error,
-                "Timeout while waiting for enqueue actor messages to complete (InstanceId={OrchestrationInstanceId}, Timeout={Timeout}).",
-                instanceId.Value,
-                actorMessagesEnqueuedTimeout.ToString("g"));
-            wasMessagesEnqueued = false;
-        }
-
-        var enqueueActorMessagesTerminationState = wasMessagesEnqueued
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
-        await context.CallActivityAsync(
-            nameof(TransitionStepToTerminatedActivity_V1),
-            new TransitionStepToTerminatedActivity_V1.ActivityInput(
-                instanceId,
-                EnqueueActorMessagesStepSequence,
-                enqueueActorMessagesTerminationState),
-            _defaultRetryOptions);
-
-        return wasMessagesEnqueued;
     }
 
     private async Task<string> TerminateOrchestrationAsync(
         TaskOrchestrationContext context,
         OrchestrationInstanceId instanceId,
-        bool wasMessagesEnqueued,
-        bool failedBusinessValidation)
+        bool businessValidationSuccess)
     {
-        var orchestrationTerminationState = wasMessagesEnqueued && !failedBusinessValidation
+        var orchestrationTerminationState = businessValidationSuccess
             ? OrchestrationInstanceTerminationState.Succeeded
             : OrchestrationInstanceTerminationState.Failed;
 
@@ -211,10 +98,8 @@ internal class Orchestration_Brs_026_V1
             new TransitionOrchestrationToTerminatedActivity_V1.ActivityInput(
                 instanceId,
                 orchestrationTerminationState),
-            _defaultRetryOptions);
+            new TaskOptions(_defaultRetryOptions));
 
-        return wasMessagesEnqueued
-            ? $"Success"
-            : "Error: Timeout while waiting for enqueue actor messages";
+        return "Success";
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Steps/BusinessValidationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Steps/BusinessValidationStep.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Activities;
+using Energinet.DataHub.ProcessManager.Shared.Processes.Activities;
+using Microsoft.DurableTask;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Steps;
+
+[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait must not be used in durable function code")]
+internal class BusinessValidationStep(
+    TaskOrchestrationContext context,
+    TaskRetryOptions defaultRetryOptions,
+    OrchestrationInstanceId instanceId)
+        : StepExecutor<PerformBusinessValidationActivity_Brs_026_V1.ActivityOutput>(
+            context,
+            defaultRetryOptions,
+            instanceId)
+{
+    internal const string StepDescription = "Forretningsvalidering";
+    internal const int StepSequence = 1;
+
+    protected override int StepSequenceNumber => StepSequence;
+
+    protected override async Task<StepOutput> OnExecuteAsync()
+    {
+        var validationResult = await Context.CallActivityAsync<PerformBusinessValidationActivity_Brs_026_V1.ActivityOutput>(
+            nameof(PerformBusinessValidationActivity_Brs_026_V1),
+            new PerformBusinessValidationActivity_Brs_026_V1.ActivityInput(
+                InstanceId,
+                StepSequence),
+            DefaultRetryOptions);
+
+        var asyncValidationTerminationState = validationResult.IsValid
+            ? OrchestrationStepTerminationState.Succeeded
+            : OrchestrationStepTerminationState.Failed;
+
+        return new StepOutput(asyncValidationTerminationState, validationResult);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Steps/EnqueueActorMessagesStep.cs
@@ -1,0 +1,74 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Activities;
+using Energinet.DataHub.ProcessManager.Shared.Processes.Activities;
+using Microsoft.DurableTask;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Steps;
+
+[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait must not be used in durable function code")]
+internal class EnqueueActorMessagesStep(
+    TaskOrchestrationContext context,
+    TaskRetryOptions defaultRetryOptions,
+    OrchestrationInstanceId instanceId,
+    PerformBusinessValidationActivity_Brs_026_V1.ActivityOutput validationResult,
+    TimeSpan actorMessagesEnqueuedTimeout)
+        : StepExecutor(context, defaultRetryOptions, instanceId)
+{
+    internal const string StepDescription = "Udsend beskeder";
+    internal const int StepSequence = 2;
+
+    private readonly TimeSpan _actorMessagesEnqueuedTimeout = actorMessagesEnqueuedTimeout;
+
+    protected override int StepSequenceNumber => StepSequence;
+
+    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    {
+        var idempotencyKey = Context.NewGuid();
+        if (validationResult.IsValid)
+        {
+            await Context.CallActivityAsync(
+                nameof(EnqueueActorMessagesActivity_Brs_026_V1),
+                new EnqueueActorMessagesActivity_Brs_026_V1.ActivityInput(
+                    InstanceId,
+                    idempotencyKey),
+                DefaultRetryOptions);
+        }
+        else
+        {
+            ArgumentNullException.ThrowIfNull(validationResult.ValidationErrors);
+
+            await Context.CallActivityAsync(
+                nameof(EnqueueRejectMessageActivity_Brs_026_V1),
+                new EnqueueRejectMessageActivity_Brs_026_V1.ActivityInput(
+                    InstanceId,
+                    validationResult.ValidationErrors,
+                    idempotencyKey),
+                DefaultRetryOptions);
+        }
+
+        // Pattern #5: Human interaction - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview?tabs=isolated-process#human
+        // If the timeout is reached, an exception will be thrown, and StepExecutor will fail the step and orchestration instance.
+        // If we later need a more complex handling of the timeout, we can try/catch the TaskCanceledException here and handle it manually.
+        var t = await Context.WaitForExternalEvent<int?>(
+            eventName: RequestCalculatedEnergyTimeSeriesNotifyEventsV1.EnqueueActorMessagesCompleted,
+            timeout: _actorMessagesEnqueuedTimeout);
+
+        return OrchestrationStepTerminationState.Succeeded;
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/OrchestrationDescriptionBuilder.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/OrchestrationDescriptionBuilder.cs
@@ -15,6 +15,7 @@
 using Energinet.DataHub.ProcessManager.Core.Application.Registration;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationDescription;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Steps;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1;
 
@@ -29,8 +30,8 @@ internal class OrchestrationDescriptionBuilder : IOrchestrationDescriptionBuilde
 
         description.ParameterDefinition.SetFromType<RequestCalculatedWholesaleServicesInputV1>();
 
-        description.AppendStepDescription("Forretningsvalidering");
-        description.AppendStepDescription("Udsend beskeder");
+        description.AppendStepDescription(BusinessValidationStep.StepDescription);
+        description.AppendStepDescription(EnqueueActorMessagesStep.StepDescription);
 
         return description;
     }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration_Brs_028_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration_Brs_028_V1.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Activities;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Models;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Steps;
 using Energinet.DataHub.ProcessManager.Shared.Processes.Activities;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.DurableTask;
@@ -28,45 +29,43 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.
 // TODO: Implement according to guidelines: https://energinet.atlassian.net/wiki/spaces/D3/pages/824803345/Durable+Functions+Development+Guidelines
 internal class Orchestration_Brs_028_V1
 {
-    public const int BusinessValidationStepSequence = 1;
-    public const int EnqueueActorMessagesStepSequence = 2;
-
     public static readonly OrchestrationDescriptionUniqueNameDto UniqueName = Brs_028.V1;
 
-    private readonly TaskOptions _defaultRetryOptions;
+    private readonly TaskRetryOptions _defaultRetryOptions;
 
     public Orchestration_Brs_028_V1()
     {
-        _defaultRetryOptions = CreateDefaultRetryOptions();
+        _defaultRetryOptions = TaskRetryOptions.FromRetryPolicy(
+            new RetryPolicy(
+                maxNumberOfAttempts: 5,
+                firstRetryInterval: TimeSpan.FromSeconds(30),
+                backoffCoefficient: 2.0));
     }
 
     [Function(nameof(Orchestration_Brs_028_V1))]
     public async Task<string> Run(
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
-        var (instanceId, options) = await InitializeOrchestrationAsync(context);
+        var orchestrationInstanceContext = await InitializeOrchestrationAsync(context);
 
-        var validationResult = await PerformBusinessValidationAsync(context, instanceId);
-        await EnqueueActorMessagesInEdiAsync(context, instanceId, validationResult);
+        var validationResult = await new BusinessValidationStep(
+                context,
+                _defaultRetryOptions,
+                orchestrationInstanceContext.Id)
+            .ExecuteAsync();
 
-        var wasMessagesEnqueued = await WaitForEnqueueActorMessagesResponseFromEdiAsync(
-            context,
-            options.EnqueueActorMessagesTimeout,
-            instanceId);
+        await new EnqueueActorMessagesStep(
+                context,
+                _defaultRetryOptions,
+                orchestrationInstanceContext.Id,
+                validationResult,
+                orchestrationInstanceContext.Options.EnqueueActorMessagesTimeout)
+            .ExecuteAsync();
 
         return await TerminateOrchestrationAsync(
             context: context,
-            instanceId: instanceId,
-            wasMessagesEnqueued: wasMessagesEnqueued,
-            failedBusinessValidation: !validationResult.IsValid);
-    }
-
-    private static TaskOptions CreateDefaultRetryOptions()
-    {
-        return TaskOptions.FromRetryPolicy(new RetryPolicy(
-            maxNumberOfAttempts: 5,
-            firstRetryInterval: TimeSpan.FromSeconds(30),
-            backoffCoefficient: 2.0));
+            instanceId: orchestrationInstanceContext.Id,
+            businessValidationSuccess: validationResult.IsValid);
     }
 
     private async Task<OrchestrationInstanceContext> InitializeOrchestrationAsync(TaskOrchestrationContext context)
@@ -77,133 +76,23 @@ internal class Orchestration_Brs_028_V1
             nameof(TransitionOrchestrationToRunningActivity_V1),
             new TransitionOrchestrationToRunningActivity_V1.ActivityInput(
                 instanceId),
-            _defaultRetryOptions);
+            new TaskOptions(_defaultRetryOptions));
 
         var orchestrationInstanceContext = await context.CallActivityAsync<OrchestrationInstanceContext>(
             nameof(GetOrchestrationInstanceContextActivity_Brs_028_V1),
             new GetOrchestrationInstanceContextActivity_Brs_028_V1.ActivityInput(
                 instanceId),
-            _defaultRetryOptions);
+            new TaskOptions(_defaultRetryOptions));
 
         return orchestrationInstanceContext;
-    }
-
-    private async Task<PerformBusinessValidationActivity_Brs_028_V1.ActivityOutput> PerformBusinessValidationAsync(
-        TaskOrchestrationContext context,
-        OrchestrationInstanceId instanceId)
-    {
-        await context.CallActivityAsync(
-            nameof(TransitionStepToRunningActivity_V1),
-            new TransitionStepToRunningActivity_V1.ActivityInput(
-                instanceId,
-                BusinessValidationStepSequence),
-            _defaultRetryOptions);
-
-        var validationResult = await context.CallActivityAsync<PerformBusinessValidationActivity_Brs_028_V1.ActivityOutput>(
-            nameof(PerformBusinessValidationActivity_Brs_028_V1),
-            new PerformBusinessValidationActivity_Brs_028_V1.ActivityInput(
-                instanceId,
-                BusinessValidationStepSequence),
-            _defaultRetryOptions);
-
-        var asyncValidationTerminationState = validationResult.IsValid
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
-        await context.CallActivityAsync(
-            nameof(TransitionStepToTerminatedActivity_V1),
-            new TransitionStepToTerminatedActivity_V1.ActivityInput(
-                instanceId,
-                BusinessValidationStepSequence,
-                asyncValidationTerminationState),
-            _defaultRetryOptions);
-
-        return validationResult;
-    }
-
-    private async Task EnqueueActorMessagesInEdiAsync(
-        TaskOrchestrationContext context,
-        OrchestrationInstanceId instanceId,
-        PerformBusinessValidationActivity_Brs_028_V1.ActivityOutput validationResult)
-    {
-        await context.CallActivityAsync(
-            nameof(TransitionStepToRunningActivity_V1),
-            new TransitionStepToRunningActivity_V1.ActivityInput(
-                instanceId,
-                EnqueueActorMessagesStepSequence),
-            _defaultRetryOptions);
-
-        var idempotencyKey = context.NewGuid();
-        if (validationResult.IsValid)
-        {
-            await context.CallActivityAsync(
-                nameof(EnqueueActorMessagesActivity_Brs_028_V1),
-                new EnqueueActorMessagesActivity_Brs_028_V1.ActivityInput(
-                    instanceId,
-                    idempotencyKey),
-                _defaultRetryOptions);
-        }
-        else
-        {
-            ArgumentNullException.ThrowIfNull(validationResult.ValidationErrors);
-
-            await context.CallActivityAsync(
-                nameof(EnqueueRejectMessageActivity_Brs_028_V1),
-                new EnqueueRejectMessageActivity_Brs_028_V1.ActivityInput(
-                    instanceId,
-                    validationResult.ValidationErrors,
-                    idempotencyKey),
-                _defaultRetryOptions);
-        }
-    }
-
-    /// <summary>
-    /// Pattern #5: Human interaction - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview?tabs=isolated-process#human
-    /// </summary>
-    private async Task<bool> WaitForEnqueueActorMessagesResponseFromEdiAsync(
-        TaskOrchestrationContext context,
-        TimeSpan actorMessagesEnqueuedTimeout,
-        OrchestrationInstanceId instanceId)
-    {
-        bool wasMessagesEnqueued;
-        try
-        {
-            await context.WaitForExternalEvent<int?>(
-                eventName: RequestCalculatedWholesaleServicesNotifyEventsV1.EnqueueActorMessagesCompleted,
-                timeout: actorMessagesEnqueuedTimeout);
-            wasMessagesEnqueued = true;
-        }
-        catch (TaskCanceledException)
-        {
-            var logger = context.CreateReplaySafeLogger<Orchestration_Brs_028_V1>();
-            logger.Log(
-                LogLevel.Error,
-                "Timeout while waiting for enqueue actor messages to complete (InstanceId={OrchestrationInstanceId}, Timeout={Timeout}).",
-                instanceId.Value,
-                actorMessagesEnqueuedTimeout.ToString("g"));
-            wasMessagesEnqueued = false;
-        }
-
-        var enqueueActorMessagesTerminationState = wasMessagesEnqueued
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
-        await context.CallActivityAsync(
-            nameof(TransitionStepToTerminatedActivity_V1),
-            new TransitionStepToTerminatedActivity_V1.ActivityInput(
-                instanceId,
-                EnqueueActorMessagesStepSequence,
-                enqueueActorMessagesTerminationState),
-            _defaultRetryOptions);
-
-        return wasMessagesEnqueued;
     }
 
     private async Task<string> TerminateOrchestrationAsync(
         TaskOrchestrationContext context,
         OrchestrationInstanceId instanceId,
-        bool wasMessagesEnqueued,
-        bool failedBusinessValidation)
+        bool businessValidationSuccess)
     {
-        var orchestrationTerminationState = wasMessagesEnqueued && !failedBusinessValidation
+        var orchestrationTerminationState = businessValidationSuccess
             ? OrchestrationInstanceTerminationState.Succeeded
             : OrchestrationInstanceTerminationState.Failed;
 
@@ -212,10 +101,8 @@ internal class Orchestration_Brs_028_V1
             new TransitionOrchestrationToTerminatedActivity_V1.ActivityInput(
                 instanceId,
                 orchestrationTerminationState),
-            _defaultRetryOptions);
+            new TaskOptions(_defaultRetryOptions));
 
-        return wasMessagesEnqueued
-            ? $"Success"
-            : "Error: Timeout while waiting for enqueue actor messages";
+        return "Success";
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Steps/BusinessValidationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Steps/BusinessValidationStep.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Activities;
+using Energinet.DataHub.ProcessManager.Shared.Processes.Activities;
+using Microsoft.DurableTask;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Steps;
+
+[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait must not be used in durable function code")]
+internal class BusinessValidationStep(
+    TaskOrchestrationContext context,
+    TaskRetryOptions defaultRetryOptions,
+    OrchestrationInstanceId instanceId)
+        : StepExecutor<PerformBusinessValidationActivity_Brs_028_V1.ActivityOutput>(
+            context,
+            defaultRetryOptions,
+            instanceId)
+{
+    internal const string StepDescription = "Forretningsvalidering";
+    internal const int StepSequence = 1;
+
+    protected override int StepSequenceNumber => StepSequence;
+
+    protected override async Task<StepOutput> OnExecuteAsync()
+    {
+        var validationResult = await Context.CallActivityAsync<PerformBusinessValidationActivity_Brs_028_V1.ActivityOutput>(
+            nameof(PerformBusinessValidationActivity_Brs_028_V1),
+            new PerformBusinessValidationActivity_Brs_028_V1.ActivityInput(
+                InstanceId,
+                StepSequence),
+            DefaultRetryOptions);
+
+        var asyncValidationTerminationState = validationResult.IsValid
+            ? OrchestrationStepTerminationState.Succeeded
+            : OrchestrationStepTerminationState.Failed;
+
+        return new StepOutput(asyncValidationTerminationState, validationResult);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Steps/EnqueueActorMessagesStep.cs
@@ -14,19 +14,19 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
-using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Activities;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Activities;
 using Energinet.DataHub.ProcessManager.Shared.Processes.Activities;
 using Microsoft.DurableTask;
 
-namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Steps;
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Steps;
 
 [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait must not be used in durable function code")]
 internal class EnqueueActorMessagesStep(
     TaskOrchestrationContext context,
     TaskRetryOptions defaultRetryOptions,
     OrchestrationInstanceId instanceId,
-    PerformBusinessValidationActivity_Brs_026_V1.ActivityOutput validationResult,
+    PerformBusinessValidationActivity_Brs_028_V1.ActivityOutput validationResult,
     TimeSpan actorMessagesEnqueuedTimeout)
         : StepExecutor(context, defaultRetryOptions, instanceId)
 {
@@ -43,8 +43,8 @@ internal class EnqueueActorMessagesStep(
         if (validationResult.IsValid)
         {
             await Context.CallActivityAsync(
-                nameof(EnqueueActorMessagesActivity_Brs_026_V1),
-                new EnqueueActorMessagesActivity_Brs_026_V1.ActivityInput(
+                nameof(EnqueueActorMessagesActivity_Brs_028_V1),
+                new EnqueueActorMessagesActivity_Brs_028_V1.ActivityInput(
                     InstanceId,
                     idempotencyKey),
                 DefaultRetryOptions);
@@ -54,8 +54,8 @@ internal class EnqueueActorMessagesStep(
             ArgumentNullException.ThrowIfNull(validationResult.ValidationErrors);
 
             await Context.CallActivityAsync(
-                nameof(EnqueueRejectMessageActivity_Brs_026_V1),
-                new EnqueueRejectMessageActivity_Brs_026_V1.ActivityInput(
+                nameof(EnqueueRejectMessageActivity_Brs_028_V1),
+                new EnqueueRejectMessageActivity_Brs_028_V1.ActivityInput(
                     InstanceId,
                     validationResult.ValidationErrors,
                     idempotencyKey),
@@ -66,7 +66,7 @@ internal class EnqueueActorMessagesStep(
         // If the timeout is reached, an exception will be thrown, and StepExecutor will fail the step and orchestration instance.
         // If we later need a more complex handling of the timeout, we can try/catch the TaskCanceledException here and handle it manually.
         await Context.WaitForExternalEvent<int?>(
-            eventName: RequestCalculatedEnergyTimeSeriesNotifyEventsV1.EnqueueActorMessagesCompleted,
+            eventName: RequestCalculatedWholesaleServicesNotifyEventsV1.EnqueueActorMessagesCompleted,
             timeout: _actorMessagesEnqueuedTimeout);
 
         return OrchestrationStepTerminationState.Succeeded;

--- a/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
+++ b/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
@@ -71,14 +71,16 @@ public static class ProcessManagerClientExtensions
     public static Task<(bool Succes, OrchestrationInstanceTypedDto<TInput>? OrchestrationInstance)> WaitForOrchestrationInstanceTerminated<TInput>(
         this IProcessManagerClient client,
         string idempotencyKey,
-        OrchestrationInstanceTerminationState terminationState)
+        OrchestrationInstanceTerminationState? terminationState = null)
         where TInput : class, IInputParameterDto
     {
         return client.TryWaitForOrchestrationInstance<TInput>(
             idempotencyKey,
             (orchestrationInstance) =>
                 orchestrationInstance.Lifecycle.State == OrchestrationInstanceLifecycleState.Terminated
-                && orchestrationInstance.Lifecycle.TerminationState == terminationState);
+                && (
+                    terminationState is null
+                    || orchestrationInstance.Lifecycle.TerminationState == terminationState));
     }
 
     /// <summary>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

- Refactor BRS-026 and BRS-028 to use the new steps with `StepExecutor` base, to help handle step lifecycle transitions and exception handling.

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/512

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task

## Copilot summary

This pull request includes several changes to the orchestration process for BRS_026 and BRS_028. The changes focus on refactoring the orchestration steps, improving code readability, and updating test scenarios to reflect the new structure.

### Refactoring Orchestration Steps:
* [`source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration_Brs_026_V1.cs`](diffhunk://#diff-02e5296e585bd469383ee44b00e4803bd757b4f92efd71c76ed8b85ad26765c8L18-R39): Replaced individual step methods with new `BusinessValidationStep` and `EnqueueActorMessagesStep` classes, and updated the orchestration run method to use these new classes. Removed obsolete methods and constants related to the old step sequences. [[1]](diffhunk://#diff-02e5296e585bd469383ee44b00e4803bd757b4f92efd71c76ed8b85ad26765c8L18-R39) [[2]](diffhunk://#diff-02e5296e585bd469383ee44b00e4803bd757b4f92efd71c76ed8b85ad26765c8L48-R65) [[3]](diffhunk://#diff-02e5296e585bd469383ee44b00e4803bd757b4f92efd71c76ed8b85ad26765c8L79-R92) [[4]](diffhunk://#diff-02e5296e585bd469383ee44b00e4803bd757b4f92efd71c76ed8b85ad26765c8L214-R103)

### Test Scenario Updates:
* [`source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs`](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005R25): Updated test scenarios to use the new step sequence constants from `EnqueueActorMessagesStep` instead of `Orchestration_Brs_026_V1`. Adjusted assertions and comments to reflect the new structure. [[1]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005R25) [[2]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005L109-R110) [[3]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005L137-R144) [[4]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005L183-R183) [[5]](diffhunk://#diff-e21c83ba1eff899adbd725eb5d16e9c2b32d34175c701addd4be331043566005L216-R222)

* [`source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs`](diffhunk://#diff-802c1bbeb26b186e07acff027f896bbb32c5dc95eee3d42c907b15296cfb187cR25): Similar updates as above for BRS_028 test scenarios, ensuring consistency across different BRS versions. [[1]](diffhunk://#diff-802c1bbeb26b186e07acff027f896bbb32c5dc95eee3d42c907b15296cfb187cR25) [[2]](diffhunk://#diff-802c1bbeb26b186e07acff027f896bbb32c5dc95eee3d42c907b15296cfb187cL109-R110) [[3]](diffhunk://#diff-802c1bbeb26b186e07acff027f896bbb32c5dc95eee3d42c907b15296cfb187cL136-R143) [[4]](diffhunk://#diff-802c1bbeb26b186e07acff027f896bbb32c5dc95eee3d42c907b15296cfb187cL181-R182) [[5]](diffhunk://#diff-802c1bbeb26b186e07acff027f896bbb32c5dc95eee3d42c907b15296cfb187cL214-R221)

### Orchestration Description Builder:
* [`source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/OrchestrationDescriptionBuilder.cs`](diffhunk://#diff-3906cddfae2422a326d93c12978b7edb9ebece63a87d47b6049216a1adf4e62bR18): Updated the `OrchestrationDescriptionBuilder` to use the new step descriptions from `BusinessValidationStep` and `EnqueueActorMessagesStep`. [[1]](diffhunk://#diff-3906cddfae2422a326d93c12978b7edb9ebece63a87d47b6049216a1adf4e62bR18) [[2]](diffhunk://#diff-3906cddfae2422a326d93c12978b7edb9ebece63a87d47b6049216a1adf4e62bL32-R34)
