### PR TITLE
feat: Use calculated measure data query in BRS-021 Electrical Heating Calculation

### DIFF
--- a/source/ProcessManager.Components.Tests/Fixtures/HealthChecksFixture.cs
+++ b/source/ProcessManager.Components.Tests/Fixtures/HealthChecksFixture.cs
@@ -60,7 +60,7 @@ public sealed class HealthChecksFixture : IDisposable
                 services.AddRouting();
 
                 // Register Databricks Jobs with health check
-                services.AddDatabricksJobs();
+                services.AddDatabricksJobsApi();
             })
             .Configure(app =>
             {

--- a/source/ProcessManager.Components.Tests/Unit/Databricks/Jobs/DatabricksJobsClientWiremockTests.cs
+++ b/source/ProcessManager.Components.Tests/Unit/Databricks/Jobs/DatabricksJobsClientWiremockTests.cs
@@ -40,7 +40,7 @@ public class DatabricksJobsClientWiremockTests : IAsyncLifetime
             [$"{_wholesaleSectionName}:{nameof(DatabricksWorkspaceOptions.Token)}"] = "not-empty",
         });
 
-        Services.AddDatabricksJobs(_wholesaleSectionName);
+        Services.AddDatabricksJobsApi(_wholesaleSectionName);
 
         ServiceProvider = Services.BuildServiceProvider();
         Sut = ServiceProvider.GetRequiredKeyedService<IDatabricksJobsClient>(_wholesaleSectionName);

--- a/source/ProcessManager.Components.Tests/Unit/Extensions/DependencyInjection/DatabricksWorkspaceExtensionsTests.cs
+++ b/source/ProcessManager.Components.Tests/Unit/Extensions/DependencyInjection/DatabricksWorkspaceExtensionsTests.cs
@@ -49,7 +49,7 @@ public class DatabricksWorkspaceExtensionsTests
         });
 
         // Act
-        Services.AddDatabricksJobs();
+        Services.AddDatabricksJobsApi();
 
         // Assert
         using var assertionScope = new AssertionScope();
@@ -89,7 +89,7 @@ public class DatabricksWorkspaceExtensionsTests
         });
 
         // Act
-        Services.AddDatabricksJobs(configSectionPath: sectionName);
+        Services.AddDatabricksJobsApi(configSectionPath: sectionName);
 
         // Assert
         using var assertionScope = new AssertionScope();
@@ -134,8 +134,8 @@ public class DatabricksWorkspaceExtensionsTests
             [$"{measurementsSectionName}:{nameof(DatabricksWorkspaceOptions.Token)}"] = TokenFake,
         });
 
-        Services.AddDatabricksJobs(configSectionPath: wholesaleSectionName);
-        Services.AddDatabricksJobs(configSectionPath: measurementsSectionName);
+        Services.AddDatabricksJobsApi(configSectionPath: wholesaleSectionName);
+        Services.AddDatabricksJobsApi(configSectionPath: measurementsSectionName);
 
         // Act
         Services.AddTransient<WholesaleClientStub>();

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/DatabricksWorkspaceExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/DatabricksWorkspaceExtensions.cs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Diagnostics.HealthChecks;
 using Energinet.DataHub.ProcessManager.Components.Databricks.Jobs;
 using Energinet.DataHub.ProcessManager.Components.Extensions.Builder;
 using Energinet.DataHub.ProcessManager.Components.Extensions.Options;
 using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -33,10 +36,10 @@ public static class DatabricksWorkspaceExtensions
     /// </summary>
     /// <remarks>
     /// If your application needs to access multiple Databricks workspaces, use the overloaded
-    /// method <see cref="AddDatabricksJobs(IServiceCollection, string)"/> that allows you to specify
+    /// method <see cref="AddDatabricksJobsApi(IServiceCollection, string)"/> that allows you to specify
     /// the configuration section name.
     /// </remarks>
-    public static IServiceCollection AddDatabricksJobs(this IServiceCollection serviceCollection)
+    public static IServiceCollection AddDatabricksJobsApi(this IServiceCollection serviceCollection)
     {
         serviceCollection
             .AddOptions<DatabricksWorkspaceOptions>()
@@ -73,7 +76,7 @@ public static class DatabricksWorkspaceExtensions
     /// </remarks>
     /// <param name="serviceCollection"></param>
     /// <param name="configSectionPath">Name of the config section from which we read options.</param>
-    public static IServiceCollection AddDatabricksJobs(this IServiceCollection serviceCollection, string configSectionPath)
+    public static IServiceCollection AddDatabricksJobsApi(this IServiceCollection serviceCollection, string configSectionPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(configSectionPath);
 
@@ -103,6 +106,22 @@ public static class DatabricksWorkspaceExtensions
             .AddDatabricksJobsApi(
                 serviceKey: configSectionPath,
                 name: $"{configSectionPath}: Databricks Jobs API");
+
+        return serviceCollection;
+    }
+
+    /// <summary>
+    /// Register Databricks SQL statement API services, options and health check for use with a Databricks workspace.
+    /// <remarks>Requires <see cref="DatabricksSqlStatementOptions"/> settings to exist in the app configuration.</remarks>
+    /// </summary>
+    public static IServiceCollection AddDatabricksSqlStatementApi(this IServiceCollection serviceCollection, IConfiguration configuration)
+    {
+        serviceCollection
+            .AddDatabricksSqlStatementExecution(configuration);
+
+        serviceCollection
+            .AddHealthChecks()
+            .AddDatabricksSqlStatementApiHealthCheck(name: "Databricks SQL statement API");
 
         return serviceCollection;
     }

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ElectricityMarketViewsWireMockExtensions.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ElectricityMarketViewsWireMockExtensions.cs
@@ -17,6 +17,8 @@ using System.Text.Json;
 using Energinet.DataHub.ElectricityMarket.Integration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Microsoft.Net.Http.Headers;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -36,13 +38,13 @@ public static class ElectricityMarketViewsWireMockExtensions
         var request = Request
             .Create()
             .WithPath("/api/get-metering-point-master-data")
-            .UsingGet();
+            .UsingPost();
 
         var response = Response
             .Create()
             .WithStatusCode(HttpStatusCode.OK)
             .WithHeader(HeaderNames.ContentType, "application/json")
-            .WithBody(JsonSerializer.Serialize(mockData));
+            .WithBody(JsonSerializer.Serialize(mockData, new JsonSerializerOptions().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb)));
 
         server
             .Given(request)

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ElectricityMarketViewsWireMockExtensions.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ElectricityMarketViewsWireMockExtensions.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Text.Json;
+using Energinet.DataHub.ElectricityMarket.Integration;
+using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
+using Microsoft.Net.Http.Headers;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
+
+public static class ElectricityMarketViewsWireMockExtensions
+{
+    /// <summary>
+    /// Mock <see cref="IElectricityMarketViews"/> <see cref="IElectricityMarketViews.GetMeteringPointMasterDataChangesAsync"/> endpoint, which can be found at:
+    /// https://github.com/Energinet-DataHub/geh-electricity-market/blob/main/source/electricity-market/ElectricityMarket.Integration/ElectricityMarketViews.cs
+    /// </summary>
+    public static WireMockServer MockElectricityMarketViewsMasterData(
+        this WireMockServer server,
+        IEnumerable<MeteringPointMasterData> mockData)
+    {
+        var request = Request
+            .Create()
+            .WithPath("/api/get-metering-point-master-data")
+            .UsingGet();
+
+        var response = Response
+            .Create()
+            .WithStatusCode(HttpStatusCode.OK)
+            .WithHeader(HeaderNames.ContentType, "application/json")
+            .WithBody(JsonSerializer.Serialize(mockData));
+
+        server
+            .Given(request)
+            .RespondWith(response);
+
+        return server;
+    }
+}

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ElectricityMarketViewsWireMockExtensions.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/Extensions/ElectricityMarketViewsWireMockExtensions.cs
@@ -44,7 +44,9 @@ public static class ElectricityMarketViewsWireMockExtensions
             .Create()
             .WithStatusCode(HttpStatusCode.OK)
             .WithHeader(HeaderNames.ContentType, "application/json")
-            .WithBody(JsonSerializer.Serialize(mockData, new JsonSerializerOptions().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb)));
+            .WithBody(JsonSerializer.Serialize(
+                    mockData,
+                    new JsonSerializerOptions().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb)));
 
         server
             .Given(request)

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.TestCommon;
+using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Client;
@@ -95,6 +96,29 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             RunLifeCycleState.TERMINATED,
             CalculationJobName);
 
+        const string meteringPointId = "1234567890123456";
+
+        // Mocking the Electricity Market Views master data API
+        Fixture.OrchestrationsAppManager.MockServer.MockElectricityMarketViewsMasterData(mockData: [
+            new MeteringPointMasterData
+            {
+                Identification = new MeteringPointIdentification(meteringPointId),
+                ValidFrom = Instant.FromUtc(2025, 04, 24, 22, 00),
+                ValidTo = Instant.FromUtc(2025, 12, 25, 22, 00),
+                GridAreaCode = new GridAreaCode("804"),
+                GridAccessProvider = "1111111111111",
+                NeighborGridAreaOwners = ["2222222222222"],
+                ConnectionState = ConnectionState.Connected,
+                Type = MeteringPointType.ElectricalHeating,
+                SubType = MeteringPointSubType.Physical,
+                Resolution = new Resolution("PT15M"),
+                Unit = MeasureUnit.kWh,
+                ProductId = ProductId.EnergyActive,
+                ParentIdentification = null,
+                EnergySupplier = "3333333333333",
+            },
+        ]);
+
         var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
 
         // Step 1: Start new calculation orchestration instance
@@ -112,7 +136,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                     OrchestrationInstanceId: orchestrationInstanceId,
                     TransactionId: Guid.NewGuid(),
                     TransactionCreationDatetime: Instant.FromUtc(2025, 04, 25, 13, 37),
-                    MeteringPointId: "1234567890123456",
+                    MeteringPointId: meteringPointId,
                     MeteringPointType: "electrical_heating",
                     ObservationTime: Instant.FromUtc(2025, 04, 25, 13, 30),
                     Quantity: 1337.42m),

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -89,7 +89,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Calculation_WhenStarted_CanMonitorLifecycle()
+    public async Task Given_StartElectricalHeatingCalculationCommand_When_Started_Then_OrchestrationInstanceTerminatesWithSuccess()
     {
         // Mocking the databricks jobs api, forcing it to return a terminated successful job status
         Fixture.OrchestrationsAppManager.MockServer.MockDatabricksJobStatusResponse(

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/Databricks/SqlStatements/CalculatedMeasurementsQuery.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/Databricks/SqlStatements/CalculatedMeasurementsQuery.cs
@@ -83,7 +83,7 @@ internal class CalculatedMeasurementsQuery(
 
     protected override bool BelongsToSameGroup(DatabricksSqlRow currentRow, DatabricksSqlRow previousRow)
     {
-        return previousRow?.ToGuid(CalculatedMeasurementsColumnNames.TransactionId) == currentRow.ToGuid(CalculatedMeasurementsColumnNames.TransactionId);
+        return previousRow.ToGuid(CalculatedMeasurementsColumnNames.TransactionId) == currentRow.ToGuid(CalculatedMeasurementsColumnNames.TransactionId);
     }
 
     protected override string BuildSqlQuery()

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/EnqueueActorMessagesStep/EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/EnqueueActorMessagesStep/EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -110,18 +110,18 @@ public class EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1
                         .ToList()));
 
         // Enqueue to EDI
-        // TODO: This probably needs to be handled differently, since this requires the orchestration to wait
+        // TODO: This needs to be handled differently, since this requires the orchestration to wait
         // for each enqueued messages event to be returned.
-        await _enqueueActorMessagesClient.EnqueueAsync(
-                orchestration: Orchestration_Brs_021_ElectricalHeatingCalculation_V1.UniqueName,
-                orchestrationInstanceId: orchestrationInstanceId.Value,
-                orchestrationStartedBy: new ActorIdentityDto(ActorNumber.Create("1234567890123"), ActorRole.GridAccessProvider), // TODO: Get this from the orchestration instance
-                // TODO: We need to create unique deterministic idempotency keys for each message sent to EDI instead,
-                // so rerunning the activity generates the same idempotency keys as previous run.
-                idempotencyKey: Guid.NewGuid(),
-                data: new EnqueueActorMessagesForMeteringPointV1(
-                    ReceiversWithMeasureData: receiversForMeteringPoint.ToElectricalHeatingReceiversWithMeasureDataV1()))
-            .ConfigureAwait(false);
+        // await _enqueueActorMessagesClient.EnqueueAsync(
+        //         orchestration: Orchestration_Brs_021_ElectricalHeatingCalculation_V1.UniqueName,
+        //         orchestrationInstanceId: orchestrationInstanceId.Value,
+        //         orchestrationStartedBy: new ActorIdentityDto(ActorNumber.Create("1234567890123"), ActorRole.GridAccessProvider), // TODO: Get this from the orchestration instance
+        //         // TODO: We need to create unique deterministic idempotency keys for each message sent to EDI instead,
+        //         // so rerunning the activity generates the same idempotency keys as previous run.
+        //         idempotencyKey: Guid.NewGuid(),
+        //         data: new EnqueueActorMessagesForMeteringPointV1(
+        //             ReceiversWithMeasureData: receiversForMeteringPoint.ToElectricalHeatingReceiversWithMeasureDataV1()))
+        //     .ConfigureAwait(false);
     }
 
     public record ActivityInput(

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/EnqueueActorMessagesStep/EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/EnqueueActorMessagesStep/EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -12,82 +12,84 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
 using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
 using Energinet.DataHub.ProcessManager.Components.EnqueueActorMessages;
+using Energinet.DataHub.ProcessManager.Components.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.Databricks.SqlStatements;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.Databricks.SqlStatements.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Orchestration;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Shared.ElectricityMarket;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Shared.ElectricityMarket.Model;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities.EnqueueActorMessagesStep;
 
 public class EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1(
+    ILogger<EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1> logger,
     MeteringPointMasterDataProvider meteringPointMasterDataProvider,
     MeteringPointReceiversProvider meteringPointReceiversProvider,
-    IEnqueueActorMessagesClient enqueueActorMessagesClient)
+    IEnqueueActorMessagesClient enqueueActorMessagesClient,
+    IOptionsSnapshot<DatabricksQueryOptions> databricksQueryOptions,
+    DatabricksSqlWarehouseQueryExecutor databricksSqlWarehouseQueryExecutor)
 {
+    private readonly ILogger<EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1> _logger = logger;
     private readonly MeteringPointMasterDataProvider _meteringPointMasterDataProvider = meteringPointMasterDataProvider;
     private readonly MeteringPointReceiversProvider _meteringPointReceiversProvider = meteringPointReceiversProvider;
     private readonly IEnqueueActorMessagesClient _enqueueActorMessagesClient = enqueueActorMessagesClient;
+    private readonly DatabricksQueryOptions _databricksQueryOptions = databricksQueryOptions.Get(QueryOptionsSectionNames.ElectricalHeatingQuery);
+    private readonly DatabricksSqlWarehouseQueryExecutor _databricksSqlWarehouseQueryExecutor = databricksSqlWarehouseQueryExecutor;
 
     [Function(nameof(EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1))]
     public async Task Run(
         [ActivityTrigger] ActivityInput input)
     {
-        // Simulate getting a stream of data.
-        // - Data must be ordered by metering point id and then by timestamp.
-        // - There must not be any gaps in the data / timestamps.
-        var dataStream = QueryDataAsync(input.CalculationPeriodStart, input.CalculationPeriodEnd);
+        var calculatedMeasureDataQuery = new CalculatedMeasurementsQuery(
+            _logger,
+            _databricksQueryOptions,
+            input.OrchestrationInstanceId.Value);
 
-        // Bundle
-        string? currentMeteringPointId = null;
-        List<(string MeteringPointId, Instant Timestamp, Resolution Resolution, int Quantity)> currentMeasureData = [];
-        await foreach (var data in dataStream.ConfigureAwait(false))
+        // This queries all data sequentially, but that probably won't be as quick as we need.
+        // TODO: How do we parallelize the query? What parameters can we use to split the query?
+        await foreach (var queryResult in calculatedMeasureDataQuery.GetAsync(_databricksSqlWarehouseQueryExecutor).ConfigureAwait(false))
         {
-            if (currentMeteringPointId == null)
-                currentMeteringPointId = data.MeteringPointId;
+            if (!queryResult.IsSuccess || queryResult.Result is null) // TODO: Actually handle errors
+                throw new Exception("Failed to get calculated measure data.");
 
-            // Metering point id has changed, create a message (with a measure data "bundle") for the previous
-            // metering point id and enqueue it to EDI.
-            if (currentMeteringPointId != data.MeteringPointId)
-            {
-                await EnqueueMessageForMeasureData(
-                        orchestrationInstanceId: input.OrchestrationInstanceId,
-                        currentMeteringPointId: currentMeteringPointId,
-                        measureData: currentMeasureData)
-                    .ConfigureAwait(false);
-
-                currentMeasureData = [];
-                currentMeteringPointId = data.MeteringPointId;
-            }
-
-            currentMeasureData.Add(data);
+            // The query result measure data is already grouped by transaction id, so
+            // we need to find receivers for it based on the master data for the metering point.
+            await EnqueueMessagesForMeasureData(
+                    orchestrationInstanceId: input.OrchestrationInstanceId,
+                    calculatedMeasureData: queryResult.Result)
+                .ConfigureAwait(false);
         }
     }
 
     /// <summary>
-    /// Enqueue measure data for a metering point.
+    /// Enqueue calculated measure data for a metering point.
     /// <remarks>
-    /// The measure data MUST be ordered by timestamp, and MUST not contain any gaps in the data !!!.
+    /// The measure data MUST be ordered by timestamp, and MUST NOT contain any gaps.
     /// </remarks>
     /// </summary>
-    private async Task EnqueueMessageForMeasureData(
+    private async Task EnqueueMessagesForMeasureData(
         OrchestrationInstanceId orchestrationInstanceId,
-        string currentMeteringPointId,
-        List<(string MeteringPointId, Instant Timestamp, Resolution Resolution, int Quantity)> measureData)
+        CalculatedMeasurement calculatedMeasureData)
     {
-        var from = measureData.First().Timestamp;
-        var to = measureData.Last().Timestamp;
+        var from = calculatedMeasureData.MeasureData.First().ObservationTime;
+        var to = calculatedMeasureData.MeasureData.Last().ObservationTime;
 
         // We need to get master data & receivers for each metering point id
         var masterDataForMeteringPoint = await _meteringPointMasterDataProvider.GetMasterData(
-                meteringPointId: currentMeteringPointId,
+                meteringPointId: calculatedMeasureData.MeteringPointId,
                 startDateTime: from,
                 endDateTime: to)
             .ConfigureAwait(false);
@@ -95,12 +97,12 @@ public class EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1
         var receiversForMeteringPoint = _meteringPointReceiversProvider
             .GetReceiversWithMeteredDataFromMasterDataList(
                 new MeteringPointReceiversProvider.FindReceiversInput(
-                    MeteringPointId: currentMeteringPointId,
+                    MeteringPointId: calculatedMeasureData.MeteringPointId,
                     StartDateTime: from,
                     EndDateTime: to,
-                    Resolution: measureData.First().Resolution,
+                    Resolution: calculatedMeasureData.Resolution,
                     MasterData: masterDataForMeteringPoint,
-                    MeasureData: measureData
+                    MeasureData: calculatedMeasureData.MeasureData
                         .Select((md, i) => new ReceiversWithMeasureData.MeasureData(
                             Position: i + 1, // Position is 1-based, so the first position must be 1.
                             EnergyQuantity: md.Quantity,
@@ -122,50 +124,6 @@ public class EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1
             .ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Simulate querying data rows from a data source. This is just dummy code,
-    /// the only important parts are:
-    /// - The data is ordered by metering point id and then by timestamp.
-    /// - There is no gaps in the data / timestamps.
-    /// </summary>
-    private async IAsyncEnumerable<
-        (string MeteringPointId,
-        Instant Timestamp,
-        Resolution Resolution,
-        int Quantity)>
-        QueryDataAsync(Instant start, Instant end)
-    {
-        var meteringPointId1 = Guid.NewGuid().ToString();
-        var meteringPointId2 = Guid.NewGuid().ToString();
-        var meteringPointId3 = Guid.NewGuid().ToString();
-
-        var resolution = Resolution.QuarterHourly;
-
-        var now = start;
-
-        var count = 0;
-        while (now < end)
-        {
-            count++;
-
-            var meteringPointId = count switch
-            {
-                > 10 => meteringPointId3,
-                > 5 => meteringPointId2,
-                _ => meteringPointId1,
-            };
-
-            var timestamp = now.Plus(Duration.FromMinutes(15)); // QuarterHourly resolution
-            yield return (meteringPointId, timestamp, resolution, 42);
-
-            now = timestamp;
-        }
-
-        await Task.CompletedTask.ConfigureAwait(false);
-    }
-
     public record ActivityInput(
-        OrchestrationInstanceId OrchestrationInstanceId,
-        Instant CalculationPeriodStart,
-        Instant CalculationPeriodEnd);
+        OrchestrationInstanceId OrchestrationInstanceId);
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/GetOrchestrationInstanceContextActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Activities/GetOrchestrationInstanceContextActivity_Brs_021_ElectricalHeatingCalculation_V1.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.ProcessManager.Components.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Options;
@@ -25,11 +24,9 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Elec
 /// Get the <see cref="OrchestrationInstanceContext"/> for the orchestration instance.
 /// </summary>
 internal class GetOrchestrationInstanceContextActivity_Brs_021_ElectricalHeatingCalculation_V1(
-    IOptions<OrchestrationOptions_Brs_021_ElectricalHeatingCalculation_V1> orchestrationOptions,
-    IOptionsSnapshot<DatabricksQueryOptions> databricksQueryOptions)
+    IOptions<OrchestrationOptions_Brs_021_ElectricalHeatingCalculation_V1> orchestrationOptions)
 {
     private readonly OrchestrationOptions_Brs_021_ElectricalHeatingCalculation_V1 _orchestrationOptions = orchestrationOptions.Value;
-    private readonly IOptionsSnapshot<DatabricksQueryOptions> _databricksQueryOptions = databricksQueryOptions;
 
     [Function(nameof(GetOrchestrationInstanceContextActivity_Brs_021_ElectricalHeatingCalculation_V1))]
     public Task<OrchestrationInstanceContext> Run(
@@ -37,7 +34,6 @@ internal class GetOrchestrationInstanceContextActivity_Brs_021_ElectricalHeating
     {
         return Task.FromResult(new OrchestrationInstanceContext(
             _orchestrationOptions,
-            _databricksQueryOptions.Get(QueryOptionsSectionNames.ElectricalHeatingQuery),
             input.InstanceId));
     }
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Model/OrchestrationInstanceContext.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Model/OrchestrationInstanceContext.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.ProcessManager.Components.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Options;
 
@@ -23,9 +22,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Elec
 /// By returning it from the first activity we get key information stored in the orchestration history.
 /// </summary>
 /// <param name="OrchestrationOptions">Options for configuration of the orchestration execution.</param>
-/// <param name="DatabricksQueryOptions">Options for the query that retrieves data from databricks.</param>
 /// <param name="OrchestrationInstanceId">The id of the orchestration instance</param>
 public record OrchestrationInstanceContext(
     OrchestrationOptions_Brs_021_ElectricalHeatingCalculation_V1 OrchestrationOptions,
-    DatabricksQueryOptions DatabricksQueryOptions,
     OrchestrationInstanceId OrchestrationInstanceId);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Activities.EnqueueActorMessagesStep;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Shared.Processes.Activities;
 using Microsoft.DurableTask;
+using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Orchestration.Steps;
 
@@ -33,9 +35,13 @@ internal class EnqueueActorMessagesStep(
 
     protected override int StepSequenceNumber => EnqueueActorMessagesStepSequence;
 
-    protected override Task<StepInstanceTerminationState> OnExecuteAsync()
+    protected override async Task<StepInstanceTerminationState> OnExecuteAsync()
     {
-        var queryOptions = orchestrationInstanceContext.DatabricksQueryOptions;
+        await Context.CallActivityAsync(
+            nameof(EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1),
+            new EnqueueActorMessageActivity_Brs_021_ElectricalHeatingCalculation_V1.ActivityInput(
+                OrchestrationInstanceId: orchestrationInstanceContext.OrchestrationInstanceId),
+            DefaultRetryOptions);
 
         // TODO - Alex: Implement and call activities to enqueue messages
         // 1. step
@@ -54,6 +60,6 @@ internal class EnqueueActorMessagesStep(
         //    .ConfigureAwait(false);
         // Blocking: Kvitteringer from many messages?
 
-        return Task.FromResult(StepInstanceTerminationState.Succeeded);
+        return StepInstanceTerminationState.Succeeded;
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ElectricalHeatingCalculation/V1/Orchestration/Steps/EnqueueActorMessagesStep.cs
@@ -17,7 +17,6 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Electric
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Shared.Processes.Activities;
 using Microsoft.DurableTask;
-using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ElectricalHeatingCalculation.V1.Orchestration.Steps;
 

--- a/source/ProcessManager.Orchestrations/Program.cs
+++ b/source/ProcessManager.Orchestrations/Program.cs
@@ -55,9 +55,10 @@ var host = new HostBuilder()
         services.AddNodaTimeForApplication();
         services.AddServiceBusClientForApplication(context.Configuration);
 
-        // Databricks Workspaces
-        services.AddDatabricksJobs(DatabricksWorkspaceNames.Wholesale);
-        services.AddDatabricksJobs(DatabricksWorkspaceNames.Measurements);
+        // Databricks
+        services.AddDatabricksJobsApi(DatabricksWorkspaceNames.Wholesale);
+        services.AddDatabricksJobsApi(DatabricksWorkspaceNames.Measurements);
+        services.AddDatabricksSqlStatementApi(context.Configuration);
 
         // Enqueue Messages in EDI
         services.AddEnqueueActorMessages(azureCredential);

--- a/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
+++ b/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
@@ -64,6 +64,44 @@ public static class ProcessManagerClientExtensions
     }
 
     /// <summary>
+    /// Wait for an orchestration instance, resolving true/false by using the given <paramref name="comparer"/> function.
+    /// <remarks>Returns false if an orchestration instance isn't found in <see cref="TimeLimitInSeconds"/> seconds.</remarks>
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="orchestrationInstanceId">The id of the orchestration instance, used to find the correct orchestration instance.</param>
+    /// <param name="comparer">The comparer method used to determine whether the orchestration instance is in a correct state.</param>
+    public static async Task<(bool Succes, OrchestrationInstanceTypedDto? OrchestrationInstance)>
+        TryWaitForOrchestrationInstance(
+            this IProcessManagerClient client,
+            Guid orchestrationInstanceId,
+            Func<OrchestrationInstanceTypedDto, bool> comparer)
+    {
+        OrchestrationInstanceTypedDto? orchestrationInstance = null;
+        var success = await Awaiter.TryWaitUntilConditionAsync(
+            async () =>
+            {
+                orchestrationInstance = await client
+                    .GetOrchestrationInstanceByIdAsync(
+                        new GetOrchestrationInstanceByIdQuery(
+                            operatingIdentity: new UserIdentityDto(
+                                UserId: Guid.NewGuid(),
+                                ActorNumber: ActorNumber.Create("1234567891234"),
+                                ActorRole: ActorRole.EnergySupplier),
+                            id: orchestrationInstanceId),
+                        CancellationToken.None);
+
+                if (orchestrationInstance is null)
+                    return false;
+
+                return comparer(orchestrationInstance);
+            },
+            timeLimit: TimeSpan.FromSeconds(TimeLimitInSeconds),
+            delay: TimeSpan.FromSeconds(1));
+
+        return (success, orchestrationInstance);
+    }
+
+    /// <summary>
     /// Wait for an orchestration instance to be terminated with the given <paramref name="terminationState"/>.
     /// <remarks>Returns false if not resolved in <see cref="TimeLimitInSeconds"/> seconds.</remarks>
     /// </summary>
@@ -78,6 +116,27 @@ public static class ProcessManagerClientExtensions
     {
         return client.TryWaitForOrchestrationInstance<TInput>(
             idempotencyKey,
+            (orchestrationInstance) =>
+                orchestrationInstance.Lifecycle.State == OrchestrationInstanceLifecycleState.Terminated
+                && (
+                    terminationState is null
+                    || orchestrationInstance.Lifecycle.TerminationState == terminationState));
+    }
+
+    /// <summary>
+    /// Wait for an orchestration instance to be terminated with the given <paramref name="terminationState"/>.
+    /// <remarks>Returns false if not resolved in <see cref="TimeLimitInSeconds"/> seconds.</remarks>
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="orchestrationInstanceId">The id of the orchestration instance, used to find the correct orchestration instance.</param>
+    /// <param name="terminationState">The termination state the orchestration instance should be in.</param>
+    public static Task<(bool Succes, OrchestrationInstanceTypedDto? OrchestrationInstance)> WaitForOrchestrationInstanceTerminated(
+        this IProcessManagerClient client,
+        Guid orchestrationInstanceId,
+        OrchestrationInstanceTerminationState? terminationState = null)
+    {
+        return client.TryWaitForOrchestrationInstance(
+            orchestrationInstanceId,
             (orchestrationInstance) =>
                 orchestrationInstance.Lifecycle.State == OrchestrationInstanceLifecycleState.Terminated
                 && (
@@ -101,6 +160,30 @@ public static class ProcessManagerClientExtensions
         return client.TryWaitForOrchestrationInstance<TInput>(
             idempotencyKey,
             (orchestrationInstance) =>
+            {
+                var enqueueActorMessagesStep = orchestrationInstance.Steps
+                    .Single(s => s.Sequence == stepSequence);
+
+                return enqueueActorMessagesStep.Lifecycle.State == StepInstanceLifecycleState.Running;
+            });
+    }
+
+    /// <summary>
+    /// Wait for an orchestration instance step to be in the <see cref="StepInstanceLifecycleState.Running"/> state.
+    /// <remarks>Returns false if not resolved in <see cref="TimeLimitInSeconds"/> seconds.</remarks>
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="orchestrationInstanceId">The idempotency key of the orchestration instance, used to find the correct orchestration instance.</param>
+    /// <param name="stepSequence">The sequence number of the step that should be in the <see cref="StepInstanceLifecycleState.Running"/> state.</param>
+    public static Task<(bool Succes, OrchestrationInstanceTypedDto? OrchestrationInstance)> WaitForStepToBeRunning<TInput>(
+        this IProcessManagerClient client,
+        Guid orchestrationInstanceId,
+        int stepSequence)
+        where TInput : class, IInputParameterDto
+    {
+        return client.TryWaitForOrchestrationInstance(
+            orchestrationInstanceId: orchestrationInstanceId,
+            comparer: orchestrationInstance =>
             {
                 var enqueueActorMessagesStep = orchestrationInstance.Steps
                     .Single(s => s.Sequence == stepSequence);

--- a/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
+++ b/source/Shared/Tests/Fixtures/Extensions/ProcessManagerClientExtensions.cs
@@ -70,8 +70,7 @@ public static class ProcessManagerClientExtensions
     /// <param name="client"></param>
     /// <param name="orchestrationInstanceId">The id of the orchestration instance, used to find the correct orchestration instance.</param>
     /// <param name="comparer">The comparer method used to determine whether the orchestration instance is in a correct state.</param>
-    public static async Task<(bool Succes, OrchestrationInstanceTypedDto? OrchestrationInstance)>
-        TryWaitForOrchestrationInstance(
+    public static async Task<(bool Success, OrchestrationInstanceTypedDto? OrchestrationInstance)> TryWaitForOrchestrationInstance(
             this IProcessManagerClient client,
             Guid orchestrationInstanceId,
             Func<OrchestrationInstanceTypedDto, bool> comparer)
@@ -108,7 +107,7 @@ public static class ProcessManagerClientExtensions
     /// <param name="client"></param>
     /// <param name="idempotencyKey">The idempotency key of the orchestration instance, used to find the correct orchestration instance.</param>
     /// <param name="terminationState">The termination state the orchestration instance should be in.</param>
-    public static Task<(bool Succes, OrchestrationInstanceTypedDto<TInput>? OrchestrationInstance)> WaitForOrchestrationInstanceTerminated<TInput>(
+    public static Task<(bool Success, OrchestrationInstanceTypedDto<TInput>? OrchestrationInstance)> WaitForOrchestrationInstanceTerminated<TInput>(
         this IProcessManagerClient client,
         string idempotencyKey,
         OrchestrationInstanceTerminationState? terminationState = null)
@@ -130,7 +129,7 @@ public static class ProcessManagerClientExtensions
     /// <param name="client"></param>
     /// <param name="orchestrationInstanceId">The id of the orchestration instance, used to find the correct orchestration instance.</param>
     /// <param name="terminationState">The termination state the orchestration instance should be in.</param>
-    public static Task<(bool Succes, OrchestrationInstanceTypedDto? OrchestrationInstance)> WaitForOrchestrationInstanceTerminated(
+    public static Task<(bool Success, OrchestrationInstanceTypedDto? OrchestrationInstance)> WaitForOrchestrationInstanceTerminated(
         this IProcessManagerClient client,
         Guid orchestrationInstanceId,
         OrchestrationInstanceTerminationState? terminationState = null)
@@ -151,7 +150,7 @@ public static class ProcessManagerClientExtensions
     /// <param name="client"></param>
     /// <param name="idempotencyKey">The idempotency key of the orchestration instance, used to find the correct orchestration instance.</param>
     /// <param name="stepSequence">The sequence number of the step that should be in the <see cref="StepInstanceLifecycleState.Running"/> state.</param>
-    public static Task<(bool Succes, OrchestrationInstanceTypedDto<TInput>? OrchestrationInstance)> WaitForStepToBeRunning<TInput>(
+    public static Task<(bool Success, OrchestrationInstanceTypedDto<TInput>? OrchestrationInstance)> WaitForStepToBeRunning<TInput>(
         this IProcessManagerClient client,
         string idempotencyKey,
         int stepSequence)
@@ -175,7 +174,7 @@ public static class ProcessManagerClientExtensions
     /// <param name="client"></param>
     /// <param name="orchestrationInstanceId">The idempotency key of the orchestration instance, used to find the correct orchestration instance.</param>
     /// <param name="stepSequence">The sequence number of the step that should be in the <see cref="StepInstanceLifecycleState.Running"/> state.</param>
-    public static Task<(bool Succes, OrchestrationInstanceTypedDto? OrchestrationInstance)> WaitForStepToBeRunning<TInput>(
+    public static Task<(bool Success, OrchestrationInstanceTypedDto? OrchestrationInstance)> WaitForStepToBeRunning<TInput>(
         this IProcessManagerClient client,
         Guid orchestrationInstanceId,
         int stepSequence)

--- a/source/Shared/Tests/Fixtures/OrchestrationsAppManager.cs
+++ b/source/Shared/Tests/Fixtures/OrchestrationsAppManager.cs
@@ -15,7 +15,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Azure.Messaging.ServiceBus.Administration;
-using Energinet.DataHub.Core.FunctionApp.TestCommon;
+using Energinet.DataHub.Core.Databricks.SqlStatementExecution;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ResourceProvider;
@@ -240,6 +240,10 @@ public class OrchestrationsAppManager : IAsyncDisposable
                 $"{DatabricksWorkspaceNames.Measurements}__{nameof(DatabricksWorkspaceOptions.BaseUrl)}",
                 useMockServer ? MockServer.Url! : IntegrationTestConfiguration.DatabricksSettings.WorkspaceUrl
             },
+            {
+                $"{nameof(DatabricksSqlStatementOptions.WorkspaceUrl)}",
+                useMockServer ? MockServer.Url! : IntegrationTestConfiguration.DatabricksSettings.WorkspaceUrl
+            },
         });
     }
 
@@ -387,17 +391,31 @@ public class OrchestrationsAppManager : IAsyncDisposable
             integrationEventTopicResources.SharedTopic.Name);
 
         // => Databricks workspaces
+        // Databricks jobs API for Wholesale
         appHostSettings.ProcessEnvironmentVariables.Add(
             $"{DatabricksWorkspaceNames.Wholesale}__{nameof(DatabricksWorkspaceOptions.BaseUrl)}",
             MockServer.Url!); // Default to use MockServer
         appHostSettings.ProcessEnvironmentVariables.Add(
             $"{DatabricksWorkspaceNames.Wholesale}__{nameof(DatabricksWorkspaceOptions.Token)}",
             IntegrationTestConfiguration.DatabricksSettings.WorkspaceAccessToken);
+
+        // Databricks jobs API for Measurement
         appHostSettings.ProcessEnvironmentVariables.Add(
             $"{DatabricksWorkspaceNames.Measurements}__{nameof(DatabricksWorkspaceOptions.BaseUrl)}",
             MockServer.Url!); // Default to use MockServer
         appHostSettings.ProcessEnvironmentVariables.Add(
             $"{DatabricksWorkspaceNames.Measurements}__{nameof(DatabricksWorkspaceOptions.Token)}",
+            IntegrationTestConfiguration.DatabricksSettings.WorkspaceAccessToken);
+
+        // Databricks SQL statement API
+        appHostSettings.ProcessEnvironmentVariables.Add(
+            $"{nameof(DatabricksSqlStatementOptions.WorkspaceUrl)}",
+            MockServer.Url!); // Default to use MockServer
+        appHostSettings.ProcessEnvironmentVariables.Add(
+            $"{nameof(DatabricksSqlStatementOptions.WarehouseId)}",
+            IntegrationTestConfiguration.DatabricksSettings.WarehouseId);
+        appHostSettings.ProcessEnvironmentVariables.Add(
+            $"{nameof(DatabricksSqlStatementOptions.WorkspaceToken)}",
             IntegrationTestConfiguration.DatabricksSettings.WorkspaceAccessToken);
 
         // => BRS 023 027 options


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

- Use `CalculatedMeasurementsQuery` in `EnqueueActorMessages` step for Electrical Heating Calculation.
- Fix Electricity Market master data mock
- Update test to use Databricks SQL statement API and Electricity Market master data mocks.

### Pull Request Overview
This PR introduces support for calculated measure data queries into the Electrical Heating Calculation orchestration, along with corresponding dependency registrations and integration test updates. Key changes include:

- Replacing legacy Databricks query options with a new SQL statement API in test fixtures and orchestration.
- Renaming and updating dependency injection methods (e.g., from AddDatabricksJobs to AddDatabricksJobsApi) to better reflect their functionality.
- Updating integration tests and orchestration step implementations to accommodate the new calculated measure data query.

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/684

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
