### PR TITLE
feat: Allow master data to have no energy suppliers

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
@@ -33,14 +33,12 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.B
     Justification = "Allow comments to increase readability")]
 public class MeteringPointMasterDataProviderTests
 {
-    private readonly ElectricityMarketViewsMock _electricityMarketViews;
     private readonly MeteringPointMasterDataProvider _sut;
 
     public MeteringPointMasterDataProviderTests()
     {
-        _electricityMarketViews = new ElectricityMarketViewsMock();
         _sut = new MeteringPointMasterDataProvider(
-            _electricityMarketViews,
+            new ElectricityMarketViewsMock(),
             new Mock<ILogger<MeteringPointMasterDataProvider>>().Object);
     }
 
@@ -60,7 +58,11 @@ public class MeteringPointMasterDataProviderTests
             "2021-01-01T00:00:00Z",
             "2021-01-01T00:00:00Z");
 
-        result.Should().BeEmpty();
+        var singleMasterData = result.Should().ContainSingle().Subject;
+        singleMasterData.MeteringPointId.Value.Should().Be("no-energy-suppliers-please");
+        singleMasterData.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        singleMasterData.ValidTo.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        singleMasterData.EnergySupplier.Should().BeNull();
     }
 
     [Fact]
@@ -78,7 +80,8 @@ public class MeteringPointMasterDataProviderTests
         singleMasterData.MeteringPointId.Value.Should().Be("one-energy-supplier-please");
         singleMasterData.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
         singleMasterData.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
-        singleMasterData.EnergySupplier.Value.Should().Be("1111111111111");
+        singleMasterData.EnergySupplier.Should().NotBeNull();
+        singleMasterData.EnergySupplier!.Value.Should().Be("1111111111111");
     }
 
     [Fact]
@@ -100,14 +103,16 @@ public class MeteringPointMasterDataProviderTests
                     first.MeteringPointId.Value.Should().Be("two-energy-suppliers-please");
                     first.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
                     first.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
-                    first.EnergySupplier.Value.Should().Be("1111111111111");
+                    first.EnergySupplier.Should().NotBeNull();
+                    first.EnergySupplier!.Value.Should().Be("1111111111111");
                 },
                 second =>
                 {
                     second.MeteringPointId.Value.Should().Be("two-energy-suppliers-please");
                     second.ValidFrom.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
                     second.ValidTo.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
-                    second.EnergySupplier.Value.Should().Be("2222222222222");
+                    second.EnergySupplier.Should().NotBeNull();
+                    second.EnergySupplier!.Value.Should().Be("2222222222222");
                 });
     }
 
@@ -130,28 +135,32 @@ public class MeteringPointMasterDataProviderTests
                     first.MeteringPointId.Value.Should().Be("two-master-data-with-two-energy-suppliers-please");
                     first.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
                     first.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
-                    first.EnergySupplier.Value.Should().Be("1111111111111");
+                    first.EnergySupplier.Should().NotBeNull();
+                    first.EnergySupplier!.Value.Should().Be("1111111111111");
                 },
                 second =>
                 {
                     second.MeteringPointId.Value.Should().Be("two-master-data-with-two-energy-suppliers-please");
                     second.ValidFrom.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
                     second.ValidTo.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
-                    second.EnergySupplier.Value.Should().Be("2222222222222");
+                    second.EnergySupplier.Should().NotBeNull();
+                    second.EnergySupplier!.Value.Should().Be("2222222222222");
                 },
                 third =>
                 {
                     third.MeteringPointId.Value.Should().Be("two-master-data-with-two-energy-suppliers-please");
                     third.ValidFrom.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
                     third.ValidTo.Should().Be(new DateTimeOffset(2021, 4, 1, 0, 0, 0, TimeSpan.Zero));
-                    third.EnergySupplier.Value.Should().Be("1111111111111");
+                    third.EnergySupplier.Should().NotBeNull();
+                    third.EnergySupplier!.Value.Should().Be("1111111111111");
                 },
                 fourth =>
                 {
                     fourth.MeteringPointId.Value.Should().Be("two-master-data-with-two-energy-suppliers-please");
                     fourth.ValidFrom.Should().Be(new DateTimeOffset(2021, 4, 1, 0, 0, 0, TimeSpan.Zero));
                     fourth.ValidTo.Should().Be(new DateTimeOffset(2021, 5, 1, 0, 0, 0, TimeSpan.Zero));
-                    fourth.EnergySupplier.Value.Should().Be("3333333333333");
+                    fourth.EnergySupplier.Should().NotBeNull();
+                    fourth.EnergySupplier!.Value.Should().Be("3333333333333");
                 });
     }
 
@@ -171,14 +180,23 @@ public class MeteringPointMasterDataProviderTests
                     first.MeteringPointId.Value.Should().Be("faulty-two-master-data-please");
                     first.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
                     first.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
-                    first.EnergySupplier.Value.Should().Be("1111111111111");
+                    first.EnergySupplier.Should().NotBeNull();
+                    first.EnergySupplier!.Value.Should().Be("1111111111111");
                 },
                 second =>
                 {
                     second.MeteringPointId.Value.Should().Be("faulty-two-master-data-please");
                     second.ValidFrom.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
                     second.ValidTo.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
-                    second.EnergySupplier.Value.Should().Be("2222222222222");
+                    second.EnergySupplier.Should().NotBeNull();
+                    second.EnergySupplier!.Value.Should().Be("2222222222222");
+                },
+                noEnergySupplier =>
+                {
+                    noEnergySupplier.MeteringPointId.Value.Should().Be("faulty-two-master-data-please");
+                    noEnergySupplier.ValidFrom.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
+                    noEnergySupplier.ValidTo.Should().Be(new DateTimeOffset(2021, 5, 1, 0, 0, 0, TimeSpan.Zero));
+                    noEnergySupplier.EnergySupplier.Should().BeNull();
                 });
     }
 
@@ -201,28 +219,32 @@ public class MeteringPointMasterDataProviderTests
                     first.MeteringPointId.Value.Should().Be("two-parents-please");
                     first.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
                     first.ValidTo.Should().Be(new DateTimeOffset(2021, 1, 16, 0, 0, 0, TimeSpan.Zero));
-                    first.EnergySupplier.Value.Should().Be("1212121212121");
+                    first.EnergySupplier.Should().NotBeNull();
+                    first.EnergySupplier!.Value.Should().Be("1212121212121");
                 },
                 second =>
                 {
                     second.MeteringPointId.Value.Should().Be("two-parents-please");
                     second.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 16, 0, 0, 0, TimeSpan.Zero));
                     second.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
-                    second.EnergySupplier.Value.Should().Be("2323232323232");
+                    second.EnergySupplier.Should().NotBeNull();
+                    second.EnergySupplier!.Value.Should().Be("2323232323232");
                 },
                 third =>
                 {
                     third.MeteringPointId.Value.Should().Be("two-parents-please");
                     third.ValidFrom.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
                     third.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 16, 0, 0, 0, TimeSpan.Zero));
-                    third.EnergySupplier.Value.Should().Be("3434343434343");
+                    third.EnergySupplier.Should().NotBeNull();
+                    third.EnergySupplier!.Value.Should().Be("3434343434343");
                 },
                 fourth =>
                 {
                     fourth.MeteringPointId.Value.Should().Be("two-parents-please");
                     fourth.ValidFrom.Should().Be(new DateTimeOffset(2021, 2, 16, 0, 0, 0, TimeSpan.Zero));
                     fourth.ValidTo.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
-                    fourth.EnergySupplier.Value.Should().Be("4545454545454");
+                    fourth.EnergySupplier.Should().NotBeNull();
+                    fourth.EnergySupplier!.Value.Should().Be("4545454545454");
                 },
                 // Master data from second parent
                 first =>
@@ -230,28 +252,32 @@ public class MeteringPointMasterDataProviderTests
                     first.MeteringPointId.Value.Should().Be("two-parents-please");
                     first.ValidFrom.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
                     first.ValidTo.Should().Be(new DateTimeOffset(2021, 3, 16, 0, 0, 0, TimeSpan.Zero));
-                    first.EnergySupplier.Value.Should().Be("9090909090909");
+                    first.EnergySupplier.Should().NotBeNull();
+                    first.EnergySupplier!.Value.Should().Be("9090909090909");
                 },
                 second =>
                 {
                     second.MeteringPointId.Value.Should().Be("two-parents-please");
                     second.ValidFrom.Should().Be(new DateTimeOffset(2021, 3, 16, 0, 0, 0, TimeSpan.Zero));
                     second.ValidTo.Should().Be(new DateTimeOffset(2021, 4, 1, 0, 0, 0, TimeSpan.Zero));
-                    second.EnergySupplier.Value.Should().Be("8989898989898");
+                    second.EnergySupplier.Should().NotBeNull();
+                    second.EnergySupplier!.Value.Should().Be("8989898989898");
                 },
                 third =>
                 {
                     third.MeteringPointId.Value.Should().Be("two-parents-please");
                     third.ValidFrom.Should().Be(new DateTimeOffset(2021, 4, 1, 0, 0, 0, TimeSpan.Zero));
                     third.ValidTo.Should().Be(new DateTimeOffset(2021, 4, 16, 0, 0, 0, TimeSpan.Zero));
-                    third.EnergySupplier.Value.Should().Be("7878787878787");
+                    third.EnergySupplier.Should().NotBeNull();
+                    third.EnergySupplier!.Value.Should().Be("7878787878787");
                 },
                 fourth =>
                 {
                     fourth.MeteringPointId.Value.Should().Be("two-parents-please");
                     fourth.ValidFrom.Should().Be(new DateTimeOffset(2021, 4, 16, 0, 0, 0, TimeSpan.Zero));
                     fourth.ValidTo.Should().Be(new DateTimeOffset(2021, 5, 1, 0, 0, 0, TimeSpan.Zero));
-                    fourth.EnergySupplier.Value.Should().Be("6767676767676");
+                    fourth.EnergySupplier.Should().NotBeNull();
+                    fourth.EnergySupplier!.Value.Should().Be("6767676767676");
                 });
     }
 
@@ -275,28 +301,32 @@ public class MeteringPointMasterDataProviderTests
                     first.MeteringPointId.Value.Should().Be("period-without-and-period-with-parent-please");
                     first.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
                     first.ValidTo.Should().Be(new DateTimeOffset(2021, 1, 16, 0, 0, 0, TimeSpan.Zero));
-                    first.EnergySupplier.Value.Should().Be("1212121212121");
+                    first.EnergySupplier.Should().NotBeNull();
+                    first.EnergySupplier!.Value.Should().Be("1212121212121");
                 },
                 second =>
                 {
                     second.MeteringPointId.Value.Should().Be("period-without-and-period-with-parent-please");
                     second.ValidFrom.Should().Be(new DateTimeOffset(2021, 1, 16, 0, 0, 0, TimeSpan.Zero));
                     second.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
-                    second.EnergySupplier.Value.Should().Be("2323232323232");
+                    second.EnergySupplier.Should().NotBeNull();
+                    second.EnergySupplier!.Value.Should().Be("2323232323232");
                 },
                 third =>
                 {
                     third.MeteringPointId.Value.Should().Be("period-without-and-period-with-parent-please");
                     third.ValidFrom.Should().Be(new DateTimeOffset(2021, 2, 1, 0, 0, 0, TimeSpan.Zero));
                     third.ValidTo.Should().Be(new DateTimeOffset(2021, 2, 16, 0, 0, 0, TimeSpan.Zero));
-                    third.EnergySupplier.Value.Should().Be("3434343434343");
+                    third.EnergySupplier.Should().NotBeNull();
+                    third.EnergySupplier!.Value.Should().Be("3434343434343");
                 },
                 fourth =>
                 {
                     fourth.MeteringPointId.Value.Should().Be("period-without-and-period-with-parent-please");
                     fourth.ValidFrom.Should().Be(new DateTimeOffset(2021, 2, 16, 0, 0, 0, TimeSpan.Zero));
                     fourth.ValidTo.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
-                    fourth.EnergySupplier.Value.Should().Be("4545454545454");
+                    fourth.EnergySupplier.Should().NotBeNull();
+                    fourth.EnergySupplier!.Value.Should().Be("4545454545454");
                 },
                 // Master data from metering point (no parent id in this period)
                 first =>
@@ -304,14 +334,16 @@ public class MeteringPointMasterDataProviderTests
                     first.MeteringPointId.Value.Should().Be("period-without-and-period-with-parent-please");
                     first.ValidFrom.Should().Be(new DateTimeOffset(2021, 3, 1, 0, 0, 0, TimeSpan.Zero));
                     first.ValidTo.Should().Be(new DateTimeOffset(2021, 4, 1, 0, 0, 0, TimeSpan.Zero));
-                    first.EnergySupplier.Value.Should().Be("1111111111111");
+                    first.EnergySupplier.Should().NotBeNull();
+                    first.EnergySupplier!.Value.Should().Be("1111111111111");
                 },
                 second =>
                 {
                     second.MeteringPointId.Value.Should().Be("period-without-and-period-with-parent-please");
                     second.ValidFrom.Should().Be(new DateTimeOffset(2021, 4, 1, 0, 0, 0, TimeSpan.Zero));
                     second.ValidTo.Should().Be(new DateTimeOffset(2021, 5, 1, 0, 0, 0, TimeSpan.Zero));
-                    second.EnergySupplier.Value.Should().Be("3333333333333");
+                    second.EnergySupplier.Should().NotBeNull();
+                    second.EnergySupplier!.Value.Should().Be("3333333333333");
                 });
     }
 

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
@@ -166,7 +166,7 @@ public class MeteringPointMasterDataProviderTests
 
     [Fact]
     public async Task
-        Given_TwoMasterDataWithOneFaultyEnergySuppliers_When_GetMasterData_Then_NonFaultMasterDataReturned()
+        Given_TwoMasterDataWithOneFaultyEnergySuppliers_When_GetMasterData_Then_AllMasterDataReturned()
     {
         var result = await _sut.GetMasterData(
             "faulty-two-master-data-please",

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProvider.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProvider.cs
@@ -153,43 +153,20 @@ public class MeteringPointMasterDataProvider(
         {
             return
             [
-                new PMMeteringPointMasterData(
-                    new MeteringPointId(meteringPointMasterData.Identification.Value),
+                CreatePMMeteringPointMasterData(
+                    meteringPointMasterData,
                     meteringPointMasterData.ValidFrom.ToDateTimeOffset(),
-                    meteringPointMasterData.ValidTo.ToDateTimeOffset(),
-                    new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
-                    ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
-                    meteringPointMasterData.NeighborGridAreaOwners,
-                    MeteringPointMasterDataMapper.ConnectionStateMap.Map(meteringPointMasterData.ConnectionState),
-                    MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(meteringPointMasterData.Type),
-                    MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(meteringPointMasterData.SubType),
-                    MeteringPointMasterDataMapper.ResolutionMap.Map(meteringPointMasterData.Resolution.Value),
-                    MeteringPointMasterDataMapper.MeasureUnitMap.Map(meteringPointMasterData.Unit),
-                    meteringPointMasterData.ProductId.ToString(),
-                    null,
-                    null),
+                    meteringPointMasterData.ValidTo.ToDateTimeOffset()),
             ];
         }
 
         return meteringPointMasterData.EnergySuppliers
             .Select(
                 meteringPointEnergySupplier =>
-                    new PMMeteringPointMasterData(
-                        new MeteringPointId(meteringPointMasterData.Identification.Value),
+                    CreatePMMeteringPointMasterData(
+                        meteringPointMasterData,
                         meteringPointEnergySupplier.StartDate.ToDateTimeOffset(),
                         meteringPointEnergySupplier.EndDate.ToDateTimeOffset(),
-                        new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
-                        ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
-                        meteringPointMasterData.NeighborGridAreaOwners,
-                        MeteringPointMasterDataMapper.ConnectionStateMap.Map(
-                            meteringPointMasterData.ConnectionState),
-                        MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(
-                            meteringPointMasterData.Type),
-                        MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(
-                            meteringPointMasterData.SubType),
-                        MeteringPointMasterDataMapper.ResolutionMap.Map(meteringPointMasterData.Resolution.Value),
-                        MeteringPointMasterDataMapper.MeasureUnitMap.Map(meteringPointMasterData.Unit),
-                        meteringPointMasterData.ProductId.ToString(),
                         null,
                         ActorNumber.Create(meteringPointEnergySupplier.EnergySupplier)))
             .ToList()
@@ -207,50 +184,44 @@ public class MeteringPointMasterDataProvider(
                         {
                             return
                             [
-                                new PMMeteringPointMasterData(
-                                    new MeteringPointId(meteringPointMasterData.Identification.Value),
+                                CreatePMMeteringPointMasterData(
+                                    meteringPointMasterData,
                                     mpmd.ValidFrom.ToDateTimeOffset(),
                                     mpmd.ValidTo.ToDateTimeOffset(),
-                                    new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
-                                    ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
-                                    meteringPointMasterData.NeighborGridAreaOwners,
-                                    MeteringPointMasterDataMapper.ConnectionStateMap.Map(
-                                        meteringPointMasterData.ConnectionState),
-                                    MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(meteringPointMasterData.Type),
-                                    MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(
-                                        meteringPointMasterData.SubType),
-                                    MeteringPointMasterDataMapper.ResolutionMap.Map(
-                                        meteringPointMasterData.Resolution.Value),
-                                    MeteringPointMasterDataMapper.MeasureUnitMap.Map(meteringPointMasterData.Unit),
-                                    meteringPointMasterData.ProductId.ToString(),
-                                    new MeteringPointId(mpmd.Identification.Value),
-                                    null),
+                                    new MeteringPointId(mpmd.Identification.Value)),
                             ];
                         }
 
                         return mpmd.EnergySuppliers
                             .Select(
-                                mpes => new PMMeteringPointMasterData(
-                                    new MeteringPointId(meteringPointMasterData.Identification.Value),
+                                mpes => CreatePMMeteringPointMasterData(
+                                    meteringPointMasterData,
                                     mpes.StartDate.ToDateTimeOffset(),
                                     mpes.EndDate.ToDateTimeOffset(),
-                                    new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
-                                    ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
-                                    meteringPointMasterData.NeighborGridAreaOwners,
-                                    MeteringPointMasterDataMapper.ConnectionStateMap.Map(
-                                        meteringPointMasterData.ConnectionState),
-                                    MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(
-                                        meteringPointMasterData.Type),
-                                    MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(
-                                        meteringPointMasterData.SubType),
-                                    MeteringPointMasterDataMapper.ResolutionMap.Map(
-                                        meteringPointMasterData.Resolution.Value),
-                                    MeteringPointMasterDataMapper.MeasureUnitMap.Map(
-                                        meteringPointMasterData.Unit),
-                                    meteringPointMasterData.ProductId.ToString(),
                                     new MeteringPointId(mpmd.Identification.Value),
                                     ActorNumber.Create(mpes.EnergySupplier)));
                     })
                 .ToList()
                 .AsReadOnly();
+
+    private PMMeteringPointMasterData CreatePMMeteringPointMasterData(
+        MeteringPointMasterData meteringPointMasterData,
+        DateTimeOffset validFrom,
+        DateTimeOffset validTo,
+        MeteringPointId? parentId = null,
+        ActorNumber? energySupplier = null) => new(
+        new MeteringPointId(meteringPointMasterData.Identification.Value),
+        validFrom,
+        validTo,
+        new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
+        ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
+        meteringPointMasterData.NeighborGridAreaOwners,
+        MeteringPointMasterDataMapper.ConnectionStateMap.Map(meteringPointMasterData.ConnectionState),
+        MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(meteringPointMasterData.Type),
+        MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(meteringPointMasterData.SubType),
+        MeteringPointMasterDataMapper.ResolutionMap.Map(meteringPointMasterData.Resolution.Value),
+        MeteringPointMasterDataMapper.MeasureUnitMap.Map(meteringPointMasterData.Unit),
+        meteringPointMasterData.ProductId.ToString(),
+        parentId,
+        energySupplier);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProvider.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProvider.cs
@@ -148,58 +148,110 @@ public class MeteringPointMasterDataProvider(
             : FlattenMasterDataForParent(meteringPointMasterData);
 
     private IReadOnlyCollection<PMMeteringPointMasterData> FlattenMasterDataForParent(
-        MeteringPointMasterData meteringPointMasterData) =>
-        meteringPointMasterData.EnergySuppliers
-                .Select(
-                    meteringPointEnergySupplier =>
-                        new PMMeteringPointMasterData(
-                            new MeteringPointId(meteringPointMasterData.Identification.Value),
-                            meteringPointEnergySupplier.StartDate.ToDateTimeOffset(),
-                            meteringPointEnergySupplier.EndDate.ToDateTimeOffset(),
-                            new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
-                            ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
-                            meteringPointMasterData.NeighborGridAreaOwners,
-                            MeteringPointMasterDataMapper.ConnectionStateMap.Map(
-                                meteringPointMasterData.ConnectionState),
-                            MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(
-                                meteringPointMasterData.Type),
-                            MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(
-                                meteringPointMasterData.SubType),
-                            MeteringPointMasterDataMapper.ResolutionMap.Map(meteringPointMasterData.Resolution.Value),
-                            MeteringPointMasterDataMapper.MeasureUnitMap.Map(meteringPointMasterData.Unit),
-                            meteringPointMasterData.ProductId.ToString(),
-                            null,
-                            ActorNumber.Create(meteringPointEnergySupplier.EnergySupplier)))
-                .ToList()
-                .AsReadOnly();
+        MeteringPointMasterData meteringPointMasterData)
+    {
+        if (meteringPointMasterData.EnergySuppliers.Count <= 0)
+        {
+            return
+            [
+                new PMMeteringPointMasterData(
+                    new MeteringPointId(meteringPointMasterData.Identification.Value),
+                    meteringPointMasterData.ValidFrom.ToDateTimeOffset(),
+                    meteringPointMasterData.ValidTo.ToDateTimeOffset(),
+                    new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
+                    ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
+                    meteringPointMasterData.NeighborGridAreaOwners,
+                    MeteringPointMasterDataMapper.ConnectionStateMap.Map(meteringPointMasterData.ConnectionState),
+                    MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(meteringPointMasterData.Type),
+                    MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(meteringPointMasterData.SubType),
+                    MeteringPointMasterDataMapper.ResolutionMap.Map(meteringPointMasterData.Resolution.Value),
+                    MeteringPointMasterDataMapper.MeasureUnitMap.Map(meteringPointMasterData.Unit),
+                    meteringPointMasterData.ProductId.ToString(),
+                    null,
+                    null),
+            ];
+        }
+
+        return meteringPointMasterData.EnergySuppliers
+            .Select(
+                meteringPointEnergySupplier =>
+                    new PMMeteringPointMasterData(
+                        new MeteringPointId(meteringPointMasterData.Identification.Value),
+                        meteringPointEnergySupplier.StartDate.ToDateTimeOffset(),
+                        meteringPointEnergySupplier.EndDate.ToDateTimeOffset(),
+                        new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
+                        ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
+                        meteringPointMasterData.NeighborGridAreaOwners,
+                        MeteringPointMasterDataMapper.ConnectionStateMap.Map(
+                            meteringPointMasterData.ConnectionState),
+                        MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(
+                            meteringPointMasterData.Type),
+                        MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(
+                            meteringPointMasterData.SubType),
+                        MeteringPointMasterDataMapper.ResolutionMap.Map(meteringPointMasterData.Resolution.Value),
+                        MeteringPointMasterDataMapper.MeasureUnitMap.Map(meteringPointMasterData.Unit),
+                        meteringPointMasterData.ProductId.ToString(),
+                        null,
+                        ActorNumber.Create(meteringPointEnergySupplier.EnergySupplier)))
+            .ToList()
+            .AsReadOnly();
+    }
 
     private IReadOnlyCollection<PMMeteringPointMasterData> FlattenMasterDataForChild(
         MeteringPointMasterData meteringPointMasterData,
         IReadOnlyDictionary<string, IReadOnlyCollection<MeteringPointMasterData>> parentMeteringPointMasterData) =>
         parentMeteringPointMasterData[meteringPointMasterData.ParentIdentification!.Value]
                 .SelectMany(
-                    mpmd => mpmd.EnergySuppliers
-                        .Select(
-                            mpes => new PMMeteringPointMasterData(
-                                new MeteringPointId(meteringPointMasterData.Identification.Value),
-                                mpes.StartDate.ToDateTimeOffset(),
-                                mpes.EndDate.ToDateTimeOffset(),
-                                new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
-                                ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
-                                meteringPointMasterData.NeighborGridAreaOwners,
-                                MeteringPointMasterDataMapper.ConnectionStateMap.Map(
-                                    meteringPointMasterData.ConnectionState),
-                                MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(
-                                    meteringPointMasterData.Type),
-                                MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(
-                                    meteringPointMasterData.SubType),
-                                MeteringPointMasterDataMapper.ResolutionMap.Map(
-                                    meteringPointMasterData.Resolution.Value),
-                                MeteringPointMasterDataMapper.MeasureUnitMap.Map(
-                                    meteringPointMasterData.Unit),
-                                meteringPointMasterData.ProductId.ToString(),
-                                new MeteringPointId(mpmd.Identification.Value),
-                                ActorNumber.Create(mpes.EnergySupplier))))
+                    mpmd =>
+                    {
+                        if (mpmd.EnergySuppliers.Count <= 0)
+                        {
+                            return
+                            [
+                                new PMMeteringPointMasterData(
+                                    new MeteringPointId(meteringPointMasterData.Identification.Value),
+                                    mpmd.ValidFrom.ToDateTimeOffset(),
+                                    mpmd.ValidTo.ToDateTimeOffset(),
+                                    new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
+                                    ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
+                                    meteringPointMasterData.NeighborGridAreaOwners,
+                                    MeteringPointMasterDataMapper.ConnectionStateMap.Map(
+                                        meteringPointMasterData.ConnectionState),
+                                    MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(meteringPointMasterData.Type),
+                                    MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(
+                                        meteringPointMasterData.SubType),
+                                    MeteringPointMasterDataMapper.ResolutionMap.Map(
+                                        meteringPointMasterData.Resolution.Value),
+                                    MeteringPointMasterDataMapper.MeasureUnitMap.Map(meteringPointMasterData.Unit),
+                                    meteringPointMasterData.ProductId.ToString(),
+                                    new MeteringPointId(mpmd.Identification.Value),
+                                    null),
+                            ];
+                        }
+
+                        return mpmd.EnergySuppliers
+                            .Select(
+                                mpes => new PMMeteringPointMasterData(
+                                    new MeteringPointId(meteringPointMasterData.Identification.Value),
+                                    mpes.StartDate.ToDateTimeOffset(),
+                                    mpes.EndDate.ToDateTimeOffset(),
+                                    new PMGridAreaCode(meteringPointMasterData.GridAreaCode.Value),
+                                    ActorNumber.Create(meteringPointMasterData.GridAccessProvider),
+                                    meteringPointMasterData.NeighborGridAreaOwners,
+                                    MeteringPointMasterDataMapper.ConnectionStateMap.Map(
+                                        meteringPointMasterData.ConnectionState),
+                                    MeteringPointMasterDataMapper.MeteringPointTypeMap.Map(
+                                        meteringPointMasterData.Type),
+                                    MeteringPointMasterDataMapper.MeteringPointSubTypeMap.Map(
+                                        meteringPointMasterData.SubType),
+                                    MeteringPointMasterDataMapper.ResolutionMap.Map(
+                                        meteringPointMasterData.Resolution.Value),
+                                    MeteringPointMasterDataMapper.MeasureUnitMap.Map(
+                                        meteringPointMasterData.Unit),
+                                    meteringPointMasterData.ProductId.ToString(),
+                                    new MeteringPointId(mpmd.Identification.Value),
+                                    ActorNumber.Create(mpes.EnergySupplier)));
+                    })
                 .ToList()
                 .AsReadOnly();
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointReceiversProvider.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointReceiversProvider.cs
@@ -209,7 +209,11 @@ public class MeteringPointReceiversProvider(
         {
             case var _ when meteringPointType == MeteringPointType.Consumption:
             case var _ when meteringPointType == MeteringPointType.Production:
-                receivers.Add(EnergySupplierReceiver(meteringPointMasterData.EnergySupplier));
+                if (meteringPointMasterData.EnergySupplier is not null)
+                {
+                    receivers.Add(EnergySupplierReceiver(meteringPointMasterData.EnergySupplier));
+                }
+
                 receivers.Add(DanishEnergyAgencyReceiver());
                 break;
             case var _ when meteringPointType == MeteringPointType.Exchange:
@@ -221,7 +225,12 @@ public class MeteringPointReceiversProvider(
             case var _ when meteringPointType == MeteringPointType.VeProduction:
                 receivers.Add(SystemOperatorReceiver());
                 receivers.Add(DanishEnergyAgencyReceiver());
-                receivers.Add(EnergySupplierReceiver(meteringPointMasterData.EnergySupplier));
+
+                if (meteringPointMasterData.EnergySupplier is not null)
+                {
+                    receivers.Add(EnergySupplierReceiver(meteringPointMasterData.EnergySupplier));
+                }
+
                 break;
             case var _ when meteringPointType == MeteringPointType.NetProduction:
             case var _ when meteringPointType == MeteringPointType.SupplyToGrid:
@@ -242,7 +251,12 @@ public class MeteringPointReceiversProvider(
             case var _ when meteringPointType == MeteringPointType.CollectiveNetConsumption:
                 if (meteringPointMasterData.ParentMeteringPointId is not null)
                 {
-                    receivers.Add(EnergySupplierReceiver(meteringPointMasterData.EnergySupplier));
+                    // It is legal for the energy supplier to be null for these metering point types
+                    // It is however not legal for the parent metering point to be null
+                    if (meteringPointMasterData.EnergySupplier is not null)
+                    {
+                        receivers.Add(EnergySupplierReceiver(meteringPointMasterData.EnergySupplier));
+                    }
                 }
                 else
                 {

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointMasterData.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Model/MeteringPointMasterData.cs
@@ -32,6 +32,6 @@ public sealed record MeteringPointMasterData(
     MeasurementUnit MeasurementUnit,
     string ProductId,
     MeteringPointId? ParentMeteringPointId,
-    ActorNumber EnergySupplier);
+    ActorNumber? EnergySupplier);
 
 public record GridAreaCode(string Value);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

It is a valid and plausible scenario, that a metering point, for a brief period, does not have an attached energy supplier. In this case we must still validate the master data and continue the flow as usual, with the implicit change, that we do not forward the metered data to any energy supplier in this period.

## Co-pilot summary

This pull request includes several changes to the `MeteringPointMasterDataProviderTests` and related classes to improve the handling of energy supplier data and ensure null checks are properly implemented. The most important changes include updating test assertions, modifying methods to handle cases with no energy suppliers, and adding null checks before accessing energy supplier properties.

### Test Improvements:
* Updated assertions in `MeteringPointMasterDataProviderTests` to check for null values and ensure energy supplier data is correctly validated in various test cases. [[1]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L63-R65) [[2]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L81-R84) [[3]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L103-R115) [[4]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L133-R163) [[5]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L174-R199) [[6]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L204-R280) [[7]](diffhunk://#diff-3023eedb6d459bf692a7163cd6bc4643d62f05964d8615d467481326b316c305L278-R346)

### Codebase Enhancements:
* Modified `FlattenMasterDataForParent` and `FlattenMasterDataForChild` methods in `MeteringPointMasterDataProvider` to handle cases with no energy suppliers and return appropriate data structures. [[1]](diffhunk://#diff-3129b674d990c9bcefa2c2fdc518d259f5e64f74e40a54af47301b89b9894b31L151-R175) [[2]](diffhunk://#diff-3129b674d990c9bcefa2c2fdc518d259f5e64f74e40a54af47301b89b9894b31R198-R232) [[3]](diffhunk://#diff-3129b674d990c9bcefa2c2fdc518d259f5e64f74e40a54af47301b89b9894b31L202-R254)
* Added null checks in `GetReceiversFromMasterData` method in `MeteringPointReceiversProvider` to ensure energy supplier data is only accessed when it is present.

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/613

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
