### PR TITLE
refac: if QuantityQuality is null, set to AsProvided

### DIFF
--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -448,9 +448,8 @@ public class StartForwardMeteredDataHandlerV1(
 
     private Point MapPoints(ForwardMeteredDataInputV1.MeteredData eo)
     {
-        // TODO: temporary solution until we have business validation rules for quality
-        var quality = string.IsNullOrWhiteSpace(eo.QuantityQuality) || eo.QuantityQuality == Quality.Incomplete.Name
-            ? Quality.NotAvailable
+        var quality = string.IsNullOrWhiteSpace(eo.QuantityQuality)
+            ? Quality.AsProvided
             : Quality.FromName(eo.QuantityQuality);
         return new Point(
             int.Parse(eo.Position!),

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -448,7 +448,7 @@ public class StartForwardMeteredDataHandlerV1(
 
     private Point MapPoints(ForwardMeteredDataInputV1.MeteredData eo)
     {
-        var quality = string.IsNullOrWhiteSpace(eo.QuantityQuality)
+        var quality = eo.QuantityQuality is null
             ? Quality.AsProvided
             : Quality.FromName(eo.QuantityQuality);
         return new Point(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
If no `QuantityQuality` is provided, it is expected to be sent forward as `AsProvided`.

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
