### PR TITLE
fix: Fix period overlap check in calculations query

### DIFF
--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/CustomQueries/SearchCalculationHandler.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/CustomQueries/SearchCalculationHandler.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.ProcessManager.Shared.Api.Mappers;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using NodaTime;
+using NodaTime.Extensions;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.CustomQueries;
 
@@ -87,12 +88,15 @@ internal class SearchCalculationHandler(
 
     private bool FilterCalculation(OrchestrationInstance orchestrationInstance, CalculationQuery query)
     {
-        var calculationInput = orchestrationInstance.ParameterValue.AsType<CalculationInputV1>();
+        var calculationParameters = orchestrationInstance.ParameterValue.AsType<CalculationInputV1>();
 
-        return (query.CalculationTypes == null || query.CalculationTypes.Contains(calculationInput.CalculationType)) &&
-                (query.GridAreaCodes == null || calculationInput.GridAreaCodes.Any(query.GridAreaCodes.Contains)) &&
-                (query.PeriodStartDate == null || calculationInput.PeriodStartDate >= query.PeriodStartDate) &&
-                (query.PeriodEndDate == null || calculationInput.PeriodEndDate <= query.PeriodEndDate) &&
-                (query.IsInternalCalculation == null || calculationInput.IsInternalCalculation == query.IsInternalCalculation);
+        return (query.CalculationTypes == null || query.CalculationTypes.Contains(calculationParameters.CalculationType)) &&
+                (query.GridAreaCodes == null || calculationParameters.GridAreaCodes.Any(query.GridAreaCodes.Contains)) &&
+                // This period check follows the algorithm "bool overlap = a.start < b.end && b.start < a.end"
+                // where a = query and b = calculationParameters.
+                // See https://stackoverflow.com/questions/13513932/algorithm-to-detect-overlapping-periods for more info.
+                (query.PeriodStartDate == null || query.PeriodStartDate < calculationParameters.PeriodEndDate) &&
+                (query.PeriodEndDate == null || calculationParameters.PeriodStartDate < query.PeriodEndDate) &&
+                (query.IsInternalCalculation == null || calculationParameters.IsInternalCalculation == query.IsInternalCalculation);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/CustomQueries/SearchCalculationHandler.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/CustomQueries/SearchCalculationHandler.cs
@@ -18,10 +18,7 @@ using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027.V1.Model;
 using Energinet.DataHub.ProcessManager.Shared.Api.Mappers;
-using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
 using NodaTime;
-using NodaTime.Extensions;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.CustomQueries;
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

The query is now equal to the old query in Wholesale. See https://stackoverflow.com/questions/13513932/algorithm-to-detect-overlapping-periods for explanation about the `bool overlap = a.start < b.end && b.start < a.end` algorithm.

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/563

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
