### PR TITLE
feat: metering point sub type  validation rule for brs021-ForwardMeteredData

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/ForwardMeteredDataBusinessValidatedDtoValidatorTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/ForwardMeteredDataBusinessValidatedDtoValidatorTests.cs
@@ -331,4 +331,38 @@ public class ForwardMeteredDataBusinessValidatedDtoValidatorTests
             .ContainSingle()
             .And.BeEquivalentTo(PositionCountValidationRule.IncorrectNumberOfPositionsError(744, 2976));
     }
+
+    [Fact]
+    public async Task Given_InvalidMeteringPointSubType_When_Validate_Then_ValidationError()
+    {
+        var invalidMeteringPointSubType = MeteringPointSubType.Calculated;
+        var input = new ForwardMeteredDataInputV1Builder()
+            .Build();
+
+        var meteringPointMasterData = new MeteringPointMasterData(
+            MeteringPointId: new MeteringPointId(input.MeteringPointId!),
+            GridAreaCode: new GridAreaCode("804"),
+            GridAccessProvider: ActorNumber.Create(input.GridAccessProviderNumber),
+            ConnectionState: ConnectionState.Connected,
+            MeteringPointType: MeteringPointType.FromName(input.MeteringPointType!),
+            MeteringPointSubType: invalidMeteringPointSubType,
+            MeasurementUnit: MeasurementUnit.FromName(input.MeasureUnit!),
+            ValidFrom: SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+            ValidTo: SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+            NeighborGridAreaOwners: [],
+            Resolution: Resolution.Hourly,
+            ProductId: "product",
+            ParentMeteringPointId: null,
+            EnergySupplier: ActorNumber.Create("1111111111112"));
+        var result = await _sut.ValidateAsync(
+            new ForwardMeteredDataBusinessValidatedDto(
+                Input: input,
+                CurrentMasterData: meteringPointMasterData,
+                HistoricalMeteringPointMasterData: [
+                    meteringPointMasterData,
+                ]));
+        result.Should()
+            .ContainSingle()
+            .And.BeEquivalentTo(MeteringPointSubTypeValidationRule.WrongMeteringPointSubTypeError);
+    }
 }

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRuleTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRuleTests.cs
@@ -1,0 +1,171 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Shared.ElectricityMarket.Model;
+using FluentAssertions;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
+
+public class MeteringPointSubTypeValidationRuleTests
+{
+    private readonly MeteringPointSubTypeValidationRule _sut = new();
+
+    public static TheoryData<MeteringPointSubType> ValidMeteringPointSubTypes => new()
+    {
+        MeteringPointSubType.Physical,
+        MeteringPointSubType.Virtual,
+    };
+
+    public static TheoryData<MeteringPointSubType> InvalidMeteringPointSubTypes => new()
+    {
+        MeteringPointSubType.Calculated,
+    };
+
+    [Fact]
+    public async Task Given_NoMasterData_When_Validate_Then_NoValidationError()
+    {
+        var input = new ForwardMeteredDataInputV1Builder()
+            .Build();
+
+        var result = await _sut.ValidateAsync(
+            new(
+                input,
+                null,
+                []));
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidMeteringPointSubTypes))]
+    public async Task Given_ValidMeteringPointSubTypes_When_Validate_Then_NoValidationError(MeteringPointSubType meteringPointSubType)
+    {
+        // Metering point subtype is not part of the input, its only part of the master data
+        var input = new ForwardMeteredDataInputV1Builder()
+            .Build();
+
+        var result = await _sut.ValidateAsync(
+            new(
+                input,
+                null,
+                [
+                    new MeteringPointMasterData(
+                        new MeteringPointId("id"),
+                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        new GridAreaCode("111"),
+                        ActorNumber.Create("1111111111111"),
+                        [],
+                        ConnectionState.Connected,
+                        MeteringPointType.Production,
+                        meteringPointSubType,
+                        Resolution.QuarterHourly,
+                        MeasurementUnit.KilowattHour,
+                        "product",
+                        null,
+                        ActorNumber.Create("1111111111112")),
+                ]));
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidMeteringPointSubTypes))]
+    public async Task Given_InvalidMeteringPointSubType_When_Validate_Then_NoValidationError(MeteringPointSubType meteringPointSubType)
+    {
+        // Metering point subtype is not part of the input, its only part of the master data
+        var input = new ForwardMeteredDataInputV1Builder()
+            .Build();
+
+        var result = await _sut.ValidateAsync(
+            new(
+                input,
+                null,
+                [
+                    new MeteringPointMasterData(
+                        new MeteringPointId("id"),
+                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                        new GridAreaCode("111"),
+                        ActorNumber.Create("1111111111111"),
+                        [],
+                        ConnectionState.Connected,
+                        MeteringPointType.Production,
+                        meteringPointSubType,
+                        Resolution.QuarterHourly,
+                        MeasurementUnit.KilowattHour,
+                        "product",
+                        null,
+                        ActorNumber.Create("1111111111112")),
+                ]));
+
+        result.Should()
+            .ContainSingle()
+            .And.BeEquivalentTo(MeteringPointSubTypeValidationRule.WrongMeteringPointSubTypeError);
+    }
+
+    [Fact]
+    public async Task Given_DifferentMeteringPointSubTypeFromMasterData_When_Validate_Then_ValidationError()
+    {
+        var input = new ForwardMeteredDataInputV1Builder()
+            .Build();
+
+        var result = await _sut.ValidateAsync(new(
+            input,
+            null,
+            [
+                new MeteringPointMasterData(
+                    new MeteringPointId("id"),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    new GridAreaCode("111"),
+                    ActorNumber.Create("1111111111111"),
+                    [],
+                    ConnectionState.Connected,
+                    MeteringPointType.Production,
+                    // One MeteringPointSubType
+                    MeteringPointSubType.Physical,
+                    Resolution.QuarterHourly,
+                    MeasurementUnit.KilowattHour,
+                    "product",
+                    null,
+                    ActorNumber.Create("1111111111112")),
+                new MeteringPointMasterData(
+                    new MeteringPointId("id"),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    SystemClock.Instance.GetCurrentInstant().ToDateTimeOffset(),
+                    new GridAreaCode("111"),
+                    ActorNumber.Create("1111111111111"),
+                    [],
+                    ConnectionState.Connected,
+                    MeteringPointType.Production,
+                    // A different MeteringPointSubType
+                    MeteringPointSubType.Virtual,
+                    Resolution.QuarterHourly,
+                    MeasurementUnit.KilowattHour,
+                    "product",
+                    null,
+                    ActorNumber.Create("1111111111112")),
+            ]));
+
+        result.Should()
+            .ContainSingle()
+            .And.BeEquivalentTo(MeteringPointSubTypeValidationRule.WrongMeteringPointSubTypeError);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRule.cs
@@ -41,7 +41,7 @@ public class MeteringPointSubTypeValidationRule
             return Task.FromResult(NoError);
         }
 
-        // Check if the metering point subtype is same for all historic master data
+        // Check if the metering point subtype is the same for all historic master data
         var uniqueMeteringPointSubTypes = subject.HistoricalMeteringPointMasterData
             .Select(mpmd => mpmd.MeteringPointSubType)
             .Distinct()

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRule.cs
@@ -23,7 +23,7 @@ public class MeteringPointSubTypeValidationRule
     : IBusinessValidationRule<ForwardMeteredDataBusinessValidatedDto>
 {
     public static IList<ValidationError> WrongMeteringPointSubTypeError => [new(
-        Message: "Målepunktet skal være enten fysisk eller virtuelt/meteringpoint must be either physical or virtual",
+        Message: "Målepunktet skal være enten fysisk eller virtuelt/metering point must be either physical or virtual",
         ErrorCode: "D37")];
 
     private static IList<ValidationError> NoError => [];

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRule.cs
@@ -1,0 +1,63 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Shared.ElectricityMarket.Model;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.BusinessValidation;
+
+public class MeteringPointSubTypeValidationRule
+    : IBusinessValidationRule<ForwardMeteredDataBusinessValidatedDto>
+{
+    public static IList<ValidationError> WrongMeteringPointSubTypeError => [new(
+        Message: "Målepunktet skal være enten fysisk eller virtuelt/meteringpoint must be either physical or virtual",
+        ErrorCode: "D37")];
+
+    private static IList<ValidationError> NoError => [];
+
+    private static IReadOnlyCollection<MeteringPointSubType> AllowedMeteringPointTypes => new[]
+    {
+        MeteringPointSubType.Physical,
+        MeteringPointSubType.Virtual,
+    };
+
+    public Task<IList<ValidationError>> ValidateAsync(ForwardMeteredDataBusinessValidatedDto subject)
+    {
+        if (subject.HistoricalMeteringPointMasterData.Count == 0)
+        {
+            return Task.FromResult(NoError);
+        }
+
+        // Check if the metering point subtype is same for all historic master data
+        var uniqueMeteringPointSubTypes = subject.HistoricalMeteringPointMasterData
+            .Select(mpmd => mpmd.MeteringPointSubType)
+            .Distinct()
+            .ToList();
+        if (uniqueMeteringPointSubTypes.Count() != 1)
+        {
+            return Task.FromResult(WrongMeteringPointSubTypeError);
+        }
+
+        // Check if the metering point subtype is allowed
+        var meteringPointSubType = uniqueMeteringPointSubTypes.First();
+        if (!AllowedMeteringPointTypes.Contains(meteringPointSubType))
+        {
+            return Task.FromResult(WrongMeteringPointSubTypeError);
+        }
+
+        return Task.FromResult(NoError);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointSubTypeValidationRule.cs
@@ -28,7 +28,7 @@ public class MeteringPointSubTypeValidationRule
 
     private static IList<ValidationError> NoError => [];
 
-    private static IReadOnlyCollection<MeteringPointSubType> AllowedMeteringPointTypes => new[]
+    private static IReadOnlyCollection<MeteringPointSubType> AllowedMeteringPointSubTypes => new[]
     {
         MeteringPointSubType.Physical,
         MeteringPointSubType.Virtual,
@@ -53,7 +53,7 @@ public class MeteringPointSubTypeValidationRule
 
         // Check if the metering point subtype is allowed
         var meteringPointSubType = uniqueMeteringPointSubTypes.First();
-        if (!AllowedMeteringPointTypes.Contains(meteringPointSubType))
+        if (!AllowedMeteringPointSubTypes.Contains(meteringPointSubType))
         {
             return Task.FromResult(WrongMeteringPointSubTypeError);
         }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
A new validation rule was added to ensure master data for the metering point has the correct metering point subtype.


## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => http://github.com/Energinet-DataHub/dh3-environments/actions/runs/14635295480
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/687