### PR TITLE
feat: full happy part of brs021

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -188,7 +188,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                 })
             .VerifyCountAsync(1);
 
-        var persistSubmittedTransactionEventFound = verifyForwardMeteredDataToMeasurementsEvent.Wait(TimeSpan.FromSeconds(30));
+        var persistSubmittedTransactionEventFound = verifyForwardMeteredDataToMeasurementsEvent.Wait(TimeSpan.FromSeconds(60));
         persistSubmittedTransactionEventFound.Should().BeTrue($"because a {nameof(PersistSubmittedTransaction)} event should have been sent");
 
         // Send a notification to the Process Manager Event Hub to simulate the notification event from measurements

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsMeteredDataClientTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsMeteredDataClientTests.cs
@@ -66,6 +66,7 @@ public class MeasurementsMeteredDataClientTests
 
         var expectedData = new PersistSubmittedTransaction
         {
+            Version = "1",
             OrchestrationInstanceId = meteredData.OrchestrationId,
             OrchestrationType = OrchestrationType.OtSubmittedMeasureData,
             MeteringPointId = meteredData.MeteringPointId,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/Contracts/Brs021ForwardMeteredDataNotifyV1.proto
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/Contracts/Brs021ForwardMeteredDataNotifyV1.proto
@@ -17,8 +17,9 @@ syntax = "proto3";
 
 package google.protobuf;
 
-option csharp_namespace = "Energinet.DataHub.Measurements.Contracts";
+option csharp_namespace = "Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.Measurements.Contracts";
 
 message Brs021ForwardMeteredDataNotifyV1 {
-  string orchestration_instance_id = 1;
+  string version = 1;
+  string orchestration_instance_id = 2;
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/Contracts/Brs021ForwardMeteredDataNotifyVersion.proto
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/Contracts/Brs021ForwardMeteredDataNotifyVersion.proto
@@ -1,0 +1,26 @@
+﻿/* Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.Measurements.Contracts";
+
+// This contract is used for the initial deserialize of the message in order to determine the version of the message 
+// and which contract to use for further deserialization
+message Brs021ForwardMeteredDataNotifyVersion {
+  string version = 1;
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsMeteredDataClient.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsMeteredDataClient.cs
@@ -22,7 +22,6 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardM
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.Logging;
 using NodaTime;
 using Point = Energinet.DataHub.Measurements.Contracts.Point;
 
@@ -41,6 +40,8 @@ public class MeasurementsMeteredDataClient(
     {
         var data = new PersistSubmittedTransaction
         {
+            // TODO: Missing version field?
+            Version = "1",
             OrchestrationInstanceId = meteredDataForMeteringPoint.OrchestrationId,
             OrchestrationType = OrchestrationType.OtSubmittedMeasureData,
             MeteringPointId = meteredDataForMeteringPoint.MeteringPointId,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/EnqueMeteredDataTrigger_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/EnqueMeteredDataTrigger_Brs_021_ForwardMeteredData_V1.cs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 using Azure.Messaging.EventHubs;
-using Energinet.DataHub.Measurements.Contracts;
 using Energinet.DataHub.ProcessManager.Orchestrations.Extensions.Options;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.Measurements.Contracts;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Handlers;
 using Microsoft.Azure.Functions.Worker;
 
@@ -36,6 +36,13 @@ public class EnqueMeteredDataTrigger_Brs_021_ForwardMeteredData_V1(
             Connection = ProcessManagerEventHubOptions.SectionName)]
         EventData message)
     {
+        var brs021ForwardMeteredDataNotifyVersion = Brs021ForwardMeteredDataNotifyVersion.Parser.ParseFrom(message.EventBody.ToArray());
+
+        if (brs021ForwardMeteredDataNotifyVersion is not { Version: "1" })
+        {
+            throw new InvalidOperationException("Failed to deserialize message");
+        }
+
         var notify = Brs021ForwardMeteredDataNotifyV1.Parser.ParseFrom(message.EventBody.ToArray());
         if (notify == null)
         {

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/StartTrigger_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/StartTrigger_Brs_021_ForwardMeteredData_V1.cs
@@ -28,6 +28,7 @@ public class StartTrigger_Brs_021_ForwardMeteredData_V1(
     /// <summary>
     /// Start a BRS-021 ForwardMeteredData.
     /// </summary>
+    [Function(nameof(StartTrigger_Brs_021_ForwardMeteredData_V1))]
     public async Task Run(
         [ServiceBusTrigger(
             $"%{Brs021ForwardMeteredDataTopicOptions.SectionName}:{nameof(Brs021ForwardMeteredDataTopicOptions.StartTopicName)}%",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Re-introduce the happy path test of brs021-forwardMeteredData and update the notification contract from measurements with a version field. 

The version field will determine which version of the contract we can use to deserialize the event from measurements when we communicate via Event Hub. 


## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13761651714
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/551
