### PR TITLE
test: Use new event hub for tests

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/OrchestrationsAppFixture.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/OrchestrationsAppFixture.cs
@@ -176,7 +176,6 @@ public class OrchestrationsAppFixture : IAsyncLifetime
         // => Creates BRS-021 Forward Metered Data Start/Notify topics and subscriptions
         await OrchestrationsAppManager.StartAsync(ediEnqueueTopicResources, integrationEventTopicResources);
 
-        // Use new event hub namespace (with support for more event hubs) until TestCommon is updated with the new namespace.
         EventHubListener = new EventHubListenerMock(
             testLogger: new TestDiagnosticsLogger(),
             eventHubFullyQualifiedNamespace: OrchestrationsAppManager.EventHubFullyQualifiedNamespace,

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/OrchestrationsAppFixture.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/OrchestrationsAppFixture.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.Core.DurableFunctionApp.TestCommon.DurableTask;
+using Energinet.DataHub.Core.FunctionApp.TestCommon;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ListenerMock;
@@ -175,13 +176,14 @@ public class OrchestrationsAppFixture : IAsyncLifetime
         // => Creates BRS-021 Forward Metered Data Start/Notify topics and subscriptions
         await OrchestrationsAppManager.StartAsync(ediEnqueueTopicResources, integrationEventTopicResources);
 
+        // Use new event hub namespace (with support for more event hubs) until TestCommon is updated with the new namespace.
         EventHubListener = new EventHubListenerMock(
-            new TestDiagnosticsLogger(),
-            IntegrationTestConfiguration.EventHubFullyQualifiedNamespace,
+            testLogger: new TestDiagnosticsLogger(),
+            eventHubFullyQualifiedNamespace: OrchestrationsAppManager.EventHubFullyQualifiedNamespace,
             eventHubName: OrchestrationsAppManager.MeasurementEventHubName,
-            AzuriteManager.BlobStorageServiceUri,
+            blobStorageServiceUri: AzuriteManager.BlobStorageServiceUri,
             blobContainerName: "container-01",
-            IntegrationTestConfiguration.Credential);
+            credential: IntegrationTestConfiguration.Credential);
         await EventHubListener.InitializeAsync();
     }
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -108,13 +108,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             [$"{MeasurementsMeteredDataClientOptions.SectionName}:{nameof(MeasurementsMeteredDataClientOptions.EventHubName)}"]
                 = _fixture.OrchestrationsAppManager.MeasurementEventHubName,
             [$"{MeasurementsMeteredDataClientOptions.SectionName}:{nameof(MeasurementsMeteredDataClientOptions.FullyQualifiedNamespace)}"]
-                = _fixture.IntegrationTestConfiguration.EventHubFullyQualifiedNamespace,
+                = _fixture.OrchestrationsAppManager.EventHubFullyQualifiedNamespace,
 
             // Process Manager Eventhub client to simulate the notification event from measurements
             [$"{ProcessManagerEventHubOptions.SectionName}:{nameof(ProcessManagerEventHubOptions.EventHubName)}"]
                 = _fixture.OrchestrationsAppManager.ProcessManagerEventhubName,
             [$"{ProcessManagerEventHubOptions.SectionName}:{nameof(ProcessManagerEventHubOptions.FullyQualifiedNamespace)}"]
-                = _fixture.IntegrationTestConfiguration.EventHubFullyQualifiedNamespace,
+                = _fixture.OrchestrationsAppManager.EventHubFullyQualifiedNamespace,
 
             // Process Manager message client
             [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]

--- a/source/Shared/Tests/Fixtures/OrchestrationsAppManager.cs
+++ b/source/Shared/Tests/Fixtures/OrchestrationsAppManager.cs
@@ -15,6 +15,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Azure.Messaging.ServiceBus.Administration;
+using Energinet.DataHub.Core.FunctionApp.TestCommon;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvider;
@@ -101,14 +102,21 @@ public class OrchestrationsAppManager : IAsyncDisposable
             IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace,
             IntegrationTestConfiguration.Credential);
 
+        // Use new event hub namespace (with support for more event hubs) until TestCommon is updated with the new namespace.
+        EventHubNamespace = IntegrationTestConfiguration.Configuration.GetValue("AZURE-EVENTHUB-NAMESPACE-PREMIUM");
         EventHubResourceProvider = new EventHubResourceProvider(
             new TestDiagnosticsLogger(),
-            IntegrationTestConfiguration.EventHubNamespaceName,
+            EventHubNamespace,
             IntegrationTestConfiguration.ResourceManagementSettings,
             IntegrationTestConfiguration.Credential);
 
         MockServer = WireMockServer.Start(port: wireMockServerPort);
     }
+
+    // Use new event hub namespace (with support for more event hubs) until TestCommon is updated with the new namespace.
+    public string EventHubNamespace { get; }
+
+    public string EventHubFullyQualifiedNamespace => $"{EventHubNamespace}.servicebus.windows.net";
 
     public ProcessManagerDatabaseManager DatabaseManager { get; }
 
@@ -415,7 +423,7 @@ public class OrchestrationsAppManager : IAsyncDisposable
             processManagerEventhubResource.Name);
         appHostSettings.ProcessEnvironmentVariables.Add(
             $"{ProcessManagerEventHubOptions.SectionName}__{nameof(ProcessManagerEventHubOptions.FullyQualifiedNamespace)}",
-            IntegrationTestConfiguration.EventHubFullyQualifiedNamespace);
+            EventHubFullyQualifiedNamespace);
 
         // Measurements Metered Data Event Hub
         appHostSettings.ProcessEnvironmentVariables.Add(
@@ -423,7 +431,7 @@ public class OrchestrationsAppManager : IAsyncDisposable
             MeasurementEventHubName);
         appHostSettings.ProcessEnvironmentVariables.Add(
             $"{MeasurementsMeteredDataClientOptions.SectionName}__{nameof(MeasurementsMeteredDataClientOptions.FullyQualifiedNamespace)}",
-            IntegrationTestConfiguration.EventHubFullyQualifiedNamespace);
+            EventHubFullyQualifiedNamespace);
 
         // Electric Market client
         appHostSettings.ProcessEnvironmentVariables.Add(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

This PR updates the test setup to use a new event hub namespace configuration for integration tests. The changes update environment variable references and add a new property in the OrchestrationsAppManager to support the new event hub namespace until TestCommon is updated.

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
