### PR TITLE
fix: re-enable get metering point master data

### DIFF
--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -338,6 +338,8 @@ public class StartForwardMeteredDataHandlerV1(
             return [];
         }
 
+        // Added temporary try-catch to avoid crashing the process if the call to the electricity market fails for actor tests.
+        // When this has been tested and verified, the try-catch should be removed.
         try
         {
             var meteringPointMasterData = await _electricityMarketViews

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -220,13 +220,12 @@ public class StartForwardMeteredDataHandlerV1(
 
         // Fetch metering point master data and store received data used to find receiver later in the orchestration
         // TODO: Use master data from the orchestration instance custom state instead
-        // var meteringPointMasterData = await GetMeteringPointMasterData(
-        //         input.MeteringPointId,
-        //         input.StartDateTime,
-        //         input.EndDateTime)
-        //     .ConfigureAwait(false);
+        var meteringPointMasterData = await GetMeteringPointMasterData(
+                input.MeteringPointId,
+                input.StartDateTime,
+                input.EndDateTime)
+            .ConfigureAwait(false);
 
-        var meteringPointMasterData = Array.Empty<MeteringPointMasterData>();
         var validationErrors = await _validator.ValidateAsync(
                 new ForwardMeteredDataBusinessValidatedDto(
                     Input: input,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -61,6 +61,7 @@ public class StartForwardMeteredDataHandlerV1(
     private readonly BusinessValidator<ForwardMeteredDataBusinessValidatedDto> _validator = validator;
     private readonly ElectricityMarket.Integration.IElectricityMarketViews _electricityMarketViews = electricityMarketViews;
     private readonly IEnqueueActorMessagesClient _enqueueActorMessagesClient = enqueueActorMessagesClient;
+    private readonly ILogger<StartForwardMeteredDataHandlerV1> _logger = logger;
 
     /// <summary>
     /// This method has multiple commits to the database, to immediately transition lifecycles. This means that
@@ -337,22 +338,30 @@ public class StartForwardMeteredDataHandlerV1(
             return [];
         }
 
-        var meteringPointMasterData = await _electricityMarketViews
-            .GetMeteringPointMasterDataChangesAsync(
-                id,
-                new Interval(parsedStartDateTime.Value, parsedEndDateTime.Value))
-            .ConfigureAwait(false);
+        try
+        {
+            var meteringPointMasterData = await _electricityMarketViews
+                .GetMeteringPointMasterDataChangesAsync(
+                    id,
+                    new Interval(parsedStartDateTime.Value, parsedEndDateTime.Value))
+                .ConfigureAwait(false);
 
-        return meteringPointMasterData
-            .Select(mpt => new MeteringPointMasterData(
-                new MeteringPointId(mpt.Identification.Value),
-                new GridAreaCode(mpt.GridAreaCode.Value),
-                ActorNumber.Create(mpt.GridAccessProvider),
-                MeteringPointMasterDataMapper.ConnectionStateMap.Map(mpt.ConnectionState),
-                MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(mpt.Type),
-                MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(mpt.SubType),
-                MeteringPointMasterDataMapper.MeasureUnitMap.Map(mpt.Unit)))
-            .ToList();
+            return meteringPointMasterData
+                .Select(mpt => new MeteringPointMasterData(
+                    new MeteringPointId(mpt.Identification.Value),
+                    new GridAreaCode(mpt.GridAreaCode.Value),
+                    ActorNumber.Create(mpt.GridAccessProvider),
+                    MeteringPointMasterDataMapper.ConnectionStateMap.Map(mpt.ConnectionState),
+                    MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(mpt.Type),
+                    MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(mpt.SubType),
+                    MeteringPointMasterDataMapper.MeasureUnitMap.Map(mpt.Unit)))
+                .ToList();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, $"Failed to get metering point master data for metering point {meteringPointIdentification} in the period {parsedStartDateTime} - {parsedEndDateTime}.");
+            return [];
+        }
     }
 
     private MeteredDataForMeteringPoint MapInputToMeasurements(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Re-enable the call to Electricity market to get the metering point master data. 

- [x] manual tests on dev002


## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13852660239
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
