### PR TITLE
refac: Rename to StepInstanceTerminationState

### DIFF
--- a/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Client Release Notes
 
+## Version 3.0.0
+
+- Renamed OrchestrationStepTerminationState` to `StepInstanceTerminationState` in domain and API model.
+
 ## Version 2.1.2
 
 - No functional changes.

--- a/docs/ProcessManager.Components.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Components.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Components.Abstractions Release Notes
 
+## Version 1.4.0
+
+- Update NuGet packages.
+
 ## Version 1.3.8
 
 - No functional changes.

--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,6 +1,6 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
-## Version 1.2.0
+## Version 1.14.0
 
 - Update NuGet packages.
 

--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
+## Version 1.2.0
+
+- Update NuGet packages.
+
 ## Version 1.13.0
 
 - Add BRS-045 Missing Measurements Log On Demand Calculation command.

--- a/source/ProcessManager.Abstractions/Api/Model/OrchestrationInstance/StepInstanceLifecycleDto.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/OrchestrationInstance/StepInstanceLifecycleDto.cs
@@ -23,6 +23,6 @@ namespace Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationI
 /// <param name="TerminatedAt">The time when the Process Manager was used from Durable Functions to transition the state to Terminated.</param>
 public record StepInstanceLifecycleDto(
     StepInstanceLifecycleState State,
-    OrchestrationStepTerminationState? TerminationState,
+    StepInstanceTerminationState? TerminationState,
     DateTimeOffset? StartedAt,
     DateTimeOffset? TerminatedAt);

--- a/source/ProcessManager.Abstractions/Api/Model/OrchestrationInstance/StepInstanceLifecycleState.cs
+++ b/source/ProcessManager.Abstractions/Api/Model/OrchestrationInstance/StepInstanceLifecycleState.cs
@@ -31,12 +31,12 @@ public enum StepInstanceLifecycleState
 
     /// <summary>
     /// A Durable Functions activity has transitioned the orchestration step into terminated.
-    /// See <see cref="OrchestrationStepTerminationState"/> for details.
+    /// See <see cref="StepInstanceTerminationState"/> for details.
     /// </summary>
     Terminated = 3,
 }
 
-public enum OrchestrationStepTerminationState
+public enum StepInstanceTerminationState
 {
     Succeeded = 1,
 

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Abstractions</PackageId>
-    <PackageVersion>2.1.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Client</PackageId>
-    <PackageVersion>2.1.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Components.Abstractions/ProcessManager.Components.Abstractions.csproj
+++ b/source/ProcessManager.Components.Abstractions/ProcessManager.Components.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Components.Abstractions</PackageId>
-    <PackageVersion>1.3.8$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.4.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Components Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Core/Domain/OrchestrationInstance/OrchestrationInstance.cs
+++ b/source/ProcessManager.Core/Domain/OrchestrationInstance/OrchestrationInstance.cs
@@ -165,7 +165,7 @@ public class OrchestrationInstance
     /// <param name="terminationState">The state of the termination step (Succeeded, failed etc.)</param>
     /// <param name="clock"></param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if a step with the given <paramref name="sequence"/> isn't found.</exception>
-    public void TransitionStepToTerminated(int sequence, OrchestrationStepTerminationState terminationState, IClock clock)
+    public void TransitionStepToTerminated(int sequence, StepInstanceTerminationState terminationState, IClock clock)
     {
         var step = GetStep(sequence);
         step.Lifecycle.TransitionToTerminated(clock, terminationState);
@@ -219,7 +219,7 @@ public class OrchestrationInstance
 
             if (skipStepsBySequence.Contains(stepInstance.Sequence))
             {
-                stepInstance.Lifecycle.TransitionToTerminated(clock, OrchestrationStepTerminationState.Skipped);
+                stepInstance.Lifecycle.TransitionToTerminated(clock, StepInstanceTerminationState.Skipped);
             }
 
             orchestrationInstance._steps.Add(stepInstance);

--- a/source/ProcessManager.Core/Domain/OrchestrationInstance/StepInstance.cs
+++ b/source/ProcessManager.Core/Domain/OrchestrationInstance/StepInstance.cs
@@ -82,6 +82,6 @@ public class StepInstance
 
     public bool IsSkipped()
     {
-        return Lifecycle.TerminationState == OrchestrationStepTerminationState.Skipped;
+        return Lifecycle.TerminationState == StepInstanceTerminationState.Skipped;
     }
 }

--- a/source/ProcessManager.Core/Domain/OrchestrationInstance/StepInstanceLifecycle.cs
+++ b/source/ProcessManager.Core/Domain/OrchestrationInstance/StepInstanceLifecycle.cs
@@ -27,7 +27,7 @@ public class StepInstanceLifecycle
 
     public StepInstanceLifecycleState State { get; private set; }
 
-    public OrchestrationStepTerminationState? TerminationState { get; private set; }
+    public StepInstanceTerminationState? TerminationState { get; private set; }
 
     /// <summary>
     /// The time when the Process Manager was used from Durable Functions to
@@ -57,17 +57,17 @@ public class StepInstanceLifecycle
         StartedAt = clock.GetCurrentInstant();
     }
 
-    public void TransitionToTerminated(IClock clock, OrchestrationStepTerminationState terminationState)
+    public void TransitionToTerminated(IClock clock, StepInstanceTerminationState terminationState)
     {
         switch (terminationState)
         {
-            case OrchestrationStepTerminationState.Succeeded:
-            case OrchestrationStepTerminationState.Failed:
+            case StepInstanceTerminationState.Succeeded:
+            case StepInstanceTerminationState.Failed:
                 if (State is not StepInstanceLifecycleState.Running)
                     throw new InvalidOperationException($"Cannot change termination state to '{terminationState}' when '{State}'.");
                 break;
 
-            case OrchestrationStepTerminationState.Skipped:
+            case StepInstanceTerminationState.Skipped:
                 if (State is not StepInstanceLifecycleState.Pending)
                     throw new InvalidOperationException($"Cannot change termination state to '{terminationState}' when '{State}'.");
                 if (CanBeSkipped == false)

--- a/source/ProcessManager.Core/Domain/OrchestrationInstance/StepInstanceLifecycleState.cs
+++ b/source/ProcessManager.Core/Domain/OrchestrationInstance/StepInstanceLifecycleState.cs
@@ -31,12 +31,12 @@ public enum StepInstanceLifecycleState
 
     /// <summary>
     /// A Durable Functions activity has transitioned the orchestration step into terminated.
-    /// See <see cref="OrchestrationStepTerminationState"/> for details.
+    /// See <see cref="StepInstanceTerminationState"/> for details.
     /// </summary>
     Terminated = 3,
 }
 
-public enum OrchestrationStepTerminationState
+public enum StepInstanceTerminationState
 {
     Succeeded = 1,
 

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_101/UpdateMeteringPointsConnectionState/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_101/UpdateMeteringPointsConnectionState/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -169,7 +169,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 
@@ -243,7 +243,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Failed);
+                        .And.Be(StepInstanceTerminationState.Failed);
                 },
                 s =>
                 {
@@ -251,7 +251,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/ActorRequestProcessExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/ActorRequestProcessExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -130,7 +130,7 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 
@@ -181,7 +181,7 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
                     validationStep.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     validationStep.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Failed);
+                        .And.Be(StepInstanceTerminationState.Failed);
 
                     var customState = JsonSerializer.Deserialize<BusinessValidationStep.CustomState>(validationStep.CustomState);
                     customState.Should().NotBeNull();
@@ -194,7 +194,7 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
                     enqueueStep.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     enqueueStep.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 }

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X03/FailingOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X03/FailingOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -126,12 +126,12 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
             successStep =>
             {
                 successStep.Sequence.Should().Be(SuccessStep.StepSequence);
-                successStep.Lifecycle.TerminationState.Should().Be(OrchestrationStepTerminationState.Succeeded);
+                successStep.Lifecycle.TerminationState.Should().Be(StepInstanceTerminationState.Succeeded);
             },
             failingStep =>
             {
                 failingStep.Sequence.Should().Be(FailingStep.StepSequence);
-                failingStep.Lifecycle.TerminationState.Should().Be(OrchestrationStepTerminationState.Failed);
+                failingStep.Lifecycle.TerminationState.Should().Be(StepInstanceTerminationState.Failed);
                 failingStep.CustomState.Should().Contain(typeof(TaskFailedException).FullName);
                 failingStep.CustomState.Should().Contain(FailingActivity_Brs_X03_FailingOrchestrationInstanceExample_V1.ExceptionMessage);
             });

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_101/UpdateMeteringPointConnectionState/V1/Orchestration/Steps/BusinessValidationStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_101/UpdateMeteringPointConnectionState/V1/Orchestration/Steps/BusinessValidationStep.cs
@@ -43,8 +43,8 @@ internal class BusinessValidationStep(
             DefaultRetryOptions);
 
         var stepTerminationState = businessValidationResult.IsValid
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
+            ? StepInstanceTerminationState.Succeeded
+            : StepInstanceTerminationState.Failed;
 
         return new StepOutput(stepTerminationState, businessValidationResult);
     }

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_101/UpdateMeteringPointConnectionState/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_101/UpdateMeteringPointConnectionState/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -36,7 +36,7 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => StepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         var enqueueIdempotencyKey = Context.NewGuid();
 
@@ -67,6 +67,6 @@ internal class EnqueueActorMessagesStep(
             eventName: UpdateMeteringPointConnectionStateNotifyEventV1.OrchestrationInstanceEventName,
             timeout: _actorMessagesEnqueuedTimeout);
 
-        return OrchestrationStepTerminationState.Succeeded;
+        return StepInstanceTerminationState.Succeeded;
     }
 }

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_X01/InputExample/V1/Orchestration/Steps/FirstStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_X01/InputExample/V1/Orchestration/Steps/FirstStep.cs
@@ -29,9 +29,9 @@ internal class FirstStep(
 
     protected override int StepSequenceNumber => StepSequence;
 
-    protected override Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // Step does nothing
-        return Task.FromResult(OrchestrationStepTerminationState.Succeeded);
+        return Task.FromResult(StepInstanceTerminationState.Succeeded);
     }
 }

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_X01/InputExample/V1/Orchestration/Steps/SkippableStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_X01/InputExample/V1/Orchestration/Steps/SkippableStep.cs
@@ -29,9 +29,9 @@ internal class SkippableStep(
 
     protected override int StepSequenceNumber => StepSequence;
 
-    protected override Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // Step does nothing
-        return Task.FromResult(OrchestrationStepTerminationState.Succeeded);
+        return Task.FromResult(StepInstanceTerminationState.Succeeded);
     }
 }

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_X01/NoInputExample/V1/Orchestration/Steps/ExampleStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_X01/NoInputExample/V1/Orchestration/Steps/ExampleStep.cs
@@ -38,6 +38,6 @@ internal class ExampleStep(
                     InstanceId),
                 DefaultRetryOptions);
 
-        return new StepOutput(OrchestrationStepTerminationState.Succeeded, workResult.CalculationResult);
+        return new StepOutput(StepInstanceTerminationState.Succeeded, workResult.CalculationResult);
     }
 }

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_X02/ActorRequestProcessExample/V1/Orchestration/Steps/BusinessValidationStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_X02/ActorRequestProcessExample/V1/Orchestration/Steps/BusinessValidationStep.cs
@@ -40,8 +40,8 @@ internal class BusinessValidationStep(
             DefaultRetryOptions);
 
         var stepTerminationState = businessValidationResult.ValidationErrors.Count == 0
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
+            ? StepInstanceTerminationState.Succeeded
+            : StepInstanceTerminationState.Failed;
 
         return new StepOutput(stepTerminationState, businessValidationResult);
     }

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_X02/ActorRequestProcessExample/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_X02/ActorRequestProcessExample/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -35,7 +35,7 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => StepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         var enqueueIdempotencyKey = Context.NewGuid();
 
@@ -67,6 +67,6 @@ internal class EnqueueActorMessagesStep(
             eventName: ActorRequestProcessExampleNotifyEventV1.OrchestrationInstanceEventName,
             timeout: waitTimeout);
 
-        return OrchestrationStepTerminationState.Succeeded;
+        return StepInstanceTerminationState.Succeeded;
     }
 }

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_X02/NotifyOrchestrationInstanceExample/V1/Orchestration/Steps/WaitForNotifyEventStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_X02/NotifyOrchestrationInstanceExample/V1/Orchestration/Steps/WaitForNotifyEventStep.cs
@@ -74,8 +74,8 @@ internal class WaitForNotifyEventStep(
 
         var hasReceivedExampleNotifyEvent = notifyData != null;
         var stepTerminationState = hasReceivedExampleNotifyEvent
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
+            ? StepInstanceTerminationState.Succeeded
+            : StepInstanceTerminationState.Failed;
 
         return new StepOutput(stepTerminationState, hasReceivedExampleNotifyEvent);
     }

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_X03/FailingOrchestrationInstanceExample/V1/Orchestration/Steps/FailingStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_X03/FailingOrchestrationInstanceExample/V1/Orchestration/Steps/FailingStep.cs
@@ -30,13 +30,13 @@ internal class FailingStep(
 
     protected override int StepSequenceNumber => StepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         await Context.CallActivityAsync(
             name: nameof(FailingActivity_Brs_X03_FailingOrchestrationInstanceExample_V1),
             options: DefaultRetryOptions);
 
         // This should never be called, since above activity throws an exception.
-        return OrchestrationStepTerminationState.Succeeded;
+        return StepInstanceTerminationState.Succeeded;
     }
 }

--- a/source/ProcessManager.Example.Orchestrations/Processes/BRS_X03/FailingOrchestrationInstanceExample/V1/Orchestration/Steps/SuccessStep.cs
+++ b/source/ProcessManager.Example.Orchestrations/Processes/BRS_X03/FailingOrchestrationInstanceExample/V1/Orchestration/Steps/SuccessStep.cs
@@ -30,12 +30,12 @@ internal class SuccessStep(
 
     protected override int StepSequenceNumber => StepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         await Context.CallActivityAsync(
             name: nameof(SuccessActivity_Brs_X03_FailingOrchestrationInstanceExample_V1),
             options: DefaultRetryOptions);
 
-        return OrchestrationStepTerminationState.Succeeded;
+        return StepInstanceTerminationState.Succeeded;
     }
 }

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>1.14.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.15.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>1.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.14.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>1.13.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.2.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -63,12 +63,12 @@ using MeteringPointSubType =
 using MeteringPointType = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.MeteringPointType;
 using OrchestrationInstanceTerminationState =
     Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance.OrchestrationInstanceTerminationState;
-using OrchestrationStepTerminationState =
-    Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance.OrchestrationStepTerminationState;
 using Quality = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.Quality;
 using Resolution = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.Resolution;
 using StepInstanceLifecycleState =
     Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance.StepInstanceLifecycleState;
+using StepInstanceTerminationState =
+    Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance.StepInstanceTerminationState;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Processes.BRS_021.ForwardMeteredData.V1;
 
@@ -286,7 +286,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 
@@ -372,7 +372,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Failed);
+                        .And.Be(StepInstanceTerminationState.Failed);
                 },
                 s =>
                 {
@@ -381,7 +381,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Skipped);
+                        .And.Be(StepInstanceTerminationState.Skipped);
                 },
                 s =>
                 {
@@ -390,7 +390,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Skipped);
+                        .And.Be(StepInstanceTerminationState.Skipped);
                 },
                 s =>
                 {
@@ -399,7 +399,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingDurableClient.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingDurableClient.cs
@@ -343,7 +343,7 @@ public class MonitorOrchestrationUsingDurableClient : IAsyncLifetime
         orchestrationInstance.Steps
             .Single(step => step.Sequence == EnqueueActorMessagesStep.EnqueueActorMessagesStepSequence)
             .Lifecycle.TerminationState
-            .Should().Be(OrchestrationStepTerminationState.Failed);
+            .Should().Be(StepInstanceTerminationState.Failed);
     }
 
     private async Task AwaitOrchestrationRuntimeStatusAsync(string orchestrationInstanceId, OrchestrationRuntimeStatus status)

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -168,7 +168,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 
@@ -248,7 +248,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Failed);
+                        .And.Be(StepInstanceTerminationState.Failed);
                 },
                 s =>
                 {
@@ -256,7 +256,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -167,7 +167,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 
@@ -247,7 +247,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Failed);
+                        .And.Be(StepInstanceTerminationState.Failed);
                 },
                 s =>
                 {
@@ -255,7 +255,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     s.Lifecycle.State.Should().Be(StepInstanceLifecycleState.Terminated);
                     s.Lifecycle.TerminationState.Should()
                         .NotBeNull()
-                        .And.Be(OrchestrationStepTerminationState.Succeeded);
+                        .And.Be(StepInstanceTerminationState.Succeeded);
                 });
     }
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/CapacitySettlementCalculation/V1/Orchestration/Steps/CalculationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/CapacitySettlementCalculation/V1/Orchestration/Steps/CalculationStep.cs
@@ -35,7 +35,7 @@ internal class CalculationStep(
 
     protected override int StepSequenceNumber => CalculationStepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // Start calculation (Databricks)
         var jobRunId = await Context.CallActivityAsync<JobRunId>(
@@ -67,7 +67,7 @@ internal class CalculationStep(
                     break;
 
                 case JobRunStatus.Completed:
-                    return OrchestrationStepTerminationState.Succeeded;
+                    return StepInstanceTerminationState.Succeeded;
 
                 case JobRunStatus.Failed:
                 case JobRunStatus.Canceled:

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/CapacitySettlementCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/CapacitySettlementCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -33,9 +33,9 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => EnqueueActorMessagesStepSequence;
 
-    protected override Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // TODO - Alex: Implement and call activities to enqueue messages
-        return Task.FromResult(OrchestrationStepTerminationState.Succeeded);
+        return Task.FromResult(StepInstanceTerminationState.Succeeded);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration/Steps/CalculationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration/Steps/CalculationStep.cs
@@ -35,7 +35,7 @@ internal class CalculationStep(
 
     protected override int StepSequenceNumber => CalculationStepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // Start calculation (Databricks)
         var jobRunId = await Context.CallActivityAsync<JobRunId>(
@@ -67,7 +67,7 @@ internal class CalculationStep(
                     break;
 
                 case JobRunStatus.Completed:
-                    return OrchestrationStepTerminationState.Succeeded;
+                    return StepInstanceTerminationState.Succeeded;
 
                 case JobRunStatus.Failed:
                 case JobRunStatus.Canceled:

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -33,9 +33,9 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => EnqueueActorMessagesStepSequence;
 
-    protected override Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // TODO - Alex: Implement and call activities to enqueue messages
-        return Task.FromResult(OrchestrationStepTerminationState.Succeeded);
+        return Task.FromResult(StepInstanceTerminationState.Succeeded);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesStepTerminateActivity_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/EnqueueActorMessagesStepTerminateActivity_Brs_021_ForwardMeteredData_V1.cs
@@ -43,5 +43,5 @@ internal class EnqueueActorMessagesStepTerminateActivity_Brs_021_ForwardMeteredD
 
     public sealed record ActivityInput(
         OrchestrationInstanceId OrchestrationInstanceId,
-        OrchestrationStepTerminationState TerminationState);
+        StepInstanceTerminationState TerminationState);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/ProgressActivityBase.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Activities/ProgressActivityBase.cs
@@ -36,7 +36,7 @@ internal abstract class ProgressActivityBase(
     protected async Task CompleteStepAsync(int sequence, OrchestrationInstance orchestrationInstance)
     {
         var step = orchestrationInstance.Steps.Single(x => x.Sequence == sequence);
-        step.Lifecycle.TransitionToTerminated(Clock, OrchestrationStepTerminationState.Succeeded);
+        step.Lifecycle.TransitionToTerminated(Clock, StepInstanceTerminationState.Succeeded);
         await ProgressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -34,11 +34,11 @@ using NodaTime.Text;
 using MeteringPointType = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.MeteringPointType;
 using OrchestrationInstanceLifecycleState =
     Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance.OrchestrationInstanceLifecycleState;
-using OrchestrationStepTerminationState =
-    Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance.OrchestrationStepTerminationState;
 using Resolution = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.Resolution;
 using StepInstanceLifecycleState =
     Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance.StepInstanceLifecycleState;
+using StepInstanceTerminationState =
+    Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance.StepInstanceTerminationState;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Handlers;
 
@@ -134,7 +134,7 @@ public class StartForwardMeteredDataHandlerV1(
                 orchestrationInstance.GetStep(OrchestrationDescriptionBuilder.ForwardToMeasurementsStep);
 
             // If the step is already skipped, do nothing (idempotency/retry check).
-            if (forwardStep.Lifecycle.TerminationState is not OrchestrationStepTerminationState.Skipped)
+            if (forwardStep.Lifecycle.TerminationState is not StepInstanceTerminationState.Skipped)
             {
                 // If the step isn't skipped, it should still be in "pending", else an exception will be thrown.
                 await StepHelper.SkipStepAndCommitIfPending(forwardStep, _clock, _progressRepository)
@@ -145,7 +145,7 @@ public class StartForwardMeteredDataHandlerV1(
             var findReceiverStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilder.FindReceiversStep);
 
             // If the step is already skipped, do nothing (idempotency/retry check).
-            if (findReceiverStep.Lifecycle.TerminationState != OrchestrationStepTerminationState.Skipped)
+            if (findReceiverStep.Lifecycle.TerminationState != StepInstanceTerminationState.Skipped)
             {
                 // If the step isn't skipped, it should still be in "pending", else an exception will be thrown.
                 await StepHelper.SkipStepAndCommitIfPending(findReceiverStep, _clock, _progressRepository)
@@ -219,7 +219,7 @@ public class StartForwardMeteredDataHandlerV1(
         // If the step is already terminated (idempotency/retry check), return the existing validation errors.
         if (validationStep.Lifecycle.State == StepInstanceLifecycleState.Terminated)
         {
-            if (validationStep.Lifecycle.TerminationState == OrchestrationStepTerminationState.Failed
+            if (validationStep.Lifecycle.TerminationState == StepInstanceTerminationState.Failed
                 && validationStep.CustomState.IsEmpty)
             {
                 throw new InvalidOperationException(
@@ -256,8 +256,8 @@ public class StartForwardMeteredDataHandlerV1(
             validationStep.CustomState.SetFromInstance(validationErrors);
 
         var validationStepTerminationState = validationSuccess
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
+            ? StepInstanceTerminationState.Succeeded
+            : StepInstanceTerminationState.Failed;
 
         await StepHelper.TerminateStepAndCommit(
                 validationStep,

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/TerminateForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/TerminateForwardMeteredDataHandlerV1.cs
@@ -65,7 +65,7 @@ public class TerminateForwardMeteredDataHandlerV1(
     {
         var businessValidationStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilder.BusinessValidationStep);
 
-        var succeededBusinessValidation = businessValidationStep.Lifecycle is { TerminationState: OrchestrationStepTerminationState.Succeeded };
+        var succeededBusinessValidation = businessValidationStep.Lifecycle is { TerminationState: StepInstanceTerminationState.Succeeded };
         if (succeededBusinessValidation)
             orchestrationInstance.Lifecycle.TransitionToSucceeded(_clock);
         else

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/StepHelper.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/StepHelper.cs
@@ -42,13 +42,13 @@ public static class StepHelper
     /// <param name="step"></param>
     /// <param name="clock"></param>
     /// <param name="progressRepository"></param>
-    /// <param name="terminationState">The termination state of the step, defaulting to <see cref="OrchestrationStepTerminationState.Succeeded"/>.</param>
+    /// <param name="terminationState">The termination state of the step, defaulting to <see cref="StepInstanceTerminationState.Succeeded"/>.</param>
     /// <exception cref="InvalidOperationException">Throws an invalid operation exception if the step isn't running.</exception>
     public static async Task TerminateStepAndCommit(
         StepInstance step,
         IClock clock,
         IOrchestrationInstanceProgressRepository progressRepository,
-        OrchestrationStepTerminationState terminationState = OrchestrationStepTerminationState.Succeeded)
+        StepInstanceTerminationState terminationState = StepInstanceTerminationState.Succeeded)
     {
         if (step.Lifecycle.State != StepInstanceLifecycleState.Running)
             throw new InvalidOperationException($"Can only terminate a running step (Step.Id={step.Id}, Step.State={step.Lifecycle.State}).");
@@ -63,7 +63,7 @@ public static class StepHelper
     /// <exception cref="InvalidOperationException">Throws an exception if the step isn't pending (thrown by the step lifecycle).</exception>
     public static async Task SkipStepAndCommitIfPending(StepInstance step, IClock clock, IOrchestrationInstanceProgressRepository progressRepository)
     {
-        step.Lifecycle.TransitionToTerminated(clock, OrchestrationStepTerminationState.Skipped);
+        step.Lifecycle.TransitionToTerminated(clock, StepInstanceTerminationState.Skipped);
         await progressRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/NetConsumptionCalculation/V1/Orchestration/Steps/CalculationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/NetConsumptionCalculation/V1/Orchestration/Steps/CalculationStep.cs
@@ -35,7 +35,7 @@ internal class CalculationStep(
 
     protected override int StepSequenceNumber => CalculationStepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // Start calculation (Databricks)
         var jobRunId = await Context.CallActivityAsync<JobRunId>(
@@ -67,7 +67,7 @@ internal class CalculationStep(
                     break;
 
                 case JobRunStatus.Completed:
-                    return OrchestrationStepTerminationState.Succeeded;
+                    return StepInstanceTerminationState.Succeeded;
 
                 case JobRunStatus.Failed:
                 case JobRunStatus.Canceled:

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/NetConsumptionCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/NetConsumptionCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -33,9 +33,9 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => EnqueueActorMessagesStepSequence;
 
-    protected override Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // TODO - Alex: Implement and call activities to enqueue messages
-        return Task.FromResult(OrchestrationStepTerminationState.Succeeded);
+        return Task.FromResult(StepInstanceTerminationState.Succeeded);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Orchestration/Steps/CalculationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Orchestration/Steps/CalculationStep.cs
@@ -37,7 +37,7 @@ internal class CalculationStep(
 
     protected override int StepSequenceNumber => CalculationStepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // Start calculation (Databricks)
         var jobRunId = await Context.CallActivityAsync<JobRunId>(
@@ -74,7 +74,7 @@ internal class CalculationStep(
                     break;
 
                 case JobRunStatus.Completed:
-                    return OrchestrationStepTerminationState.Succeeded;
+                    return StepInstanceTerminationState.Succeeded;
 
                 case JobRunStatus.Failed:
                 case JobRunStatus.Canceled:

--- a/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_023_027/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -61,7 +61,7 @@ internal class EnqueueActorMessagesStep(
                 timeout: timeout);
 
             if (enqueueEvent.Success)
-                return new StepOutput(OrchestrationStepTerminationState.Succeeded, enqueueEvent.Success);
+                return new StepOutput(StepInstanceTerminationState.Succeeded, enqueueEvent.Success);
 
             throw new Exception($"Enqueue messages did not finish within {orchestrationInstanceContext.OrchestrationOptions.MessagesEnqueuingExpiryTimeInSeconds} seconds");
         }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration/Steps/BusinessValidationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration/Steps/BusinessValidationStep.cs
@@ -44,8 +44,8 @@ internal class BusinessValidationStep(
             DefaultRetryOptions);
 
         var asyncValidationTerminationState = validationResult.IsValid
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
+            ? StepInstanceTerminationState.Succeeded
+            : StepInstanceTerminationState.Failed;
 
         return new StepOutput(asyncValidationTerminationState, validationResult);
     }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -35,7 +35,7 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => StepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         var idempotencyKey = Context.NewGuid();
         if (validationResult.IsValid)
@@ -67,6 +67,6 @@ internal class EnqueueActorMessagesStep(
             eventName: RequestCalculatedEnergyTimeSeriesNotifyEventV1.OrchestrationInstanceEventName,
             timeout: _actorMessagesEnqueuedTimeout);
 
-        return OrchestrationStepTerminationState.Succeeded;
+        return StepInstanceTerminationState.Succeeded;
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration/Steps/BusinessValidationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration/Steps/BusinessValidationStep.cs
@@ -44,8 +44,8 @@ internal class BusinessValidationStep(
             DefaultRetryOptions);
 
         var asyncValidationTerminationState = validationResult.IsValid
-            ? OrchestrationStepTerminationState.Succeeded
-            : OrchestrationStepTerminationState.Failed;
+            ? StepInstanceTerminationState.Succeeded
+            : StepInstanceTerminationState.Failed;
 
         return new StepOutput(asyncValidationTerminationState, validationResult);
     }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_028/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -35,7 +35,7 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => StepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         var idempotencyKey = Context.NewGuid();
         if (validationResult.IsValid)
@@ -67,6 +67,6 @@ internal class EnqueueActorMessagesStep(
             eventName: RequestCalculatedWholesaleServicesNotifyEventV1.OrchestrationInstanceEventName,
             timeout: _actorMessagesEnqueuedTimeout);
 
-        return OrchestrationStepTerminationState.Succeeded;
+        return StepInstanceTerminationState.Succeeded;
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/Orchestration/Steps/CalculationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/Orchestration/Steps/CalculationStep.cs
@@ -35,7 +35,7 @@ internal class CalculationStep(
 
     protected override int StepSequenceNumber => CalculationStepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // Start calculation (Databricks)
         var jobRunId = await Context.CallActivityAsync<JobRunId>(
@@ -67,7 +67,7 @@ internal class CalculationStep(
                     break;
 
                 case JobRunStatus.Completed:
-                    return OrchestrationStepTerminationState.Succeeded;
+                    return StepInstanceTerminationState.Succeeded;
 
                 case JobRunStatus.Failed:
                 case JobRunStatus.Canceled:

--- a/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -33,9 +33,9 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => EnqueueActorMessagesStepSequence;
 
-    protected override Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // TODO - Alex: Implement and call activities to enqueue messages
-        return Task.FromResult(OrchestrationStepTerminationState.Succeeded);
+        return Task.FromResult(StepInstanceTerminationState.Succeeded);
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Orchestration/Steps/CalculationStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Orchestration/Steps/CalculationStep.cs
@@ -35,7 +35,7 @@ internal class CalculationStep(
 
     protected override int StepSequenceNumber => CalculationStepSequence;
 
-    protected override async Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // Start calculation (Databricks)
         var jobRunId = await Context.CallActivityAsync<JobRunId>(
@@ -67,7 +67,7 @@ internal class CalculationStep(
                     break;
 
                 case JobRunStatus.Completed:
-                    return OrchestrationStepTerminationState.Succeeded;
+                    return StepInstanceTerminationState.Succeeded;
 
                 case JobRunStatus.Failed:
                 case JobRunStatus.Canceled:

--- a/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -33,9 +33,9 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => EnqueueActorMessagesStepSequence;
 
-    protected override Task<OrchestrationStepTerminationState> OnExecuteAsync()
+    protected override Task<StepInstanceTerminationState> OnExecuteAsync()
     {
         // TODO - Alex: Implement and call activities to enqueue messages
-        return Task.FromResult(OrchestrationStepTerminationState.Succeeded);
+        return Task.FromResult(StepInstanceTerminationState.Succeeded);
     }
 }

--- a/source/Shared/Api/Mappers/OrchestrationInstanceMapperExtensions.cs
+++ b/source/Shared/Api/Mappers/OrchestrationInstanceMapperExtensions.cs
@@ -122,7 +122,7 @@ internal static class OrchestrationInstanceMapperExtensions
                 ? lifecycleStateResult
                 : throw new InvalidOperationException($"Invalid State '{entity.State}'; cannot be mapped."),
             TerminationState: Enum
-                .TryParse<ApiModel.OrchestrationInstance.OrchestrationStepTerminationState>(
+                .TryParse<ApiModel.OrchestrationInstance.StepInstanceTerminationState>(
                     entity.TerminationState.ToString(),
                     ignoreCase: true,
                     out var terminationStateResult)

--- a/source/Shared/Processes/Activities/StepExecutor.cs
+++ b/source/Shared/Processes/Activities/StepExecutor.cs
@@ -93,7 +93,7 @@ internal abstract class StepExecutorBase(
     /// Transition the step instance's lifecycle to the given <paramref name="stepTerminationState"/>.
     /// </summary>
     /// <param name="stepTerminationState">The termination state to transition of the step.</param>
-    protected async Task TransitionToTerminated(OrchestrationStepTerminationState stepTerminationState)
+    protected async Task TransitionToTerminated(StepInstanceTerminationState stepTerminationState)
     {
         await Context.CallActivityAsync(
             name: nameof(TransitionStepToTerminatedActivity_V1),
@@ -124,7 +124,7 @@ internal abstract class StepExecutor(
     {
         await TransitionToRunning();
 
-        OrchestrationStepTerminationState terminationState;
+        StepInstanceTerminationState terminationState;
         try
         {
             terminationState = await OnExecuteAsync();
@@ -158,7 +158,7 @@ internal abstract class StepExecutor(
     /// </remarks>
     /// </summary>
     /// <returns>The step termination state, which the step instance will be transitioned to.</returns>
-    protected abstract Task<OrchestrationStepTerminationState> OnExecuteAsync();
+    protected abstract Task<StepInstanceTerminationState> OnExecuteAsync();
 }
 
 /// <inheritdoc/>
@@ -180,7 +180,7 @@ internal abstract class StepExecutor<TStepOutput>(
     {
         await TransitionToRunning();
 
-        OrchestrationStepTerminationState terminationState;
+        StepInstanceTerminationState terminationState;
         TStepOutput output;
         try
         {
@@ -222,7 +222,7 @@ internal abstract class StepExecutor<TStepOutput>(
     protected abstract Task<StepOutput> OnExecuteAsync();
 
     internal record StepOutput(
-        OrchestrationStepTerminationState TerminationState,
+        StepInstanceTerminationState TerminationState,
         TStepOutput Output);
 }
 #pragma warning restore CA2007

--- a/source/Shared/Processes/Activities/TransitionOrchestrationAndStepToFailedActivity_V1.cs
+++ b/source/Shared/Processes/Activities/TransitionOrchestrationAndStepToFailedActivity_V1.cs
@@ -39,7 +39,7 @@ internal class TransitionOrchestrationAndStepToFailedActivity_V1(
             .ConfigureAwait(false);
 
         var step = orchestrationInstance.GetStep(input.FailedStepSequence);
-        step.Lifecycle.TransitionToTerminated(_clock, OrchestrationStepTerminationState.Failed);
+        step.Lifecycle.TransitionToTerminated(_clock, StepInstanceTerminationState.Failed);
         step.CustomState.SetFromInstance(new FailedStepCustomState(
             ErrorMessage: input.FailedStepErrorMessage));
 

--- a/source/Shared/Processes/Activities/TransitionStepToTerminatedActivity_V1.cs
+++ b/source/Shared/Processes/Activities/TransitionStepToTerminatedActivity_V1.cs
@@ -45,5 +45,5 @@ internal class TransitionStepToTerminatedActivity_V1(
     internal record ActivityInput(
         OrchestrationInstanceId OrchestrationInstanceId,
         int StepSequence,
-        OrchestrationStepTerminationState TerminationState);
+        StepInstanceTerminationState TerminationState);
 }


### PR DESCRIPTION
## Description

Fix incorrect naming of `OrchestrationStepTerminationState` in domain and API model. Renamed to `StepInstanceTerminationState`.

Testet manually in `dev_002`, by starting Aggregering and BalanceFixing.

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/630

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
