### PR TITLE
refac: Renamed net consumption (again)

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/NetConsumptionCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/NetConsumptionCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -38,7 +38,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {
-    private const string CalculationJobName = "NetConsumption";
+    private const string CalculationJobName = "NetConsumptionGroup6";
 
     public MonitorOrchestrationUsingClientsScenario(
         OrchestrationsAppFixture fixture,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/NetConsumptionCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_021_NetConsumptionCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/NetConsumptionCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_021_NetConsumptionCalculation_V1.cs
@@ -35,7 +35,7 @@ internal class CalculationStepStartJobActivity_Brs_021_NetConsumptionCalculation
             $"--orchestration-instance-id={input.InstanceId.Value}",
         };
 
-        return await _client.StartJobAsync("NetConsumption", jobParameters).ConfigureAwait(false);
+        return await _client.StartJobAsync("NetConsumptionGroup6", jobParameters).ConfigureAwait(false);
     }
 
     public record ActivityInput(


### PR DESCRIPTION
The new name is "NetConsumptionGroup6".

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
