### PR TITLE
chore: Improve tests execution in CI 

### DIFF
--- a/.github/workflows/ci-dotnet-runtests.yml
+++ b/.github/workflows/ci-dotnet-runtests.yml
@@ -62,12 +62,66 @@ jobs:
           $matrixBuilds = @()
 
           foreach ($project in $affectedProjects) {
-            if ($project.Name -like '*Tests*' -and $project.Name -notlike '*.SubsystemTests') {
+            if ($project.Name -like '*.SubsystemTests') {
+              # Skip
+            }
+            else if ($project.Name -like '*ProcessManager.Orchestrations.Tests') {
+              # All tests not in a bucket + those in the 'Default' bucket
+              $matrixBuilds += [PSCustomObject]@{
+                name              = $project.Name
+                filepath          = $project.FilePath
+                assembly_name     = "Energinet.DataHub.$($project.Name).dll"
+                dotnet_version    = "${{ inputs.dotnet_version }}"
+                filter_expression = WorkflowBucket!~Bucket)
+              }
+              # Bucket01
+              $matrixBuilds += [PSCustomObject]@{
+                name              = $project.Name
+                filepath          = $project.FilePath
+                assembly_name     = "Energinet.DataHub.$($project.Name).dll"
+                dotnet_version    = "${{ inputs.dotnet_version }}"
+                filter_expression = WorkflowBucket=Bucket01
+              }
+              # Bucket02
+              $matrixBuilds += [PSCustomObject]@{
+                name              = $project.Name
+                filepath          = $project.FilePath
+                assembly_name     = "Energinet.DataHub.$($project.Name).dll"
+                dotnet_version    = "${{ inputs.dotnet_version }}"
+                filter_expression = WorkflowBucket=Bucket02
+              }
+              # Bucket03
+              $matrixBuilds += [PSCustomObject]@{
+                name              = $project.Name
+                filepath          = $project.FilePath
+                assembly_name     = "Energinet.DataHub.$($project.Name).dll"
+                dotnet_version    = "${{ inputs.dotnet_version }}"
+                filter_expression = WorkflowBucket=Bucket03
+              }
+              # Bucket04
+              $matrixBuilds += [PSCustomObject]@{
+                name              = $project.Name
+                filepath          = $project.FilePath
+                assembly_name     = "Energinet.DataHub.$($project.Name).dll"
+                dotnet_version    = "${{ inputs.dotnet_version }}"
+                filter_expression = WorkflowBucket=Bucket04
+              }
+              # Bucket05
+              $matrixBuilds += [PSCustomObject]@{
+                name              = $project.Name
+                filepath          = $project.FilePath
+                assembly_name     = "Energinet.DataHub.$($project.Name).dll"
+                dotnet_version    = "${{ inputs.dotnet_version }}"
+                filter_expression = WorkflowBucket=Bucket05
+              }
+            }
+            else if ($project.Name -like '*Tests*') {
               $matrixBuilds += [PSCustomObject]@{
                 name           = $project.Name
                 filepath       = $project.FilePath
                 assembly_name  = "Energinet.DataHub.$($project.Name).dll"
                 dotnet_version = "${{ inputs.dotnet_version }}"
+                filter_expression = empty # Means skip.
               }
             }
           }
@@ -108,7 +162,6 @@ jobs:
       azure_keyvault_url: ${{ vars.integration_test_azure_keyvault_url }}
       environment: AzureAuth
       run_integration_tests: true
-      tests_filter_expression: empty # Means skip.
       use_azure_functions_tools: true
       azure_functions_core_tools_version: 4.0.5455
       aspnetcore_test_contentroot_variable_name: empty
@@ -119,4 +172,5 @@ jobs:
       # Matrix parameters
       testproject_artifact_name: pm-tests-${{ matrix.project.name }}-${{ needs.build_matrix.outputs.pr_number }}
       testproject_name: ${{ matrix.project.name }}
-      tests_dll_file_path: \source\${{ matrix.project.name}}\bin\Release\${{matrix.project.dotnet_version}}\${{ matrix.project.assembly_name }}
+      tests_dll_file_path: \source\${{ matrix.project.name }}\bin\Release\${{ matrix.project.dotnet_version }}\${{ matrix.project.assembly_name }}
+      tests_filter_expression: ${{ matrix.project.filter_expression }}

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/Xunit/Attributes/ParallelWorkflowAttribute.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/Xunit/Attributes/ParallelWorkflowAttribute.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit.Sdk;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
+
+/// <summary>
+/// Apply attribute on xUnit test class for tests to specify in which
+/// workflow bucket the containing tests should be executed. Each
+/// bucket should be executed on its own GitHub runner.
+///
+/// GitHub workflows should then use xUnit trait filter expressions to
+/// execute tests accordingly.
+///
+/// See xUnit filter possibilities: https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=xunit
+/// </summary>
+[TraitDiscoverer(
+    typeName: "Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.TraitDiscoverers.ParallelWorkflowDiscoverer",
+    assemblyName: "Energinet.DataHub.ProcessManager.Orchestrations.Tests")]
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class ParallelWorkflowAttribute : Attribute, ITraitAttribute
+{
+    public ParallelWorkflowAttribute(
+        WorkflowBucket bucket = WorkflowBucket.Default)
+    {
+    }
+}
+
+/// <summary>
+/// Workflow bucket filter.
+/// </summary>
+#pragma warning disable SA1201 // Elements should appear in the correct order
+public enum WorkflowBucket
+#pragma warning restore SA1201 // Elements should appear in the correct order
+{
+    Default,
+    Bucket01,
+    Bucket02,
+    Bucket03,
+    Bucket04,
+    Bucket05,
+}

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/Xunit/TraitDiscoverers/ParallelWorkflowDiscoverer.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/Xunit/TraitDiscoverers/ParallelWorkflowDiscoverer.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.TraitDiscoverers;
+
+/// <summary>
+/// This class discovers all the xUnit test classes that have applied
+/// the <see cref="ParallelWorkflowAttribute"/> attribute. It then configures
+/// xUnit 'traits' based on the parameters given to the attribute.
+/// Traits should be used in filters to control which tests we execute in a given
+/// context.
+/// </summary>
+public class ParallelWorkflowDiscoverer : ITraitDiscoverer
+{
+    public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+    {
+        var constructorArgs = traitAttribute
+            .GetConstructorArguments()
+            .ToList();
+
+#pragma warning disable CS8604 // Possible null reference argument.
+        yield return new KeyValuePair<string, string>("WorkflowBucket", constructorArgs[0].ToString());
+#pragma warning restore CS8604 // Possible null reference argument.
+    }
+}

--- a/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchCalculationsHandlerV1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchCalculationsHandlerV1Tests.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.ProcessManager.Core.Infrastructure.Database;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.CustomQueries.Calculations.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.CustomQueries.Calculations.V1;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Api.Mappers;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore.SqlServer.NodaTime.Extensions;
@@ -30,6 +31,7 @@ using ApiModel = Energinet.DataHub.ProcessManager.Abstractions.Api.Model.Orchest
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.CustomQueries.Calculations.V1;
 
+[ParallelWorkflow(WorkflowBucket.Bucket01)]
 public class SearchCalculationsHandlerV1Tests :
     IClassFixture<ProcessManagerDatabaseFixture>,
     IAsyncLifetime

--- a/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_CalculationById_V1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_CalculationById_V1Tests.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.CustomQueries.Calculations.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -32,6 +33,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Cust
 /// Test collection that verifies the Process Manager clients can be used to
 /// perform a custom search for Calculations orchestration instances.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket01)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class SearchTrigger_CalculationById_V1Tests : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_Calculations_V1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_Calculations_V1Tests.cs
@@ -19,6 +19,7 @@ using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.CustomQueries.Calculations.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -33,6 +34,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Cust
 /// Test collection that verifies the Process Manager clients can be used to
 /// perform a custom search for Calculations orchestration instances.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket01)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/CapacitySettlementCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/CapacitySettlementCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.CapacitySettlementCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -35,6 +36,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test case where we verify the Process Manager clients can be used to start a
 /// calculation orchestration (with no input parameter) and monitor its status during its lifetime.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket04)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -35,6 +36,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test case where we verify the Process Manager clients can be used to start a
 /// calculation orchestration (with no input parameter) and monitor its status during its lifetime.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket04)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -37,6 +37,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardM
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Triggers;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -76,6 +77,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test collection that verifies the Process Manager clients can be used to start a
 /// forward metered data flow
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket03)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/NetConsumptionCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/NetConsumptionCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.NetConsumptionCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -35,6 +36,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test case where we verify the Process Manager clients can be used to start a
 /// calculation orchestration (with no input parameter) and monitor its status during its lifetime.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket04)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/CustomQueries/SearchCalculationHandlerTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/CustomQueries/SearchCalculationHandlerTests.cs
@@ -21,12 +21,14 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.CustomQueries;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Api.Mappers;
 using FluentAssertions;
 using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Processes.BRS_023_027.V1.CustomQueries;
 
+[ParallelWorkflow(WorkflowBucket.Bucket01)]
 public class SearchCalculationHandlerTests : IClassFixture<ProcessManagerDatabaseFixture>, IAsyncLifetime
 {
     private readonly ProcessManagerDatabaseFixture _fixture;

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -23,6 +23,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -38,6 +39,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test case where we verify the Process Manager clients can be used to start a
 /// calculation orchestration (with input parameter) and monitor its status during its lifetime.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket01)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingDurableClient.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingDurableClient.cs
@@ -29,6 +29,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_023_027.V1.O
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Wiremock;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Processes.Activities;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
@@ -47,6 +48,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// <summary>
 /// Test to verify the state of an orchestration.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket01)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingDurableClient : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -23,7 +23,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Orchestration.Steps;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
-using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -38,6 +38,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test collection that verifies the Process Manager clients can be used to start a
 /// request calculated energy time series orchestration and monitor its status during its lifetime.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket02)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -23,7 +23,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Orchestration.Steps;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
-using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -38,6 +38,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test collection that verifies the Process Manager clients can be used to start a
 /// request calculated energy time series orchestration and monitor its status during its lifetime.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket02)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/CustomQueries/SearchTrigger_Brs_026_028Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/CustomQueries/SearchTrigger_Brs_026_028Tests.cs
@@ -24,6 +24,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_026.V1.Orchestration;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.BRS_028.V1.Orchestration;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -38,6 +39,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test collection that verifies the Process Manager clients can be used to
 /// perform a custom search for BRS 026 + 028 orchestration instances.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket02)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class SearchTrigger_Brs_026_028Tests : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
@@ -17,6 +17,7 @@ using Energinet.DataHub.ProcessManager.Components.Databricks.Jobs.Model;
 using Energinet.DataHub.ProcessManager.Components.Time;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_045.MissingMeasurementsLogCalculation.V1.Activities.CalculationStep;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using Moq;
@@ -24,6 +25,7 @@ using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Processes.BRS_045.MissingMeasurementsLogCalculation.V1.Activities.CalculationStep;
 
+[ParallelWorkflow(WorkflowBucket.Bucket05)]
 public class CalculationStepStartJobActivityBrs045MissingMeasurementsLogCalculationV1Tests()
 {
     [Fact]

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_045.MissingMeasurementsLogCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -35,6 +36,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test case where we verify the Process Manager clients can be used to start a
 /// calculation orchestration (with no input parameter) and monitor its status during its lifetime.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket05)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_045.MissingMeasurementsLogOnDemandCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
@@ -35,6 +36,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Proc
 /// Test case where we verify the Process Manager clients can be used to start a
 /// calculation orchestration (with input parameters) and monitor its status during its lifetime.
 /// </summary>
+[ParallelWorkflow(WorkflowBucket.Bucket05)]
 [Collection(nameof(OrchestrationsAppCollection))]
 public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 {


### PR DESCRIPTION
## Description

Implement `ParallelWorkflowAttribute` and `ParallelWorkflowDiscoverer`.

Using `ParallelWorkflowAttribute` it is possible to easily distribute test classes (and hence tests within) into multiple parallel workflows, without having to change the YAML.

Current workflow configuration will run tests from `ProcessManager.Orchestrations.Tests` in 6 workflows:
- One for all that doesn't specify the attribute, or who set it to `[ParallelWorkflow(WorkflowBucket.Default)]`
- One for each bucket (from 01-05)

Currently the name of the job/workflow doesn't show which bucket is executed; this would require a change in the reusable workflow, which we could ask Fusion to perform.

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
