### PR TITLE
fix: issue with instant parsing for ebix with fractional seconds

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/Extensions/InstantPatternWithOptionalSecondsTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/Extensions/InstantPatternWithOptionalSecondsTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Extensions;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_021.ForwardMeteredData.V1.Extensions;
+
+public class InstantPatternWithOptionalSecondsTests
+{
+    [Theory]
+    [InlineData("2025-03-17T11:13Z", true)] // Valid Cim format
+    [InlineData("2025-03-17T11:13:48Z", true)] // Valid Ebix format
+    [InlineData("2025-03-17T11:13:48.1955802Z", true)] // Valid Ebix format
+    [InlineData("2025-03-17T11:13:48.1955802", false)]
+    [InlineData("2025-03-17 11:13:48.1955802Z", false)]
+    [InlineData("2025-03-17T11:13:48.1955802+00:00", false)]
+    public void Parse_ShouldReturnExpectedResult(string dateTime, bool isValid)
+    {
+        // Act
+        var result = InstantPatternWithOptionalSeconds.Parse(dateTime);
+
+        // Assert
+        if (isValid)
+        {
+            Assert.True(result.Success);
+        }
+        else
+        {
+            Assert.False(result.Success);
+        }
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Extensions/InstantPatternWithOptionalSeconds.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Extensions/InstantPatternWithOptionalSeconds.cs
@@ -22,8 +22,11 @@ public class InstantPatternWithOptionalSeconds
 {
     /// <summary>
     /// Supported formats:
+    /// Cim formats
     /// yyyy-MM-ddTHH:mm'Z'
+    /// Ebix formats
     /// yyyy-MM-ddTHH:mm:ss'Z'
+    /// yyyy-MM-ddTHH:mm:ss.fffffff'Z'
     /// </summary>
     /// <param name="dateTime"></param>
     public static ParseResult<Instant> Parse(string dateTime)
@@ -34,6 +37,8 @@ public class InstantPatternWithOptionalSeconds
                 { InstantPattern.Create("yyyy-MM-ddTHH:mm'Z'", CultureInfo.InvariantCulture), _ => false },
                 // allowed to incl seconds
                 { InstantPattern.Create("yyyy-MM-ddTHH:mm:ss'Z'", CultureInfo.InvariantCulture), _ => false },
+                // allowed to incl seconds and fractional seconds
+                { InstantPattern.Create("yyyy-MM-ddTHH:mm:ss.fffffff'Z'", CultureInfo.InvariantCulture), _ => false },
             }
             .Build();
         return pattern.Parse(dateTime);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Fix: None of the specified formats matches the given value string. Value being parsed: '^2025-03-17T11:13:48.1955802Z'. (^ indicates error position.)

When Process Manager parses the string representation of a date.

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/14128489782
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
