### PR TITLE
feat: support for normalised MeteringPointMasterData 

### DIFF
--- a/source/ProcessManager.Components/ProcessManager.Components.csproj
+++ b/source/ProcessManager.Components/ProcessManager.Components.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Messaging.EventHubs" Version="9.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.6" />
-    <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.4.0" />
+    <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="6.1.4" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.3" />

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -637,16 +637,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             Unit = MeasureUnit.kWh,
             ProductId = ProductId.Tariff,
             ParentIdentification = null,
-            EnergySuppliers =
-            [
-                new MeteringPointEnergySupplier
-                {
-                    Identification = new MeteringPointIdentification(MeteringPointId),
-                    EnergySupplier = EnergySupplier,
-                    StartDate = _validFrom,
-                    EndDate = _validTo,
-                },
-            ],
+            EnergySupplier = EnergySupplier,
         };
 
         // IEnumerable<HistoricalMeteringPointMasterData>

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
@@ -816,6 +816,54 @@ public class MeteringPointMasterDataProviderTests
                     {
                         Identification = new MeteringPointIdentification("parent-metering-point-id-two"),
                         ValidFrom = Instant.FromUtc(2021, 3, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 3, 16, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = null,
+                        EnergySupplier = "9090909090909",
+                    },
+                     new()
+                    {
+                        Identification = new MeteringPointIdentification("parent-metering-point-id-two"),
+                        ValidFrom = Instant.FromUtc(2021, 3, 16, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 4, 1, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = null,
+                        EnergySupplier = "8989898989898",
+                    },
+                     new()
+                    {
+                        Identification = new MeteringPointIdentification("parent-metering-point-id-two"),
+                        ValidFrom = Instant.FromUtc(2021, 4, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 4, 16, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = null,
+                        EnergySupplier = "7878787878787",
+                    },
+                     new()
+                    {
+                        Identification = new MeteringPointIdentification("parent-metering-point-id-two"),
+                        ValidFrom = Instant.FromUtc(2021, 4, 16, 0, 0),
                         ValidTo = Instant.FromUtc(2021, 5, 1, 0, 0),
                         GridAreaCode = new GridAreaCode("804"),
                         GridAccessProvider = "9999999999999",
@@ -826,37 +874,7 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = null,
-                        EnergySuppliers =
-                        [
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("parent-metering-point-id-two"),
-                                EnergySupplier = "9090909090909",
-                                StartDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 3, 16, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("parent-metering-point-id-two"),
-                                EnergySupplier = "8989898989898",
-                                StartDate = Instant.FromUtc(2021, 3, 16, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 4, 1, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("parent-metering-point-id-two"),
-                                EnergySupplier = "7878787878787",
-                                StartDate = Instant.FromUtc(2021, 4, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 4, 16, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("parent-metering-point-id-two"),
-                                EnergySupplier = "6767676767676",
-                                StartDate = Instant.FromUtc(2021, 4, 16, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 5, 1, 0, 0),
-                            },
-                        ],
+                        EnergySupplier = "6767676767676",
                     },
                 ]),
                 _ => throw new ArgumentOutOfRangeException(

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
@@ -377,7 +377,7 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = null,
-                        EnergySuppliers = [],
+                        EnergySupplier = null,
                     },
                 ]),
                 "one-energy-supplier-please" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(
@@ -396,16 +396,7 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = null,
-                        EnergySuppliers =
-                        [
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("one-energy-supplier-please"),
-                                EnergySupplier = "1111111111111",
-                                StartDate = Instant.FromUtc(2021, 1, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                            },
-                        ],
+                        EnergySupplier = "1111111111111",
                     },
                 ]),
                 "two-energy-suppliers-please" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(
@@ -414,6 +405,22 @@ public class MeteringPointMasterDataProviderTests
                     {
                         Identification = new MeteringPointIdentification("two-energy-suppliers-please"),
                         ValidFrom = Instant.FromUtc(2021, 1, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 2, 1, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = null,
+                        EnergySupplier = "1111111111111",
+                    },
+                    new()
+                    {
+                        Identification = new MeteringPointIdentification("two-energy-suppliers-please"),
+                        ValidFrom = Instant.FromUtc(2021, 2, 1, 0, 0),
                         ValidTo = Instant.FromUtc(2021, 3, 1, 0, 0),
                         GridAreaCode = new GridAreaCode("804"),
                         GridAccessProvider = "9999999999999",
@@ -424,23 +431,7 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = null,
-                        EnergySuppliers =
-                        [
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("two-energy-suppliers-please"),
-                                EnergySupplier = "1111111111111",
-                                StartDate = Instant.FromUtc(2021, 1, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("two-energy-suppliers-please"),
-                                EnergySupplier = "2222222222222",
-                                StartDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                            },
-                        ],
+                        EnergySupplier = "2222222222222",
                     },
                 ]),
                 "faulty-two-master-data-please" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(
@@ -449,6 +440,22 @@ public class MeteringPointMasterDataProviderTests
                     {
                         Identification = new MeteringPointIdentification("faulty-two-master-data-please"),
                         ValidFrom = Instant.FromUtc(2021, 1, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 2, 1, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = null,
+                        EnergySupplier = "1111111111111",
+                    },
+                    new()
+                    {
+                        Identification = new MeteringPointIdentification("faulty-two-master-data-please"),
+                        ValidFrom = Instant.FromUtc(2021, 2, 1, 0, 0),
                         ValidTo = Instant.FromUtc(2021, 3, 1, 0, 0),
                         GridAreaCode = new GridAreaCode("804"),
                         GridAccessProvider = "9999999999999",
@@ -459,23 +466,7 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = null,
-                        EnergySuppliers =
-                        [
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("faulty-two-master-data-please"),
-                                EnergySupplier = "1111111111111",
-                                StartDate = Instant.FromUtc(2021, 1, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("faulty-two-master-data-please"),
-                                EnergySupplier = "2222222222222",
-                                StartDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                            },
-                        ],
+                        EnergySupplier = "2222222222222",
                     },
                     new()
                     {
@@ -491,13 +482,42 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = null,
-                        EnergySuppliers = [],
+                        EnergySupplier = null,
                     },
                 ]),
                 "two-master-data-with-two-energy-suppliers-please" => Task
                     .FromResult<IEnumerable<MeteringPointMasterData>>(
                     [
                         new()
+                        {
+                            Identification =
+                                new MeteringPointIdentification(
+                                    "two-master-data-with-two-energy-suppliers-please"),
+                            ValidFrom = Instant.FromUtc(
+                                2021,
+                                1,
+                                1,
+                                0,
+                                0),
+                            ValidTo = Instant.FromUtc(
+                                2021,
+                                2,
+                                1,
+                                0,
+                                0),
+                            GridAreaCode = new GridAreaCode("804"),
+                            GridAccessProvider = "9999999999999",
+                            ConnectionState =
+                                ConnectionState.Connected,
+                            Type = MeteringPointType.Consumption,
+                            SubType = MeteringPointSubType.Physical,
+                            Resolution = new Resolution("PT1H"),
+                            Unit = MeasureUnit.kWh,
+                            ProductId = ProductId.PowerActive,
+                            ParentIdentification = null,
+                            EnergySupplier = "1111111111111",
+                        },
+                         new()
                         {
                             Identification =
                                 new MeteringPointIdentification(
@@ -524,49 +544,7 @@ public class MeteringPointMasterDataProviderTests
                             Unit = MeasureUnit.kWh,
                             ProductId = ProductId.PowerActive,
                             ParentIdentification = null,
-                            EnergySuppliers =
-                            [
-                                new()
-                                {
-                                    Identification =
-                                        new
-                                            MeteringPointIdentification(
-                                                "two-master-data-with-two-energy-suppliers-please"),
-                                    EnergySupplier = "1111111111111",
-                                    StartDate = Instant.FromUtc(
-                                        2021,
-                                        1,
-                                        1,
-                                        0,
-                                        0),
-                                    EndDate = Instant.FromUtc(
-                                        2021,
-                                        2,
-                                        1,
-                                        0,
-                                        0),
-                                },
-                                new()
-                                {
-                                    Identification =
-                                        new
-                                            MeteringPointIdentification(
-                                                "two-master-data-with-two-energy-suppliers-please"),
-                                    EnergySupplier = "2222222222222",
-                                    StartDate = Instant.FromUtc(
-                                        2021,
-                                        2,
-                                        1,
-                                        0,
-                                        0),
-                                    EndDate = Instant.FromUtc(
-                                        2021,
-                                        3,
-                                        1,
-                                        0,
-                                        0),
-                                },
-                            ],
+                            EnergySupplier = "2222222222222",
                         },
                         new()
                         {
@@ -576,6 +554,35 @@ public class MeteringPointMasterDataProviderTests
                             ValidFrom = Instant.FromUtc(
                                 2021,
                                 3,
+                                1,
+                                0,
+                                0),
+                            ValidTo = Instant.FromUtc(
+                                2021,
+                                4,
+                                1,
+                                0,
+                                0),
+                            GridAreaCode = new GridAreaCode("804"),
+                            GridAccessProvider = "9999999999999",
+                            ConnectionState =
+                                ConnectionState.Connected,
+                            Type = MeteringPointType.Consumption,
+                            SubType = MeteringPointSubType.Physical,
+                            Resolution = new Resolution("PT1H"),
+                            Unit = MeasureUnit.kWh,
+                            ProductId = ProductId.PowerActive,
+                            ParentIdentification = null,
+                            EnergySupplier = "1111111111111",
+                        },
+                        new()
+                        {
+                            Identification =
+                                new MeteringPointIdentification(
+                                    "two-master-data-with-two-energy-suppliers-please"),
+                            ValidFrom = Instant.FromUtc(
+                                2021,
+                                4,
                                 1,
                                 0,
                                 0),
@@ -595,49 +602,7 @@ public class MeteringPointMasterDataProviderTests
                             Unit = MeasureUnit.kWh,
                             ProductId = ProductId.PowerActive,
                             ParentIdentification = null,
-                            EnergySuppliers =
-                            [
-                                new()
-                                {
-                                    Identification =
-                                        new
-                                            MeteringPointIdentification(
-                                                "two-master-data-with-two-energy-suppliers-please"),
-                                    EnergySupplier = "1111111111111",
-                                    StartDate = Instant.FromUtc(
-                                        2021,
-                                        3,
-                                        1,
-                                        0,
-                                        0),
-                                    EndDate = Instant.FromUtc(
-                                        2021,
-                                        4,
-                                        1,
-                                        0,
-                                        0),
-                                },
-                                new()
-                                {
-                                    Identification =
-                                        new
-                                            MeteringPointIdentification(
-                                                "two-master-data-with-two-energy-suppliers-please"),
-                                    EnergySupplier = "3333333333333",
-                                    StartDate = Instant.FromUtc(
-                                        2021,
-                                        4,
-                                        1,
-                                        0,
-                                        0),
-                                    EndDate = Instant.FromUtc(
-                                        2021,
-                                        5,
-                                        1,
-                                        0,
-                                        0),
-                                },
-                            ],
+                            EnergySupplier = "22222222222222",
                         },
                     ]),
                 "two-parents-please" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(
@@ -646,6 +611,22 @@ public class MeteringPointMasterDataProviderTests
                     {
                         Identification = new MeteringPointIdentification("two-parents-please"),
                         ValidFrom = Instant.FromUtc(2021, 1, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 2, 1, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = new MeteringPointIdentification("parent-metering-point-id-one"),
+                        EnergySupplier = "1111111111111",
+                    },
+                    new()
+                    {
+                        Identification = new MeteringPointIdentification("two-parents-please"),
+                        ValidFrom = Instant.FromUtc(2021, 2, 1, 0, 0),
                         ValidTo = Instant.FromUtc(2021, 3, 1, 0, 0),
                         GridAreaCode = new GridAreaCode("804"),
                         GridAccessProvider = "9999999999999",
@@ -656,28 +637,28 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = new MeteringPointIdentification("parent-metering-point-id-one"),
-                        EnergySuppliers =
-                        [
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("two-parents-please"),
-                                EnergySupplier = "1111111111111",
-                                StartDate = Instant.FromUtc(2021, 1, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("two-parents-please"),
-                                EnergySupplier = "2222222222222",
-                                StartDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                            },
-                        ],
+                        EnergySupplier = "2222222222222",
                     },
                     new()
                     {
                         Identification = new MeteringPointIdentification("two-parents-please"),
                         ValidFrom = Instant.FromUtc(2021, 3, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 4, 1, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = new MeteringPointIdentification("parent-metering-point-id-two"),
+                        EnergySupplier = "1111111111111",
+                    },
+                    new()
+                    {
+                        Identification = new MeteringPointIdentification("two-parents-please"),
+                        ValidFrom = Instant.FromUtc(2021, 4, 1, 0, 0),
                         ValidTo = Instant.FromUtc(2021, 5, 1, 0, 0),
                         GridAreaCode = new GridAreaCode("804"),
                         GridAccessProvider = "9999999999999",
@@ -688,23 +669,7 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = new MeteringPointIdentification("parent-metering-point-id-two"),
-                        EnergySuppliers =
-                        [
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("two-parents-please"),
-                                EnergySupplier = "1111111111111",
-                                StartDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 4, 1, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("two-parents-please"),
-                                EnergySupplier = "3333333333333",
-                                StartDate = Instant.FromUtc(2021, 4, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 5, 1, 0, 0),
-                            },
-                        ],
+                        EnergySupplier = "3333333333333",
                     },
                 ]),
                 "period-without-and-period-with-parent-please" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(
@@ -714,6 +679,23 @@ public class MeteringPointMasterDataProviderTests
                         Identification =
                             new MeteringPointIdentification("period-without-and-period-with-parent-please"),
                         ValidFrom = Instant.FromUtc(2021, 1, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 2, 1, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = new MeteringPointIdentification("parent-metering-point-id-one"),
+                        EnergySupplier = "1111111111111",
+                    },
+                    new()
+                    {
+                        Identification =
+                            new MeteringPointIdentification("period-without-and-period-with-parent-please"),
+                        ValidFrom = Instant.FromUtc(2021, 2, 1, 0, 0),
                         ValidTo = Instant.FromUtc(2021, 3, 1, 0, 0),
                         GridAreaCode = new GridAreaCode("804"),
                         GridAccessProvider = "9999999999999",
@@ -724,31 +706,30 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = new MeteringPointIdentification("parent-metering-point-id-one"),
-                        EnergySuppliers =
-                        [
-                            new()
-                            {
-                                Identification =
-                                    new MeteringPointIdentification("period-without-and-period-with-parent-please"),
-                                EnergySupplier = "1111111111111",
-                                StartDate = Instant.FromUtc(2021, 1, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification =
-                                    new MeteringPointIdentification("period-without-and-period-with-parent-please"),
-                                EnergySupplier = "2222222222222",
-                                StartDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                            },
-                        ],
+                        EnergySupplier = "2222222222222",
                     },
                     new()
                     {
                         Identification =
                             new MeteringPointIdentification("period-without-and-period-with-parent-please"),
                         ValidFrom = Instant.FromUtc(2021, 3, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 4, 1, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = null,
+                        EnergySupplier = "1111111111111",
+                    },
+                    new()
+                    {
+                        Identification =
+                            new MeteringPointIdentification("period-without-and-period-with-parent-please"),
+                        ValidFrom = Instant.FromUtc(2021, 4, 1, 0, 0),
                         ValidTo = Instant.FromUtc(2021, 5, 1, 0, 0),
                         GridAreaCode = new GridAreaCode("804"),
                         GridAccessProvider = "9999999999999",
@@ -759,25 +740,7 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = null,
-                        EnergySuppliers =
-                        [
-                            new()
-                            {
-                                Identification =
-                                    new MeteringPointIdentification("period-without-and-period-with-parent-please"),
-                                EnergySupplier = "1111111111111",
-                                StartDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 4, 1, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification =
-                                    new MeteringPointIdentification("period-without-and-period-with-parent-please"),
-                                EnergySupplier = "3333333333333",
-                                StartDate = Instant.FromUtc(2021, 4, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 5, 1, 0, 0),
-                            },
-                        ],
+                        EnergySupplier = "3333333333333",
                     },
                 ]),
                 "parent-metering-point-id-one" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
@@ -749,6 +749,22 @@ public class MeteringPointMasterDataProviderTests
                     {
                         Identification = new MeteringPointIdentification("parent-metering-point-id-one"),
                         ValidFrom = Instant.FromUtc(2021, 1, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 1, 16, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = null,
+                        EnergySupplier = "1212121212121",
+                    },
+                    new()
+                    {
+                        Identification = new MeteringPointIdentification("parent-metering-point-id-one"),
+                        ValidFrom = Instant.FromUtc(2021, 1, 16, 0, 0),
                         ValidTo = Instant.FromUtc(2021, 2, 1, 0, 0),
                         GridAreaCode = new GridAreaCode("804"),
                         GridAccessProvider = "9999999999999",
@@ -759,37 +775,39 @@ public class MeteringPointMasterDataProviderTests
                         Unit = MeasureUnit.kWh,
                         ProductId = ProductId.PowerActive,
                         ParentIdentification = null,
-                        EnergySuppliers =
-                        [
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("parent-metering-point-id-one"),
-                                EnergySupplier = "1212121212121",
-                                StartDate = Instant.FromUtc(2021, 1, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 1, 16, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("parent-metering-point-id-one"),
-                                EnergySupplier = "2323232323232",
-                                StartDate = Instant.FromUtc(2021, 1, 16, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("parent-metering-point-id-one"),
-                                EnergySupplier = "3434343434343",
-                                StartDate = Instant.FromUtc(2021, 2, 1, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 2, 16, 0, 0),
-                            },
-                            new()
-                            {
-                                Identification = new MeteringPointIdentification("parent-metering-point-id-one"),
-                                EnergySupplier = "4545454545454",
-                                StartDate = Instant.FromUtc(2021, 2, 16, 0, 0),
-                                EndDate = Instant.FromUtc(2021, 3, 1, 0, 0),
-                            },
-                        ],
+                        EnergySupplier = "2323232323232",
+                    },
+                    new()
+                    {
+                        Identification = new MeteringPointIdentification("parent-metering-point-id-one"),
+                        ValidFrom = Instant.FromUtc(2021, 2, 1, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 2, 16, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = null,
+                        EnergySupplier = "3434343434343",
+                    },
+                    new()
+                    {
+                        Identification = new MeteringPointIdentification("parent-metering-point-id-one"),
+                        ValidFrom = Instant.FromUtc(2021, 2, 16, 0, 0),
+                        ValidTo = Instant.FromUtc(2021, 3, 1, 0, 0),
+                        GridAreaCode = new GridAreaCode("804"),
+                        GridAccessProvider = "9999999999999",
+                        ConnectionState = ConnectionState.Connected,
+                        Type = MeteringPointType.Consumption,
+                        SubType = MeteringPointSubType.Physical,
+                        Resolution = new Resolution("PT1H"),
+                        Unit = MeasureUnit.kWh,
+                        ProductId = ProductId.PowerActive,
+                        ParentIdentification = null,
+                        EnergySupplier = "4545454545454",
                     },
                 ]),
                 "parent-metering-point-id-two" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/ElectricityMarket/MeteringPointMasterDataProviderTests.cs
@@ -524,7 +524,7 @@ public class MeteringPointMasterDataProviderTests
                                     "two-master-data-with-two-energy-suppliers-please"),
                             ValidFrom = Instant.FromUtc(
                                 2021,
-                                1,
+                                2,
                                 1,
                                 0,
                                 0),
@@ -602,7 +602,7 @@ public class MeteringPointMasterDataProviderTests
                             Unit = MeasureUnit.kWh,
                             ProductId = ProductId.PowerActive,
                             ParentIdentification = null,
-                            EnergySupplier = "22222222222222",
+                            EnergySupplier = "3333333333333",
                         },
                     ]),
                 "two-parents-please" => Task.FromResult<IEnumerable<MeteringPointMasterData>>(

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointTypeValidationRuleTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointTypeValidationRuleTests.cs
@@ -55,14 +55,6 @@ public class MeteringPointTypeValidationRuleTests
         MeteringPointType.NetLossCorrection,
     };
 
-    public static TheoryData<MeteringPointType> InvalidMeteringPointTypes => new()
-    {
-        MeteringPointType.ActivatedDownRegulation,
-        MeteringPointType.ActivatedUpRegulation,
-        MeteringPointType.ActualConsumption,
-        MeteringPointType.ActualProduction,
-    };
-
     [Fact]
     public async Task Given_NoMasterData_When_Validate_Then_NoValidationError()
     {
@@ -109,41 +101,6 @@ public class MeteringPointTypeValidationRuleTests
                 ]));
 
         result.Should().BeEmpty();
-    }
-
-    [Theory]
-    [MemberData(nameof(InvalidMeteringPointTypes))]
-    public async Task Given_InvalidMeteringPointType_When_Validate_Then_ValidationError(MeteringPointType meteringPointType)
-    {
-        var input = new ForwardMeteredDataInputV1Builder()
-            .WithMeteringPointType(meteringPointType.Name)
-            .Build();
-
-        var result = await _sut.ValidateAsync(
-            new(
-                input,
-                null,
-                [
-                    new MeteringPointMasterData(
-                        new MeteringPointId("id"),
-                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
-                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
-                        new GridAreaCode("111"),
-                        ActorNumber.Create("1111111111111"),
-                        [],
-                        ConnectionState.Connected,
-                        MeteringPointType.Production,
-                        MeteringPointSubType.Physical,
-                        Resolution.QuarterHourly,
-                        MeasurementUnit.KilowattHour,
-                        "product",
-                        null,
-                        ActorNumber.Create("1111111111112")),
-                ]));
-
-        result.Should()
-            .ContainSingle()
-            .And.BeEquivalentTo(MeteringPointTypeValidationRule.WrongMeteringPointError);
     }
 
     [Fact]

--- a/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
+++ b/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
@@ -15,7 +15,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="DurableFunctionsMonitor.DotNetIsolated" Version="6.6.0" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="6.1.4" />
-    <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.4.0" />
+    <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.6" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Mapper/MeteringPointMasterDataMapper.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Mapper/MeteringPointMasterDataMapper.cs
@@ -46,6 +46,10 @@ public static class MeteringPointMasterDataMapper
         { MeteringPointType.ExchangeReactiveEnergy, PMTypes.MeteringPointType.ExchangeReactiveEnergy },
         { MeteringPointType.CollectiveNetProduction, PMTypes.MeteringPointType.CollectiveNetProduction },
         { MeteringPointType.CollectiveNetConsumption, PMTypes.MeteringPointType.CollectiveNetConsumption },
+        { MeteringPointType.ActivatedDownregulation, PMTypes.MeteringPointType.ActivatedDownRegulation },
+        { MeteringPointType.ActivatedUpregulation, PMTypes.MeteringPointType.ActivatedUpRegulation },
+        { MeteringPointType.ActualConsumption, PMTypes.MeteringPointType.ActualConsumption },
+        { MeteringPointType.ActualProduction, PMTypes.MeteringPointType.ActualProduction },
         { MeteringPointType.InternalUse, PMTypes.MeteringPointType.InternalUse },
     };
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Mapper/MeteringPointMasterDataMapper.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Mapper/MeteringPointMasterDataMapper.cs
@@ -46,10 +46,6 @@ public static class MeteringPointMasterDataMapper
         { MeteringPointType.ExchangeReactiveEnergy, PMTypes.MeteringPointType.ExchangeReactiveEnergy },
         { MeteringPointType.CollectiveNetProduction, PMTypes.MeteringPointType.CollectiveNetProduction },
         { MeteringPointType.CollectiveNetConsumption, PMTypes.MeteringPointType.CollectiveNetConsumption },
-        { MeteringPointType.ActivatedDownregulation, PMTypes.MeteringPointType.ActivatedDownRegulation },
-        { MeteringPointType.ActivatedUpregulation, PMTypes.MeteringPointType.ActivatedUpRegulation },
-        { MeteringPointType.ActualConsumption, PMTypes.MeteringPointType.ActualConsumption },
-        { MeteringPointType.ActualProduction, PMTypes.MeteringPointType.ActualProduction },
         { MeteringPointType.InternalUse, PMTypes.MeteringPointType.InternalUse },
     };
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
- Switched to ElectricityMarket Integration 4.0.5
- Rewrote `GetMasterData` to support normalised data which is returned from `ElectricityMarket`  when getting `MeteringPointMasterData`.
- `GetMasterData` now supports adding slices for parents periods within a childs period. (Written with help from ChatGTP)

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/658
Link to assignment:

## Checklist

- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) https://github.com/Energinet-DataHub/dh3-environments/actions/runs/14500206180
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task
