### PR TITLE
feat: Remove master data validation

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
@@ -52,18 +52,15 @@ public class MeteringPointMasterDataProviderTests
             .BeEmpty();
     }
 
-    [Fact(Skip = "Awaiting clarification wrt the expected behavior")]
-    public async Task Given_MasterDataWithNoEnergySuppliers_When_GetMasterData_Then_Error()
+    [Fact]
+    public async Task Given_MasterDataWithNoEnergySuppliers_When_GetMasterData_Then_NoMasterData()
     {
-        var act = async () => await _sut.GetMasterData(
+        var result = await _sut.GetMasterData(
             "no-energy-suppliers-please",
             "2021-01-01T00:00:00Z",
             "2021-01-01T00:00:00Z");
 
-        await act.Should()
-            .ThrowAsync<Exception>()
-            .WithMessage(
-                "No energy suppliers found for metering point 'no-energy-suppliers-please' in period 2021-01-01T00:00:00Z--2021-01-01T00:00:00Z.");
+        result.Should().BeEmpty();
     }
 
     [Fact]
@@ -117,10 +114,8 @@ public class MeteringPointMasterDataProviderTests
     [Fact]
     public async Task Given_TwoMasterDataWithTwoEnergySuppliers_When_GetMasterData_Then_ListOfFour()
     {
-        _electricityMarketViews.MeteringPointMasterDataProvider = () => GetMeteringPointMasterData();
-
         var meteringPointMasterData = await _sut.GetMasterData(
-            "custom-metering-point-master-data",
+            "two-master-data-with-two-energy-suppliers-please",
             "2021-01-01T00:00:00Z",
             "2021-01-05T00:00:00Z");
 
@@ -132,46 +127,59 @@ public class MeteringPointMasterDataProviderTests
             .SatisfyRespectively(
                 first =>
                 {
-                    first.MeteringPointId.Value.Should().Be("custom-metering-point-master-data");
+                    first.MeteringPointId.Value.Should().Be("two-master-data-with-two-energy-suppliers-please");
                     first.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
                     first.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
                     first.EnergySupplier.Value.Should().Be("1111111111111");
                 },
                 second =>
                 {
-                    second.MeteringPointId.Value.Should().Be("custom-metering-point-master-data");
+                    second.MeteringPointId.Value.Should().Be("two-master-data-with-two-energy-suppliers-please");
                     second.ValidFrom.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
                     second.ValidTo.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
                     second.EnergySupplier.Value.Should().Be("2222222222222");
                 },
                 third =>
                 {
-                    third.MeteringPointId.Value.Should().Be("custom-metering-point-master-data");
+                    third.MeteringPointId.Value.Should().Be("two-master-data-with-two-energy-suppliers-please");
                     third.ValidFrom.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
                     third.ValidTo.Should().Be(new DateTimeOffset(2021, 4, 1, 0, 0, 0, TimeSpan.Zero));
                     third.EnergySupplier.Value.Should().Be("1111111111111");
                 },
                 fourth =>
                 {
-                    fourth.MeteringPointId.Value.Should().Be("custom-metering-point-master-data");
+                    fourth.MeteringPointId.Value.Should().Be("two-master-data-with-two-energy-suppliers-please");
                     fourth.ValidFrom.Should().Be(new DateTimeOffset(2021, 4, 1, 0, 0, 0, TimeSpan.Zero));
                     fourth.ValidTo.Should().Be(new DateTimeOffset(2021, 5, 1, 0, 0, 0, TimeSpan.Zero));
                     fourth.EnergySupplier.Value.Should().Be("3333333333333");
                 });
     }
 
-    [Fact(Skip = "Awaiting clarification wrt the expected behavior")]
-    public async Task Given_TwoMasterDataWithOneFaultyEnergySuppliers_When_GetMasterData_Then_Error()
+    [Fact]
+    public async Task
+        Given_TwoMasterDataWithOneFaultyEnergySuppliers_When_GetMasterData_Then_NonFaultMasterDataReturned()
     {
-        var act = async () => await _sut.GetMasterData(
+        var result = await _sut.GetMasterData(
             "faulty-two-master-data-please",
             "2021-01-01T00:00:00Z",
-            "2021-01-01T00:00:00Z");
+            "2021-01-05T00:00:00Z");
 
-        await act.Should()
-            .ThrowAsync<Exception>()
-            .WithMessage(
-                "No energy suppliers found for metering point 'faulty-two-master-data-please' in period 2021-03-01T00:00:00Z--2021-05-01T00:00:00Z.");
+        result.Should()
+            .SatisfyRespectively(
+                first =>
+                {
+                    first.MeteringPointId.Value.Should().Be("faulty-two-master-data-please");
+                    first.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
+                    first.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
+                    first.EnergySupplier.Value.Should().Be("1111111111111");
+                },
+                second =>
+                {
+                    second.MeteringPointId.Value.Should().Be("faulty-two-master-data-please");
+                    second.ValidFrom.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
+                    second.ValidTo.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
+                    second.EnergySupplier.Value.Should().Be("2222222222222");
+                });
     }
 
     [Fact]
@@ -307,181 +315,8 @@ public class MeteringPointMasterDataProviderTests
                 });
     }
 
-    [Fact(Skip = "Awaiting clarification wrt the expected behavior")]
-    public async Task Given_MasterDataWithEnergySupplierAndMasterDataWithMissingEnergySupplier_When_GetMasterData_Then_Error()
-    {
-        _electricityMarketViews.MeteringPointMasterDataProvider = () => GetMeteringPointMasterData(gapInDates: true);
-
-        var act = async () => await _sut.GetMasterData(
-            "custom-metering-point-master-data",
-            "2021-01-01T00:00:00Z",
-            "2021-01-01T00:00:00Z");
-
-        await act.Should().ThrowAsync<Exception>().WithMessage("Metering point master data is not consistent");
-    }
-
-    [Fact(Skip = "Awaiting clarification wrt the expected behavior")]
-    public async Task Given_MasterDataWithOverlappingEnergySuppliers_When_GetMasterData_Then_Error()
-    {
-        _electricityMarketViews.MeteringPointMasterDataProvider =
-            () => GetMeteringPointMasterData(overlapInDates: true);
-
-        var act = async () => await _sut.GetMasterData(
-            "custom-metering-point-master-data",
-            "2021-01-01T00:00:00Z",
-            "2021-01-01T00:00:00Z");
-
-        await act.Should().ThrowAsync<Exception>().WithMessage("Metering point master data is not consistent");
-    }
-
-    [Fact(Skip = "Awaiting clarification wrt the expected behavior")]
-    public async Task Given_MasterDataWithNonMatchingDatesForEnergySuppliers_When_GetMasterData_Then_Error()
-    {
-        _electricityMarketViews.MeteringPointMasterDataProvider =
-            () => GetMeteringPointMasterData(datesNotMatching: true);
-
-        var act = async () => await _sut.GetMasterData(
-            "custom-metering-point-master-data",
-            "2021-01-01T00:00:00Z",
-            "2021-01-01T00:00:00Z");
-
-        await act.Should()
-            .ThrowAsync<Exception>()
-            .WithMessage(
-                "The interval of the energy suppliers (2021-01-01T00:00:00Z--2021-03-01T00:00:00Z) does not match the master data interval (2021-01-01T00:00:00Z--2021-03-02T00:00:00Z).");
-    }
-
-    [Fact(Skip = "Awaiting clarification wrt the expected behavior")]
-    public async Task Given_MasterDataWithInconsistentMeteringPointType_When_GetMasterData_Then_Error()
-    {
-        _electricityMarketViews.MeteringPointMasterDataProvider =
-            () => GetMeteringPointMasterData(changeToType: true);
-
-        var act = async () => await _sut.GetMasterData(
-            "custom-metering-point-master-data",
-            "2021-01-01T00:00:00Z",
-            "2021-01-01T00:00:00Z");
-
-        await act.Should()
-            .ThrowAsync<Exception>()
-            .WithMessage("MeteringPointType 'Production' is not equal to previous MeteringPointType 'Consumption'");
-    }
-
-    [Fact(Skip = "Awaiting clarification wrt the expected behavior")]
-    public async Task Given_MasterDataWithChangeToMeasurementUnit_When_GetMasterData_Then_Error()
-    {
-        _electricityMarketViews.MeteringPointMasterDataProvider =
-            () => GetMeteringPointMasterData(changeToMeasurementUnit: true);
-
-        var act = async () => await _sut.GetMasterData(
-            "custom-metering-point-master-data",
-            "2021-01-01T00:00:00Z",
-            "2021-01-01T00:00:00Z");
-
-        await act.Should()
-            .ThrowAsync<Exception>()
-            .WithMessage("MeasurementUnit 'kWh' is not equal to previous MeasurementUnit 'MVAr'");
-    }
-
-    [Fact(Skip = "Awaiting clarification wrt the expected behavior")]
-    public async Task Given_MasterDataWithChangeToProductId_When_GetMasterData_Then_Error()
-    {
-        _electricityMarketViews.MeteringPointMasterDataProvider =
-            () => GetMeteringPointMasterData(changeToProductId: true);
-
-        var act = async () => await _sut.GetMasterData(
-            "custom-metering-point-master-data",
-            "2021-01-01T00:00:00Z",
-            "2021-01-01T00:00:00Z");
-
-        await act.Should()
-            .ThrowAsync<Exception>()
-            .WithMessage("ProductId 'Tariff' is not equal to previous ProductId 'EnergyActivate'");
-    }
-
-    private IReadOnlyCollection<MeteringPointMasterData> GetMeteringPointMasterData(
-        bool gapInDates = false,
-        bool overlapInDates = false,
-        bool datesNotMatching = false,
-        bool changeToType = false,
-        bool changeToMeasurementUnit = false,
-        bool changeToProductId = false) =>
-    [
-        new()
-        {
-            Identification = new MeteringPointIdentification("custom-metering-point-master-data"),
-            ValidFrom = Instant.FromUtc(2021, 1, 1, 0, 0),
-            ValidTo = Instant.FromUtc(2021, 3, datesNotMatching ? 2 : 1, 0, 0),
-            GridAreaCode = new GridAreaCode("804"),
-            GridAccessProvider = "9999999999999",
-            ConnectionState = ConnectionState.Connected,
-            Type = MeteringPointType.Consumption,
-            SubType = MeteringPointSubType.Physical,
-            Resolution = new Resolution("PT1H"),
-            Unit = changeToMeasurementUnit ? MeasureUnit.MVAr : MeasureUnit.kWh,
-            ProductId = ProductId.PowerActive,
-            ParentIdentification = null,
-            EnergySuppliers =
-            [
-                new()
-                {
-                    Identification = new MeteringPointIdentification("custom-metering-point-master-data"),
-                    EnergySupplier = "1111111111111",
-                    StartDate = Instant.FromUtc(2021, 1, 1, 0, 0),
-                    EndDate = Instant.FromUtc(2021, 2, overlapInDates ? 2 : 1, 0, 0),
-                },
-                new()
-                {
-                    Identification = new MeteringPointIdentification("custom-metering-point-master-data"),
-                    EnergySupplier = "2222222222222",
-                    StartDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                    EndDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                },
-            ],
-        },
-        new()
-        {
-            Identification = new MeteringPointIdentification("custom-metering-point-master-data"),
-            ValidFrom = Instant.FromUtc(2021, 3, 1, 0, 0),
-            ValidTo = Instant.FromUtc(2021, 5, 1, 0, 0),
-            GridAreaCode = new GridAreaCode("804"),
-            GridAccessProvider = "9999999999999",
-            ConnectionState = ConnectionState.Connected,
-            Type = changeToType ? MeteringPointType.Production : MeteringPointType.Consumption,
-            SubType = MeteringPointSubType.Physical,
-            Resolution = new Resolution("PT1H"),
-            Unit = MeasureUnit.kWh,
-            ProductId = changeToProductId ? ProductId.Tariff : ProductId.PowerActive,
-            ParentIdentification = null,
-            EnergySuppliers =
-            [
-                new()
-                {
-                    Identification = new MeteringPointIdentification("custom-metering-point-master-data"),
-                    EnergySupplier = "1111111111111",
-                    StartDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                    EndDate = Instant.FromUtc(2021, 4, 1, 0, 0),
-                },
-                new()
-                {
-                    Identification = new MeteringPointIdentification("custom-metering-point-master-data"),
-                    EnergySupplier = "3333333333333",
-                    StartDate = Instant.FromUtc(2021, 4, gapInDates ? 2 : 1, 0, 0),
-                    EndDate = Instant.FromUtc(2021, 5, 1, 0, 0),
-                },
-            ],
-        },
-    ];
-
     private class ElectricityMarketViewsMock : IElectricityMarketViews
     {
-        /// <summary>
-        /// Property used to store custom master data that is not part of the default scenarios provided by default.
-        /// Simply set this value to the desired master data to be returned before the mock is invoked.
-        /// </summary>
-        public Func<IEnumerable<MeteringPointMasterData>> MeteringPointMasterDataProvider { get; set; } =
-            () => [];
-
         /// <summary>
         /// The <paramref name="meteringPointIdentification"/> is used to determine which static data to return.
         /// The id describes the scenario the data is supposed to mimic.
@@ -493,7 +328,6 @@ public class MeteringPointMasterDataProviderTests
         {
             return meteringPointIdentification.Value switch
             {
-                "custom-metering-point-master-data" => Task.FromResult(MeteringPointMasterDataProvider()),
                 "no-master-data-please" => Task.FromResult<IEnumerable<MeteringPointMasterData>>([]),
                 "no-energy-suppliers-please" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(
                 [
@@ -628,6 +462,152 @@ public class MeteringPointMasterDataProviderTests
                         EnergySuppliers = [],
                     },
                 ]),
+                "two-master-data-with-two-energy-suppliers-please" => Task
+                    .FromResult<IEnumerable<MeteringPointMasterData>>(
+                    [
+                        new()
+                        {
+                            Identification =
+                                new MeteringPointIdentification(
+                                    "two-master-data-with-two-energy-suppliers-please"),
+                            ValidFrom = Instant.FromUtc(
+                                2021,
+                                1,
+                                1,
+                                0,
+                                0),
+                            ValidTo = Instant.FromUtc(
+                                2021,
+                                3,
+                                1,
+                                0,
+                                0),
+                            GridAreaCode = new GridAreaCode("804"),
+                            GridAccessProvider = "9999999999999",
+                            ConnectionState =
+                                ConnectionState.Connected,
+                            Type = MeteringPointType.Consumption,
+                            SubType = MeteringPointSubType.Physical,
+                            Resolution = new Resolution("PT1H"),
+                            Unit = MeasureUnit.kWh,
+                            ProductId = ProductId.PowerActive,
+                            ParentIdentification = null,
+                            EnergySuppliers =
+                            [
+                                new()
+                                {
+                                    Identification =
+                                        new
+                                            MeteringPointIdentification(
+                                                "two-master-data-with-two-energy-suppliers-please"),
+                                    EnergySupplier = "1111111111111",
+                                    StartDate = Instant.FromUtc(
+                                        2021,
+                                        1,
+                                        1,
+                                        0,
+                                        0),
+                                    EndDate = Instant.FromUtc(
+                                        2021,
+                                        2,
+                                        1,
+                                        0,
+                                        0),
+                                },
+                                new()
+                                {
+                                    Identification =
+                                        new
+                                            MeteringPointIdentification(
+                                                "two-master-data-with-two-energy-suppliers-please"),
+                                    EnergySupplier = "2222222222222",
+                                    StartDate = Instant.FromUtc(
+                                        2021,
+                                        2,
+                                        1,
+                                        0,
+                                        0),
+                                    EndDate = Instant.FromUtc(
+                                        2021,
+                                        3,
+                                        1,
+                                        0,
+                                        0),
+                                },
+                            ],
+                        },
+                        new()
+                        {
+                            Identification =
+                                new MeteringPointIdentification(
+                                    "two-master-data-with-two-energy-suppliers-please"),
+                            ValidFrom = Instant.FromUtc(
+                                2021,
+                                3,
+                                1,
+                                0,
+                                0),
+                            ValidTo = Instant.FromUtc(
+                                2021,
+                                5,
+                                1,
+                                0,
+                                0),
+                            GridAreaCode = new GridAreaCode("804"),
+                            GridAccessProvider = "9999999999999",
+                            ConnectionState =
+                                ConnectionState.Connected,
+                            Type = MeteringPointType.Consumption,
+                            SubType = MeteringPointSubType.Physical,
+                            Resolution = new Resolution("PT1H"),
+                            Unit = MeasureUnit.kWh,
+                            ProductId = ProductId.PowerActive,
+                            ParentIdentification = null,
+                            EnergySuppliers =
+                            [
+                                new()
+                                {
+                                    Identification =
+                                        new
+                                            MeteringPointIdentification(
+                                                "two-master-data-with-two-energy-suppliers-please"),
+                                    EnergySupplier = "1111111111111",
+                                    StartDate = Instant.FromUtc(
+                                        2021,
+                                        3,
+                                        1,
+                                        0,
+                                        0),
+                                    EndDate = Instant.FromUtc(
+                                        2021,
+                                        4,
+                                        1,
+                                        0,
+                                        0),
+                                },
+                                new()
+                                {
+                                    Identification =
+                                        new
+                                            MeteringPointIdentification(
+                                                "two-master-data-with-two-energy-suppliers-please"),
+                                    EnergySupplier = "3333333333333",
+                                    StartDate = Instant.FromUtc(
+                                        2021,
+                                        4,
+                                        1,
+                                        0,
+                                        0),
+                                    EndDate = Instant.FromUtc(
+                                        2021,
+                                        5,
+                                        1,
+                                        0,
+                                        0),
+                                },
+                            ],
+                        },
+                    ]),
                 "two-parents-please" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(
                 [
                     new()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

This pull request focuses on updating the unit tests for the `MeteringPointMasterDataProvider` class in the `ProcessManager.Orchestrations` project. The changes include renaming test methods for clarity, modifying test logic to check for different outcomes, and removing obsolete tests.

Key changes include:

### Test Method Updates:
* Renamed and updated the test method `Given_MasterDataWithNoEnergySuppliers_When_GetMasterData_Then_Error` to `Given_MasterDataWithNoEnergySuppliers_When_GetMasterData_Then_NoMasterData` and changed the logic to check for an empty result instead of throwing an exception.
* Renamed and updated the test method `Given_TwoMasterDataWithOneFaultyEnergySuppliers_When_GetMasterData_Then_Error` to `Given_TwoMasterDataWithOneFaultyEnergySuppliers_When_GetMasterData_Then_NonFaultMasterDataReturned` and changed the logic to verify the returned data instead of throwing an exception.

### Test Data Changes:
* Updated the test data for `Given_TwoMasterDataWithTwoEnergySuppliers_When_GetMasterData_Then_ListOfFour` to use a new identifier `two-master-data-with-two-energy-suppliers-please` instead of `custom-metering-point-master-data`. [[1]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L120-R118) [[2]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L135-R182)

### Removal of Obsolete Tests:
* Removed several test methods that were marked as skipped and awaiting clarification regarding the expected behavior. These tests included scenarios for missing energy suppliers, overlapping energy suppliers, non-matching dates, inconsistent metering point types, changes to measurement units, and changes to product IDs.

### Code Cleanup:
* Removed unused code and comments related to the obsolete test methods and their setup data. [[1]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L496) [[2]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305R465-R610)

### Namespace and Using Directive Updates:
* Removed an unused `using` directive for `PMResolution` in the `MeteringPointMasterDataProvider.cs` file.

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/613

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
