### PR TITLE
feat: measurement unit validation rule for brs021-ForwardMeteredData

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/ForwardMeteredDataBusinessValidatedDtoValidatorTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/ForwardMeteredDataBusinessValidatedDtoValidatorTests.cs
@@ -331,4 +331,39 @@ public class ForwardMeteredDataBusinessValidatedDtoValidatorTests
             .ContainSingle()
             .And.BeEquivalentTo(PositionCountValidationRule.IncorrectNumberOfPositionsError(744, 2976));
     }
+
+    [Fact]
+    public async Task Given_InvalidMeasurementUnit_When_Validate_Then_ValidationError()
+    {
+        var invalidMeasurementUnit = "InvalidMeasurementUnit";
+        var input = new ForwardMeteredDataInputV1Builder()
+            .WithMeasureUnit(invalidMeasurementUnit)
+            .Build();
+
+        var meteringPointMasterData = new MeteringPointMasterData(
+            MeteringPointId: new MeteringPointId(input.MeteringPointId!),
+            GridAreaCode: new GridAreaCode("804"),
+            GridAccessProvider: ActorNumber.Create(input.GridAccessProviderNumber),
+            ConnectionState: ConnectionState.Connected,
+            MeteringPointType: MeteringPointType.FromName(input.MeteringPointType!),
+            MeteringPointSubType: MeteringPointSubType.Physical,
+            MeasurementUnit: MeasurementUnit.KilowattHour,
+            ValidFrom: SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+            ValidTo: SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+            NeighborGridAreaOwners: [],
+            Resolution: Resolution.Hourly,
+            ProductId: "product",
+            ParentMeteringPointId: null,
+            EnergySupplier: ActorNumber.Create("1111111111112"));
+        var result = await _sut.ValidateAsync(
+            new ForwardMeteredDataBusinessValidatedDto(
+                Input: input,
+                CurrentMasterData: meteringPointMasterData,
+                HistoricalMeteringPointMasterData: [
+                    meteringPointMasterData,
+                ]));
+        result.Should()
+            .ContainSingle()
+            .And.BeEquivalentTo(MeasurementUnitValidationRule.MeteringPointConnectionStateError);
+    }
 }

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeasurementUnitValidationRuleTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeasurementUnitValidationRuleTests.cs
@@ -1,0 +1,214 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Shared.ElectricityMarket.Model;
+using FluentAssertions;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
+
+public class MeasurementUnitValidationRuleTests
+{
+    private readonly MeasurementUnitValidationRule _sut = new();
+
+    public static TheoryData<MeasurementUnit> ValidMeasurementUnits => new()
+    {
+        MeasurementUnit.KilowattHour,
+        MeasurementUnit.KiloVoltAmpereReactiveHour,
+    };
+
+    public static TheoryData<MeasurementUnit> InvalidMeasurementUnits => new()
+    {
+        MeasurementUnit.Ampere,
+        MeasurementUnit.Pieces,
+        MeasurementUnit.Kilowatt,
+        MeasurementUnit.Megawatt,
+        MeasurementUnit.MegawattHour,
+        MeasurementUnit.MetricTon,
+        MeasurementUnit.MegaVoltAmpereReactivePower,
+        MeasurementUnit.DanishTariffCode,
+    };
+
+    [Fact]
+    public async Task Given_NoMasterData_When_Validate_Then_NoValidationError()
+    {
+        var input = new ForwardMeteredDataInputV1Builder()
+            .Build();
+
+        var result = await _sut.ValidateAsync(
+            new(
+                input,
+                null,
+                []));
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidMeasurementUnits))]
+    public async Task Given_ValidMeasurementUnits_When_Validate_Then_NoValidationError(MeasurementUnit measurementUnit)
+    {
+        var input = new ForwardMeteredDataInputV1Builder()
+            .WithMeasureUnit(measurementUnit.Name)
+            .Build();
+
+        var result = await _sut.ValidateAsync(
+            new(
+                input,
+                null,
+                [
+                    new MeteringPointMasterData(
+                        new MeteringPointId("id"),
+                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        new GridAreaCode("111"),
+                        ActorNumber.Create("1111111111111"),
+                        [],
+                        ConnectionState.Connected,
+                        MeteringPointType.Production,
+                        MeteringPointSubType.Physical,
+                        Resolution.QuarterHourly,
+                        measurementUnit,
+                        "product",
+                        null,
+                        ActorNumber.Create("1111111111112")),
+                ]));
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidMeasurementUnits))]
+    public async Task Given_InvalidMeasurementUnits_When_Validate_Then_NoValidationError(MeasurementUnit measurementUnit)
+    {
+        var input = new ForwardMeteredDataInputV1Builder()
+            .WithMeasureUnit(measurementUnit.Name)
+            .Build();
+
+        var result = await _sut.ValidateAsync(
+            new(
+                input,
+                null,
+                [
+                    new MeteringPointMasterData(
+                        new MeteringPointId("id"),
+                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        new GridAreaCode("111"),
+                        ActorNumber.Create("1111111111111"),
+                        [],
+                        ConnectionState.Connected,
+                        MeteringPointType.Production,
+                        MeteringPointSubType.Physical,
+                        Resolution.QuarterHourly,
+                        measurementUnit,
+                        "product",
+                        null,
+                        ActorNumber.Create("1111111111112")),
+                ]));
+
+        result.Should()
+            .ContainSingle()
+            .And.BeEquivalentTo(MeasurementUnitValidationRule.MeteringPointConnectionStateError);
+    }
+
+    [Fact]
+    public async Task Given_DifferentMeasurementUnitFromMasterData_When_Validate_Then_ValidationError()
+    {
+        var input = new ForwardMeteredDataInputV1Builder()
+            .Build();
+
+        var result = await _sut.ValidateAsync(new(
+            input,
+            null,
+            [
+                new MeteringPointMasterData(
+                    new MeteringPointId("id"),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    new GridAreaCode("111"),
+                    ActorNumber.Create("1111111111111"),
+                    [],
+                    ConnectionState.Connected,
+                    MeteringPointType.Production,
+                    MeteringPointSubType.Physical,
+                    Resolution.QuarterHourly,
+                    // One MeasurementUnit
+                    MeasurementUnit.KilowattHour,
+                    "product",
+                    null,
+                    ActorNumber.Create("1111111111112")),
+                new MeteringPointMasterData(
+                    new MeteringPointId("id"),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    new GridAreaCode("111"),
+                    ActorNumber.Create("1111111111111"),
+                    [],
+                    ConnectionState.Connected,
+                    MeteringPointType.Production,
+                    MeteringPointSubType.Physical,
+                    Resolution.QuarterHourly,
+                    // A different MeasurementUnit
+                    MeasurementUnit.KiloVoltAmpereReactiveHour,
+                    "product",
+                    null,
+                    ActorNumber.Create("1111111111112")),
+            ]));
+
+        result.Should()
+            .ContainSingle()
+            .And.BeEquivalentTo(MeasurementUnitValidationRule.MeteringPointConnectionStateError);
+    }
+
+    [Fact]
+    public async Task Given_IncomingMeasurementUnitDoesNotMatchMasterDataMeasurementUnit_When_Validate_Then_ValidationError()
+    {
+        var input = new ForwardMeteredDataInputV1Builder()
+            // Incoming MeasurementUnit
+            .WithMeasureUnit(MeasurementUnit.KiloVoltAmpereReactiveHour.Name)
+            .Build();
+
+        var result = await _sut.ValidateAsync(new(
+            input,
+            null,
+            [
+                new MeteringPointMasterData(
+                    new MeteringPointId("id"),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    new GridAreaCode("111"),
+                    ActorNumber.Create("1111111111111"),
+                    [],
+                    ConnectionState.Connected,
+                    MeteringPointType.Consumption,
+                    MeteringPointSubType.Physical,
+                    Resolution.QuarterHourly,
+                    // MeasurementUnit different from incoming
+                    MeasurementUnit.KilowattHour,
+                    "product",
+                    null,
+                    ActorNumber.Create("1111111111112")),
+            ]));
+
+        result.Should()
+            .ContainSingle()
+            .And.BeEquivalentTo(MeasurementUnitValidationRule.MeteringPointConnectionStateError);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeasurementUnitValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeasurementUnitValidationRule.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
+
+public class MeasurementUnitValidationRule
+    : IBusinessValidationRule<ForwardMeteredDataBusinessValidatedDto>
+{
+    public static IList<ValidationError> MeteringPointConnectionStateError => [new(
+        Message: "Energienhed skal svare til energienhed på målepunktet/Measure unit must be the same as the one registrered on the meteringpoint",
+        ErrorCode: "E73")];
+
+    private static IList<ValidationError> NoError => [];
+
+    private static IReadOnlyCollection<MeasurementUnit> AllowedMeasurementUnits => new[]
+    {
+        MeasurementUnit.KilowattHour,
+        MeasurementUnit.KiloVoltAmpereReactiveHour,
+    };
+
+    public Task<IList<ValidationError>> ValidateAsync(
+        ForwardMeteredDataBusinessValidatedDto subject)
+    {
+        if (subject.HistoricalMeteringPointMasterData.Count == 0)
+        {
+            return Task.FromResult(NoError);
+        }
+
+        var incomingMeasurementUnit = MeasurementUnit.FromNameOrDefault(subject.Input.MeasureUnit);
+        if (!AllowedMeasurementUnits.Contains(incomingMeasurementUnit))
+        {
+            return Task.FromResult(MeteringPointConnectionStateError);
+        }
+
+        // Check if the measure unit is same for all historic master data
+        if (subject.HistoricalMeteringPointMasterData
+            .Select(mpmd => mpmd.MeasurementUnit)
+            .Any(meteringPointType => meteringPointType != incomingMeasurementUnit))
+        {
+            return Task.FromResult(MeteringPointConnectionStateError);
+        }
+
+        return Task.FromResult(NoError);
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
A new validation rule was added to ensure that incoming metered data has the correct measurement unit according to master data and allowed types. 

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/667
