### PR TITLE
feat: return business validation error when no master data for metering point

### DIFF
--- a/source/ProcessManager.Core/Application/FeatureFlags/FeatureFlag.cs
+++ b/source/ProcessManager.Core/Application/FeatureFlags/FeatureFlag.cs
@@ -38,9 +38,9 @@ public enum FeatureFlag
     SilentMode,
 
     /// <summary>
-    /// Enables the use of the BRS_021 business validation for metering points.
+    /// Enables the use of the BRS_021_ForwardMeteredData business validation for metering points.
     /// If this feature flag is enabled, the business validation rule will return a business validation error
     /// if the metering point does not exist.
     /// </summary>
-    UseBrs021BusinessValidationForMeteringPoint,
+    UseBrs021ForwardMeteredDataBusinessValidationForMeteringPoint,
 }

--- a/source/ProcessManager.Core/Application/FeatureFlags/FeatureFlag.cs
+++ b/source/ProcessManager.Core/Application/FeatureFlags/FeatureFlag.cs
@@ -42,5 +42,5 @@ public enum FeatureFlag
     /// If this feature flag is enabled, the business validation rule will return a business validation error
     /// if the metering point does not exist.
     /// </summary>
-    UseBrs021ForwardMeteredDataBusinessValidationForMeteringPoint,
+    EnableBrs021ForwardMeteredDataBusinessValidationForMeteringPoint,
 }

--- a/source/ProcessManager.Core/Application/FeatureFlags/FeatureFlag.cs
+++ b/source/ProcessManager.Core/Application/FeatureFlags/FeatureFlag.cs
@@ -36,4 +36,11 @@ public enum FeatureFlag
     /// the log and dead-letter queue for the PM core will be flooded with false errors.
     /// </summary>
     SilentMode,
+
+    /// <summary>
+    /// Enables the use of the BRS_021 business validation for metering points.
+    /// If this feature flag is enabled, the business validation rule will return a business validation error
+    /// if the metering point does not exist.
+    /// </summary>
+    UseBrs021BusinessValidationForMeteringPoint,
 }

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRuleTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRuleTests.cs
@@ -65,7 +65,7 @@ public class MeteringPointValidationRuleTests
     {
         var featureManager = new Mock<IFeatureManager>();
         featureManager
-            .Setup(x => x.IsEnabledAsync(FeatureFlag.UseBrs021BusinessValidationForMeteringPoint.ToString()))
+            .Setup(x => x.IsEnabledAsync(FeatureFlag.UseBrs021ForwardMeteredDataBusinessValidationForMeteringPoint.ToString()))
             .ReturnsAsync(true);
         _sut = new(new MicrosoftFeatureFlagManager(featureManager.Object));
         var input = new ForwardMeteredDataInputV1Builder()

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRuleTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRuleTests.cs
@@ -65,7 +65,7 @@ public class MeteringPointValidationRuleTests
     {
         var featureManager = new Mock<IFeatureManager>();
         featureManager
-            .Setup(x => x.IsEnabledAsync(FeatureFlag.UseBrs021ForwardMeteredDataBusinessValidationForMeteringPoint.ToString()))
+            .Setup(x => x.IsEnabledAsync(FeatureFlag.EnableBrs021ForwardMeteredDataBusinessValidationForMeteringPoint.ToString()))
             .ReturnsAsync(true);
         _sut = new(new MicrosoftFeatureFlagManager(featureManager.Object));
         var input = new ForwardMeteredDataInputV1Builder()

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRuleTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRuleTests.cs
@@ -14,17 +14,21 @@
 
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
 using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Core.Application.FeatureFlags;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Core.Infrastructure.FeatureFlags;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using FluentAssertions;
+using Microsoft.FeatureManagement;
+using Moq;
 using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
 
 public class MeteringPointValidationRuleTests
 {
-    private readonly MeteringPointValidationRule _sut = new();
+    private MeteringPointValidationRule _sut = new(new MicrosoftFeatureFlagManager(new Mock<IFeatureManager>().Object));
 
     [Fact]
     public async Task Given_MeteringPointMasterData_When_Validate_Then_NoValidationError()
@@ -56,9 +60,14 @@ public class MeteringPointValidationRuleTests
         result.Should().BeEmpty();
     }
 
-    [Fact(Skip = "'Metering point doesn't exists' validation is currently disabled")]
+    [Fact]
     public async Task Given_NoMeteringPointMasterData_When_Validate_Then_ValidationError()
     {
+        var featureManager = new Mock<IFeatureManager>();
+        featureManager
+            .Setup(x => x.IsEnabledAsync(FeatureFlag.UseBrs021BusinessValidationForMeteringPoint.ToString()))
+            .ReturnsAsync(true);
+        _sut = new(new MicrosoftFeatureFlagManager(featureManager.Object));
         var input = new ForwardMeteredDataInputV1Builder()
             .Build();
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRule.cs
@@ -36,7 +36,7 @@ public class MeteringPointValidationRule(IFeatureFlagManager featureFlagManager)
     public async Task<IList<ValidationError>> ValidateAsync(
         ForwardMeteredDataBusinessValidatedDto subject)
     {
-        if (await _featureFlagManager.IsEnabledAsync(FeatureFlag.UseBrs021ForwardMeteredDataBusinessValidationForMeteringPoint).ConfigureAwait(false))
+        if (await _featureFlagManager.IsEnabledAsync(FeatureFlag.EnableBrs021ForwardMeteredDataBusinessValidationForMeteringPoint).ConfigureAwait(false))
         {
             if (subject.MeteringPointMasterData.Count == 0)
                 return MeteringPointDoesntExistsError;

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointValidationRule.cs
@@ -36,7 +36,7 @@ public class MeteringPointValidationRule(IFeatureFlagManager featureFlagManager)
     public async Task<IList<ValidationError>> ValidateAsync(
         ForwardMeteredDataBusinessValidatedDto subject)
     {
-        if (await _featureFlagManager.IsEnabledAsync(FeatureFlag.UseBrs021BusinessValidationForMeteringPoint).ConfigureAwait(false))
+        if (await _featureFlagManager.IsEnabledAsync(FeatureFlag.UseBrs021ForwardMeteredDataBusinessValidationForMeteringPoint).ConfigureAwait(false))
         {
             if (subject.MeteringPointMasterData.Count == 0)
                 return MeteringPointDoesntExistsError;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
To test the reject flow where we enqueue an RSM009 document. MeteringPoint business validation rule is enabled behind a feature flag:
- UseBrs021ForwardMeteredDataBusinessValidationForMeteringPoint

If the feature is enabled, missing master data for a metering point triggers the reject flow.

Infra PR: https://github.com/Energinet-DataHub/dh3-infrastructure/pull/3225


## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/14054006221
- [x] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
