### PR TITLE
feat: Add metering point ownership validation

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -462,7 +462,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             Resolution: Resolution.Hourly.Name,
             StartDateTime: "2024-12-01T23:00:00Z",
             EndDateTime: "2024-12-02T23:00:00Z",
-            GridAccessProviderNumber: "5790002606892",
+            GridAccessProviderNumber: GridAccessProvider,
             DelegatedGridAreaCodes: null,
             MeteredDataList:
             [

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/ForwardMeteredDataBusinessValidatedDtoValidatorTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/ForwardMeteredDataBusinessValidatedDtoValidatorTests.cs
@@ -144,4 +144,38 @@ public class ForwardMeteredDataBusinessValidatedDtoValidatorTests
             .ContainSingle()
             .And.BeEquivalentTo(MeteringPointValidationRule.MeteringPointDoesntExistsError);
     }
+
+    [Fact]
+    public async Task Given_WrongMeteringPointOwner_When_Validate_Then_InvalidMeteringPointOwnershipValidationError()
+    {
+        var input = new ForwardMeteredDataInputV1Builder()
+            .WithGridAccessProviderNumber("1111111111111")
+            .Build();
+
+        var result = await _sut.ValidateAsync(
+            new ForwardMeteredDataBusinessValidatedDto(
+                Input: input,
+                MeteringPointMasterData:
+                [
+                    new MeteringPointMasterData(
+                        MeteringPointId: new MeteringPointId(input.MeteringPointId!),
+                        GridAreaCode: new GridAreaCode("804"),
+                        GridAccessProvider: ActorNumber.Create("9999999999999"),
+                        ConnectionState: ConnectionState.Connected,
+                        MeteringPointType: MeteringPointType.FromName(input.MeteringPointType!),
+                        MeteringPointSubType: MeteringPointSubType.Physical,
+                        MeasurementUnit: MeasurementUnit.FromName(input.MeasureUnit!),
+                        ValidFrom: SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        ValidTo: SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        NeighborGridAreaOwners: [],
+                        Resolution: Resolution.Hourly,
+                        ProductId: "product",
+                        ParentMeteringPointId: null,
+                        EnergySupplier: ActorNumber.Create("1111111111112")),
+                ]));
+
+        result.Should()
+            .ContainSingle()
+            .And.BeEquivalentTo(MeteringPointOwnershipValidationRule.MeteringPointHasWrongOwnerError);
+    }
 }

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRuleTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRuleTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
+using FluentAssertions;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_021.ForwardMeteredData.V1.
+    BusinessValidation;
+
+public class MeteringPointOwnershipValidationRuleTests
+{
+    private readonly MeteringPointOwnershipValidationRule _sut = new();
+
+    [Fact]
+    public async Task Given_NoMasterData_When_ValidateAsync_Then_NoError()
+    {
+        var result = await _sut.ValidateAsync(
+            new ForwardMeteredDataBusinessValidatedDto(
+                new ForwardMeteredDataInputV1Builder().Build(),
+                []));
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Given_MasterDataWithAtLeastOneWrongOwner_When_ValidateAsync_Then_Error()
+    {
+        var result = await _sut.ValidateAsync(
+            new ForwardMeteredDataBusinessValidatedDto(
+                new ForwardMeteredDataInputV1Builder().WithGridAccessProviderNumber("9999999999999").Build(),
+                [
+                    new MeteringPointMasterData(
+                        MeteringPointId: new MeteringPointId("1"),
+                        ValidFrom: DateTimeOffset.Now,
+                        ValidTo: DateTimeOffset.Now,
+                        GridAreaCode: new GridAreaCode("1"),
+                        GridAccessProvider: ActorNumber.Create("9999999999999"),
+                        NeighborGridAreaOwners: [],
+                        ConnectionState: ConnectionState.Connected,
+                        MeteringPointType: MeteringPointType.Consumption,
+                        MeteringPointSubType: MeteringPointSubType.Physical,
+                        Resolution: Resolution.Hourly,
+                        MeasurementUnit: MeasurementUnit.KilowattHour,
+                        ProductId: "1",
+                        ParentMeteringPointId: null,
+                        EnergySupplier: ActorNumber.Create("1111111111111")),
+                    new MeteringPointMasterData(
+                        MeteringPointId: new MeteringPointId("1"),
+                        ValidFrom: DateTimeOffset.Now,
+                        ValidTo: DateTimeOffset.Now,
+                        GridAreaCode: new GridAreaCode("1"),
+                        GridAccessProvider: ActorNumber.Create("8888888888888"),
+                        NeighborGridAreaOwners: [],
+                        ConnectionState: ConnectionState.Connected,
+                        MeteringPointType: MeteringPointType.Consumption,
+                        MeteringPointSubType: MeteringPointSubType.Physical,
+                        Resolution: Resolution.Hourly,
+                        MeasurementUnit: MeasurementUnit.KilowattHour,
+                        ProductId: "1",
+                        ParentMeteringPointId: null,
+                        EnergySupplier: ActorNumber.Create("1111111111111")),
+                ]));
+
+        result.Should().Contain(MeteringPointOwnershipValidationRule.MeteringPointHasWrongOwnerError);
+    }
+
+    [Fact]
+    public async Task Given_MasterDataWithCorrectOwner_When_ValidateAsync_Then_NoError()
+    {
+        var result = await _sut.ValidateAsync(
+            new ForwardMeteredDataBusinessValidatedDto(
+                new ForwardMeteredDataInputV1Builder().WithGridAccessProviderNumber("9999999999999").Build(),
+                [
+                    new MeteringPointMasterData(
+                        MeteringPointId: new MeteringPointId("1"),
+                        ValidFrom: DateTimeOffset.Now,
+                        ValidTo: DateTimeOffset.Now,
+                        GridAreaCode: new GridAreaCode("1"),
+                        GridAccessProvider: ActorNumber.Create("9999999999999"),
+                        NeighborGridAreaOwners: [],
+                        ConnectionState: ConnectionState.Connected,
+                        MeteringPointType: MeteringPointType.Consumption,
+                        MeteringPointSubType: MeteringPointSubType.Physical,
+                        Resolution: Resolution.Hourly,
+                        MeasurementUnit: MeasurementUnit.KilowattHour,
+                        ProductId: "1",
+                        ParentMeteringPointId: null,
+                        EnergySupplier: ActorNumber.Create("1111111111111")),
+                    new MeteringPointMasterData(
+                        MeteringPointId: new MeteringPointId("1"),
+                        ValidFrom: DateTimeOffset.Now,
+                        ValidTo: DateTimeOffset.Now,
+                        GridAreaCode: new GridAreaCode("1"),
+                        GridAccessProvider: ActorNumber.Create("9999999999999"),
+                        NeighborGridAreaOwners: [],
+                        ConnectionState: ConnectionState.Connected,
+                        MeteringPointType: MeteringPointType.Consumption,
+                        MeteringPointSubType: MeteringPointSubType.Physical,
+                        Resolution: Resolution.Hourly,
+                        MeasurementUnit: MeasurementUnit.KilowattHour,
+                        ProductId: "1",
+                        ParentMeteringPointId: null,
+                        EnergySupplier: ActorNumber.Create("1111111111111")),
+                ]));
+
+        result.Should().BeEmpty();
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRule.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Components.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Core.Application.FeatureFlags;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
+
+/// <summary>
+/// Business validation rule for metering point validation
+/// if the metering point does not exist, a business validation error is returned
+/// </summary>
+public class MeteringPointOwnershipValidationRule : IBusinessValidationRule<ForwardMeteredDataBusinessValidatedDto>
+{
+    public static IList<ValidationError> MeteringPointHasWrongOwnerError =>
+    [
+        new(
+            Message: "Forkert ejer af målepunktet / wrong owner of metering point",
+            ErrorCode: "D50"),
+    ];
+
+    private static IList<ValidationError> NoError => [];
+
+    public Task<IList<ValidationError>> ValidateAsync(
+        ForwardMeteredDataBusinessValidatedDto subject)
+    {
+        if (subject.MeteringPointMasterData
+            .Select(mpmd => mpmd.GridAccessProvider.Value)
+            .Any(gap => gap != subject.Input.GridAccessProviderNumber))
+        {
+            return Task.FromResult(MeteringPointHasWrongOwnerError);
+        }
+
+        return Task.FromResult(NoError);
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Ensure that the grid area owner in the input is in fact the grid area owner according to the relevant metering point master data.

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/437

## Checklist

- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task
