### PR TITLE
test: Update subsystem tests to wait for orchestration to be running

### DIFF
--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/StartTrigger_Brs_026_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/StartTrigger_Brs_026_V1.cs
@@ -23,7 +23,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.
 // meaning not including the "version" part; this will minimize how often we need to adjust infrastructure
 // with regards to "subscriptions". Hence this trigger should not be located within the "V1".
 // Also we need a generic way to first parse the "version" of a command and then direct the message to
-// the correct "version handler."
+// the correct "version handler".
 public class StartTrigger_Brs_026_V1(
     RequestCalculatedEnergyTimeSeriesHandlerV1 handler)
 {

--- a/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/StartTrigger_Brs_026_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_026_028/BRS_026/V1/StartTrigger_Brs_026_V1.cs
@@ -23,7 +23,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_026_028.
 // meaning not including the "version" part; this will minimize how often we need to adjust infrastructure
 // with regards to "subscriptions". Hence this trigger should not be located within the "V1".
 // Also we need a generic way to first parse the "version" of a command and then direct the message to
-// the correct "version handler".
+// the correct "version handler."
 public class StartTrigger_Brs_026_V1(
     RequestCalculatedEnergyTimeSeriesHandlerV1 handler)
 {

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_026_028/BRS_026/V1/RequestCalculatedEnergyTimeSeriesScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_026_028/BRS_026/V1/RequestCalculatedEnergyTimeSeriesScenario.cs
@@ -78,12 +78,12 @@ public class RequestCalculatedEnergyTimeSeriesScenario : IClassFixture<ProcessMa
 
     [SubsystemFact]
     [ScenarioStep(3)]
-    public async Task When_OrchestrationInstanceIsStarted()
+    public async Task When_OrchestrationInstanceIsRunning()
     {
         var (success, orchestrationInstance, _) =
             await _fixture.WaitForOrchestrationInstanceAsync<RequestCalculatedEnergyTimeSeriesInputV1>(
                 _fixture.TestConfiguration.Request.IdempotencyKey,
-                OrchestrationInstanceLifecycleState.Queued);
+                OrchestrationInstanceLifecycleState.Running);
 
         Assert.Multiple(
             () => Assert.True(
@@ -105,7 +105,7 @@ public class RequestCalculatedEnergyTimeSeriesScenario : IClassFixture<ProcessMa
 
         Assert.Multiple(
             () => Assert.Equal(request.IdempotencyKey, orchestrationInstance.IdempotencyKey),
-            () => Assert.Contains(orchestrationInstance.Lifecycle.State, new[] { OrchestrationInstanceLifecycleState.Queued, OrchestrationInstanceLifecycleState.Running, OrchestrationInstanceLifecycleState.Terminated }),
+            () => Assert.Contains(orchestrationInstance.Lifecycle.State, new[] { OrchestrationInstanceLifecycleState.Running, OrchestrationInstanceLifecycleState.Terminated }),
             () => Assert.Null(orchestrationInstance.Lifecycle.TerminationState),
             () => Assert.Equal(2, orchestrationInstance.Steps.Count),
             () => Assert.Equivalent(request.InputParameter, orchestrationInstance.ParameterValue),

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_026_028/BRS_028/V1/RequestCalculatedWholesaleServicesScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_026_028/BRS_028/V1/RequestCalculatedWholesaleServicesScenario.cs
@@ -78,12 +78,12 @@ public class RequestCalculatedWholesaleServicesScenario : IClassFixture<ProcessM
 
     [SubsystemFact]
     [ScenarioStep(3)]
-    public async Task When_OrchestrationInstanceIsStarted()
+    public async Task When_OrchestrationInstanceIsRunning()
     {
         var (success, orchestrationInstance, _) =
             await _fixture.WaitForOrchestrationInstanceAsync<RequestCalculatedWholesaleServicesInputV1>(
                 _fixture.TestConfiguration.Request.IdempotencyKey,
-                OrchestrationInstanceLifecycleState.Queued);
+                OrchestrationInstanceLifecycleState.Running);
 
         Assert.Multiple(
             () => Assert.True(
@@ -105,7 +105,7 @@ public class RequestCalculatedWholesaleServicesScenario : IClassFixture<ProcessM
 
         Assert.Multiple(
             () => Assert.Equal(request.IdempotencyKey, orchestrationInstance.IdempotencyKey),
-            () => Assert.Contains(orchestrationInstance.Lifecycle.State, new[] { OrchestrationInstanceLifecycleState.Queued, OrchestrationInstanceLifecycleState.Running, OrchestrationInstanceLifecycleState.Terminated }),
+            () => Assert.Contains(orchestrationInstance.Lifecycle.State, new[] { OrchestrationInstanceLifecycleState.Running, OrchestrationInstanceLifecycleState.Terminated }),
             () => Assert.Null(orchestrationInstance.Lifecycle.TerminationState),
             () => Assert.Equal(2, orchestrationInstance.Steps.Count),
             () => Assert.Equivalent(request.InputParameter, orchestrationInstance.ParameterValue),


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

This PR updates two subsystem tests to wait for the orchestration instance to be running rather than queued before proceeding.

- Renames test methods from When_OrchestrationInstanceIsStarted to When_OrchestrationInstanceIsRunning.
- Updates the orchestration state check from Queued to Running in the WaitForOrchestrationInstanceAsync calls and corresponding assertions.

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
