### PR TITLE
feat: added health checks on start and notify brs021_forward topics and subscription

### DIFF
--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
@@ -80,38 +80,38 @@ public static class ProcessManagerTopicExtensions
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartTopicName,
                 tokenCredentialFactory: _ => credential,
-                name: "Process Manager Start Topic")
+                name: "BRS-021-ForwardMeteredData Start Topic")
             .AddAzureServiceBusSubscription(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartTopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartSubscriptionName,
                 tokenCredentialFactory: _ => credential,
-                name: "BRS-021-ForwardMeteredData Subscription")
+                name: "BRS-021-ForwardMeteredData Start Subscription")
             .AddServiceBusTopicSubscriptionDeadLetter(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartTopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartSubscriptionName,
                 tokenCredentialFactory: _ => credential,
-                name: "BRS-021-ForwardMeteredData Dead-letter",
+                name: "BRS-021-ForwardMeteredData Start Dead-letter",
                 [HealthChecksConstants.StatusHealthCheckTag])
             // Add health check for the Brs021ForwardMeteredData notify Topic and subscription
             .AddAzureServiceBusTopic(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifyTopicName,
                 tokenCredentialFactory: _ => credential,
-                name: "Process Manager Start Topic")
+                name: "BRS-021-ForwardMeteredData Notify Topic")
             .AddAzureServiceBusSubscription(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifyTopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifySubscriptionName,
                 tokenCredentialFactory: _ => credential,
-                name: "BRS-021-ForwardMeteredData Subscription")
+                name: "BRS-021-ForwardMeteredData Notify Subscription")
             .AddServiceBusTopicSubscriptionDeadLetter(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifyTopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifySubscriptionName,
                 tokenCredentialFactory: _ => credential,
-                name: "BRS-021-ForwardMeteredData Dead-letter",
+                name: "BRS-021-ForwardMeteredData Notify Dead-letter",
                 [HealthChecksConstants.StatusHealthCheckTag]);
 
         return services;

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
@@ -38,6 +38,11 @@ public static class ProcessManagerTopicExtensions
             .BindConfiguration(ProcessManagerStartTopicOptions.SectionName)
             .ValidateDataAnnotations();
 
+        services
+            .AddOptions<Brs021ForwardMeteredDataTopicOptions>()
+            .BindConfiguration(Brs021ForwardMeteredDataTopicOptions.SectionName)
+            .ValidateDataAnnotations();
+
         services.AddHealthChecks()
             .AddAzureServiceBusTopic(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
@@ -69,6 +74,44 @@ public static class ProcessManagerTopicExtensions
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.Brs028SubscriptionName,
                 tokenCredentialFactory: _ => credential,
                 name: "BRS-028 Dead-letter",
+                [HealthChecksConstants.StatusHealthCheckTag])
+            // Add health check for the Brs021ForwardMeteredData start Topic and subscription
+            .AddAzureServiceBusTopic(
+                fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
+                topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartTopicName,
+                tokenCredentialFactory: _ => credential,
+                name: "Process Manager Start Topic")
+            .AddAzureServiceBusSubscription(
+                fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
+                topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartTopicName,
+                subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartSubscriptionName,
+                tokenCredentialFactory: _ => credential,
+                name: "BRS-021-ForwardMeteredData Subscription")
+            .AddServiceBusTopicSubscriptionDeadLetter(
+                fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
+                topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartTopicName,
+                subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartSubscriptionName,
+                tokenCredentialFactory: _ => credential,
+                name: "BRS-021-ForwardMeteredData Dead-letter",
+                [HealthChecksConstants.StatusHealthCheckTag])
+            // Add health check for the Brs021ForwardMeteredData notify Topic and subscription
+            .AddAzureServiceBusTopic(
+                fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
+                topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifyTopicName,
+                tokenCredentialFactory: _ => credential,
+                name: "Process Manager Start Topic")
+            .AddAzureServiceBusSubscription(
+                fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
+                topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifyTopicName,
+                subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifySubscriptionName,
+                tokenCredentialFactory: _ => credential,
+                name: "BRS-021-ForwardMeteredData Subscription")
+            .AddServiceBusTopicSubscriptionDeadLetter(
+                fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
+                topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifyTopicName,
+                subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifySubscriptionName,
+                tokenCredentialFactory: _ => credential,
+                name: "BRS-021-ForwardMeteredData Dead-letter",
                 [HealthChecksConstants.StatusHealthCheckTag]);
 
         return services;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Adding health checks on service bus topics and subscriptions related to brs021_forwardMeteredData

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003) =>https://github.com/Energinet-DataHub/dh3-environments/actions/runs/14053773521
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
