### PR TITLE
feat: Use the same idempotency key for BRS-021 enqueue actor messages, even if retrying

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -324,7 +324,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                 s =>
                 {
                     // Find receiver step should be skipped
-                    s.Sequence.Should().Be(OrchestrationDescriptionBuilderV1.FindReceiverStep);
+                    s.Sequence.Should().Be(OrchestrationDescriptionBuilderV1.FindReceiversStep);
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeteredDataHandlerV1.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.ProcessManager.Components.EnqueueActorMessages;
 using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Energinet.DataHub.ProcessManager.Shared.Api.Mappers;
 using NodaTime;
 
@@ -28,8 +29,9 @@ public class EnqueueMeteredDataHandlerV1(
     IClock clock,
     IEnqueueActorMessagesClient enqueueActorMessagesClient)
 {
-    private readonly IEnqueueActorMessagesClient _enqueueActorMessagesClient = enqueueActorMessagesClient;
     private readonly IOrchestrationInstanceProgressRepository _progressRepository = progressRepository;
+    private readonly IClock _clock = clock;
+    private readonly IEnqueueActorMessagesClient _enqueueActorMessagesClient = enqueueActorMessagesClient;
 
     public async Task HandleAsync(OrchestrationInstanceId orchestrationInstanceId)
     {
@@ -40,53 +42,111 @@ public class EnqueueMeteredDataHandlerV1(
         if (orchestrationInstance.Lifecycle.State != OrchestrationInstanceLifecycleState.Running)
             return;
 
-        // Terminate Step: Forward metered data step
-        var forwardToMeasurementStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilderV1.ForwardToMeasurementsStep);
-        await StepHelper.TerminateStepAndCommit(forwardToMeasurementStep, clock, _progressRepository).ConfigureAwait(false);
+        var forwardMeteredDataInput = orchestrationInstance.ParameterValue.AsType<ForwardMeteredDataInputV1>();
+
+        await TerminateForwardToMeasurementStep(orchestrationInstance).ConfigureAwait(false);
 
         // Start Step: Find receiver step
-        var findReceiverStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilderV1.FindReceiverStep);
-        await StepHelper.StartStepAndCommitIfPending(findReceiverStep, clock, _progressRepository).ConfigureAwait(false);
-
-        if (findReceiverStep.Lifecycle.State == StepInstanceLifecycleState.Running)
-        {
-            // Find Receivers
-
-            // Terminate Step: Find receiver step
-            await StepHelper.TerminateStepAndCommit(findReceiverStep, clock, _progressRepository).ConfigureAwait(false);
-        }
+        await FindReceivers(orchestrationInstance).ConfigureAwait(false);
 
         // Start Step: Enqueue actor messages step
-        var enqueueActorMessagesStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilderV1.EnqueueActorMessagesStep);
-        await StepHelper.StartStepAndCommitIfPending(enqueueActorMessagesStep, clock, _progressRepository).ConfigureAwait(false);
+        await EnqueueAcceptedActorMessagesAsync(
+                orchestrationInstance,
+                forwardMeteredDataInput)
+            .ConfigureAwait(false);
+    }
 
-        if (enqueueActorMessagesStep.Lifecycle.State == StepInstanceLifecycleState.Running)
+    private async Task FindReceivers(OrchestrationInstance orchestrationInstance)
+    {
+        var findReceiversStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilderV1.FindReceiversStep);
+
+        // If the step is already terminated (idempotency/retry check), do nothing.
+        if (findReceiversStep.Lifecycle.State == StepInstanceLifecycleState.Terminated)
+            return;
+
+        await StepHelper.StartStepAndCommitIfPending(findReceiversStep, _clock, _progressRepository).ConfigureAwait(false);
+
+        // If we reach this point, the step should be running, so this check is just an extra safeguard.
+        if (findReceiversStep.Lifecycle.State is not StepInstanceLifecycleState.Running)
+            throw new InvalidOperationException($"Find receivers step must be running (Id={findReceiversStep.Id}, State={findReceiversStep.Lifecycle.State}).");
+
+        // Find Receivers
+        // TODO: Implement find receivers
+
+        // Terminate Step: Find receiver step
+        await StepHelper.TerminateStepAndCommit(findReceiversStep, _clock, _progressRepository).ConfigureAwait(false);
+    }
+
+    private async Task TerminateForwardToMeasurementStep(OrchestrationInstance orchestrationInstance)
+    {
+        var forwardToMeasurementStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilderV1.ForwardToMeasurementsStep);
+
+        // If the step is already terminated (idempotency/retry check), do nothing.
+        if (forwardToMeasurementStep.Lifecycle.State == StepInstanceLifecycleState.Terminated)
+            return;
+
+        // If we reach this point, the step should be running, so this check is just an extra safeguard.
+        // The alternative is that the step is pending, but we shouldn't be able to receive a "notify" event
+        // from measurements if the step hasn't transitioned to running yet.
+        if (forwardToMeasurementStep.Lifecycle.State is not StepInstanceLifecycleState.Running)
+            throw new InvalidOperationException($"Forward to measurements step must be running (Id={forwardToMeasurementStep.Id}, State={forwardToMeasurementStep.Lifecycle.State}).");
+
+        await StepHelper.TerminateStepAndCommit(forwardToMeasurementStep, _clock, _progressRepository).ConfigureAwait(false);
+    }
+
+    private async Task EnqueueAcceptedActorMessagesAsync(
+        OrchestrationInstance orchestrationInstance,
+        ForwardMeteredDataInputV1 forwardMeteredDataInput)
+    {
+        var enqueueStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilderV1.EnqueueActorMessagesStep);
+
+        // If the step is already terminated (idempotency/retry check), do nothing.
+        if (enqueueStep.Lifecycle.State == StepInstanceLifecycleState.Terminated)
+            return;
+
+        await StepHelper.StartStepAndCommitIfPending(enqueueStep, _clock, _progressRepository).ConfigureAwait(false);
+
+        // If we reach this point, the step should be running, so this check is just an extra safeguard.
+        if (enqueueStep.Lifecycle.State is not StepInstanceLifecycleState.Running)
+            throw new InvalidOperationException($"Enqueue accepted message step must be running (Id={enqueueStep.Id}, State={enqueueStep.Lifecycle.State}).");
+
+        // Ensure always using the same idempotency key
+        Guid idempotencyKey;
+        if (enqueueStep.CustomState.IsEmpty)
         {
-            var orchestrationInput = orchestrationInstance.ParameterValue.AsType<ForwardMeteredDataInputV1>();
-
-            var data = new ForwardMeteredDataAcceptedV1(
-                OriginalActorMessageId: orchestrationInput.ActorMessageId,
-                MeteringPointId: orchestrationInput.MeteringPointId ?? throw new InvalidOperationException("MeteringPointId is missing"),
-                MeteringPointType: MeteringPointType.Production,
-                OriginalTransactionId: orchestrationInput.TransactionId,
-                ProductNumber: orchestrationInput.ProductNumber ?? "test-product-number",
-                MeasureUnit: MeasurementUnit.KilowattHour,
-                RegistrationDateTime: clock.GetCurrentInstant().ToDateTimeOffset(),
-                Resolution: Resolution.QuarterHourly,
-                StartDateTime: clock.GetCurrentInstant().ToDateTimeOffset(),
-                EndDateTime: clock.GetCurrentInstant().ToDateTimeOffset(),
-                AcceptedEnergyObservations:
-                [
-                    new(1, 1, Quality.Calculated),
-                ],
-                MarketActorRecipients: [new MarketActorRecipientV1(ActorNumber.Create("8100000000115"), ActorRole.EnergySupplier)]);
-
-            await _enqueueActorMessagesClient.EnqueueAsync(
-                orchestration: OrchestrationDescriptionBuilderV1.UniqueName,
-                orchestrationInstanceId: orchestrationInstanceId.Value,
-                orchestrationStartedBy: orchestrationInstance.Lifecycle.CreatedBy.Value.MapToDto(),
-                idempotencyKey: Guid.NewGuid(), // TODO: fix this
-                data: data).ConfigureAwait(false);
+            idempotencyKey = Guid.NewGuid();
+            enqueueStep.CustomState.SetFromInstance(new EnqueueActorMessagesStepCustomStateV1(idempotencyKey));
+            await _progressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
         }
+        else
+        {
+            idempotencyKey = enqueueStep.CustomState.AsType<EnqueueActorMessagesStepCustomStateV1>().IdempotencyKey;
+        }
+
+        // Enqueue forward metered data actor messages
+        var data = new ForwardMeteredDataAcceptedV1(
+            OriginalActorMessageId: forwardMeteredDataInput.ActorMessageId,
+            MeteringPointId: forwardMeteredDataInput.MeteringPointId ?? throw new InvalidOperationException("MeteringPointId is missing"),
+            MeteringPointType: MeteringPointType.Production,
+            OriginalTransactionId: forwardMeteredDataInput.TransactionId,
+            ProductNumber: forwardMeteredDataInput.ProductNumber ?? "test-product-number",
+            MeasureUnit: MeasurementUnit.KilowattHour,
+            RegistrationDateTime: clock.GetCurrentInstant().ToDateTimeOffset(),
+            Resolution: Resolution.QuarterHourly,
+            StartDateTime: clock.GetCurrentInstant().ToDateTimeOffset(),
+            EndDateTime: clock.GetCurrentInstant().ToDateTimeOffset(),
+            AcceptedEnergyObservations:
+            [
+                new(1, 1, Quality.Calculated),
+            ],
+            MarketActorRecipients: [new MarketActorRecipientV1(ActorNumber.Create("8100000000115"), ActorRole.EnergySupplier)]);
+
+        await _enqueueActorMessagesClient.EnqueueAsync(
+                orchestration: OrchestrationDescriptionBuilderV1.UniqueName,
+                orchestrationInstanceId: orchestrationInstance.Id.Value,
+                orchestrationStartedBy: orchestrationInstance.Lifecycle.CreatedBy.Value.MapToDto(),
+                idempotencyKey: idempotencyKey,
+                data: data)
+            .ConfigureAwait(false);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeteredDataHandlerV1.cs
@@ -131,10 +131,10 @@ public class EnqueueMeteredDataHandlerV1(
             OriginalTransactionId: forwardMeteredDataInput.TransactionId,
             ProductNumber: forwardMeteredDataInput.ProductNumber ?? "test-product-number",
             MeasureUnit: MeasurementUnit.KilowattHour,
-            RegistrationDateTime: clock.GetCurrentInstant().ToDateTimeOffset(),
+            RegistrationDateTime: _clock.GetCurrentInstant().ToDateTimeOffset(),
             Resolution: Resolution.QuarterHourly,
-            StartDateTime: clock.GetCurrentInstant().ToDateTimeOffset(),
-            EndDateTime: clock.GetCurrentInstant().ToDateTimeOffset(),
+            StartDateTime: _clock.GetCurrentInstant().ToDateTimeOffset(),
+            EndDateTime: _clock.GetCurrentInstant().ToDateTimeOffset(),
             AcceptedEnergyObservations:
             [
                 new(1, 1, Quality.Calculated),

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeteredDataHandlerV1.cs
@@ -124,6 +124,7 @@ public class EnqueueMeteredDataHandlerV1(
         }
 
         // Enqueue forward metered data actor messages
+        // TODO: Implement correct message data
         var data = new ForwardMeteredDataAcceptedV1(
             OriginalActorMessageId: forwardMeteredDataInput.ActorMessageId,
             MeteringPointId: forwardMeteredDataInput.MeteringPointId ?? throw new InvalidOperationException("MeteringPointId is missing"),

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -126,7 +126,7 @@ public class StartForwardMeteredDataHandlerV1(
             }
 
             // Skip step: Find receiver
-            var findReceiverStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilderV1.FindReceiverStep);
+            var findReceiverStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilderV1.FindReceiversStep);
 
             // If the step is already skipped, do nothing (idempotency/retry check).
             if (findReceiverStep.Lifecycle.TerminationState != OrchestrationStepTerminationState.Skipped)
@@ -293,12 +293,12 @@ public class StartForwardMeteredDataHandlerV1(
         if (enqueueStep.CustomState.IsEmpty)
         {
             idempotencyKey = Guid.NewGuid();
-            enqueueStep.CustomState.SetFromInstance(new EnqueueActorMessagesCustomStateV1(idempotencyKey));
+            enqueueStep.CustomState.SetFromInstance(new EnqueueActorMessagesStepCustomStateV1(idempotencyKey));
             await _progressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
         }
         else
         {
-            idempotencyKey = enqueueStep.CustomState.AsType<EnqueueActorMessagesCustomStateV1>().IdempotencyKey;
+            idempotencyKey = enqueueStep.CustomState.AsType<EnqueueActorMessagesStepCustomStateV1>().IdempotencyKey;
         }
 
         await _enqueueActorMessagesClient.EnqueueAsync(

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/EnqueueActorMessagesStepCustomStateV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/EnqueueActorMessagesStepCustomStateV1.cs
@@ -14,5 +14,5 @@
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
 
-public record EnqueueActorMessagesCustomStateV1(
+public record EnqueueActorMessagesStepCustomStateV1(
     Guid IdempotencyKey);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/OrchestrationDescriptionBuilderV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/OrchestrationDescriptionBuilderV1.cs
@@ -24,7 +24,7 @@ internal class OrchestrationDescriptionBuilderV1 : IOrchestrationDescriptionBuil
 {
     public const int BusinessValidationStep = 1;
     public const int ForwardToMeasurementsStep = 2;
-    public const int FindReceiverStep = 3;
+    public const int FindReceiversStep = 3;
     public const int EnqueueActorMessagesStep = 4;
     public static readonly OrchestrationDescriptionUniqueNameDto UniqueName = new("Brs_021_ForwardMeteredData", 1);
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

- Use the same idempotency key for enqueuing BRS-021 messages
- Refactor `EnqueueMeteredDataHandlerV1` to align idempotency/retry logic

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
