### PR TITLE
feat: added metric in brs021-forward process

### DIFF
--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -28,6 +28,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardM
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Shared.ElectricityMarket;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Shared.ElectricityMarket.Extensions;
 using Energinet.DataHub.ProcessManager.Shared.Api.Mappers;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using MeteringPointType = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.MeteringPointType;
@@ -50,7 +51,8 @@ public class StartForwardMeteredDataHandlerV1(
     BusinessValidator<ForwardMeteredDataBusinessValidatedDto> validator,
     MeteringPointMasterDataProvider meteringPointMasterDataProvider,
     IEnqueueActorMessagesClient enqueueActorMessagesClient,
-    DelegationProvider delegationProvider)
+    DelegationProvider delegationProvider,
+    TelemetryClient telemetryClient)
     : StartOrchestrationInstanceFromMessageHandlerBase<ForwardMeteredDataInputV1>(logger)
 {
     private readonly IStartOrchestrationInstanceMessageCommands _commands = commands;
@@ -61,6 +63,7 @@ public class StartForwardMeteredDataHandlerV1(
     private readonly MeteringPointMasterDataProvider _meteringPointMasterDataProvider = meteringPointMasterDataProvider;
     private readonly IEnqueueActorMessagesClient _enqueueActorMessagesClient = enqueueActorMessagesClient;
     private readonly DelegationProvider _delegationProvider = delegationProvider;
+    private readonly TelemetryClient _telemetryClient = telemetryClient;
 
     /// <summary>
     /// This method has multiple commits to the database, to immediately transition lifecycles. This means that
@@ -285,6 +288,7 @@ public class StartForwardMeteredDataHandlerV1(
                         validationStep,
                         _clock,
                         _progressRepository,
+                        _telemetryClient,
                         StepInstanceTerminationState.Failed)
                     .ConfigureAwait(false);
                 return new List<ValidationError>()
@@ -320,6 +324,7 @@ public class StartForwardMeteredDataHandlerV1(
                 validationStep,
                 _clock,
                 _progressRepository,
+                _telemetryClient,
                 validationStepTerminationState)
             .ConfigureAwait(false);
 

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/TerminateForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/TerminateForwardMeteredDataHandlerV1.cs
@@ -14,16 +14,19 @@
 
 using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Microsoft.ApplicationInsights;
 using NodaTime;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Handlers;
 
 public class TerminateForwardMeteredDataHandlerV1(
     IOrchestrationInstanceProgressRepository progressRepository,
-    IClock clock)
+    IClock clock,
+    TelemetryClient telemetryClient)
 {
     private readonly IOrchestrationInstanceProgressRepository _progressRepository = progressRepository;
     private readonly IClock _clock = clock;
+    private readonly TelemetryClient _telemetryClient = telemetryClient;
 
     public async Task HandleAsync(OrchestrationInstanceId orchestrationInstanceId)
     {
@@ -58,7 +61,7 @@ public class TerminateForwardMeteredDataHandlerV1(
         if (enqueueStep.Lifecycle.State is not StepInstanceLifecycleState.Running)
             throw new InvalidOperationException($"Enqueue actor messages step must be running (Id={enqueueStep.Id}, State={enqueueStep.Lifecycle.State}).");
 
-        await StepHelper.TerminateStepAndCommit(enqueueStep, _clock, _progressRepository).ConfigureAwait(false);
+        await StepHelper.TerminateStepAndCommit(enqueueStep, _clock, _progressRepository, _telemetryClient).ConfigureAwait(false);
     }
 
     private async Task TerminateOrchestrationInstance(OrchestrationInstance orchestrationInstance)

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/EnqueueMeteredDataTrigger_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/EnqueueMeteredDataTrigger_Brs_021_ForwardMeteredData_V1.cs
@@ -45,7 +45,10 @@ public class EnqueueMeteredDataTrigger_Brs_021_ForwardMeteredData_V1(
             Connection = ProcessManagerEventHubOptions.SectionName)]
         EventData message)
     {
-        using var operation = _telemetryClient.StartOperation<RequestTelemetry>(nameof(StartTrigger_Brs_021_ForwardMeteredData_V1));
+        // Tracks structured telemetry data for Application Insights, including request details such as duration, success/failure, and dependencies.
+        // Enables distributed tracing, allowing correlation of this request with related telemetry (e.g., dependencies, exceptions, custom metrics) in the same operation.
+        // Automatically tracks metrics like request count, duration, and failure rate for RequestTelemetry.
+        using var operation = _telemetryClient.StartOperation<RequestTelemetry>(nameof(EnqueueMeteredDataTrigger_Brs_021_ForwardMeteredData_V1));
         try
         {
             var brs021ForwardMeteredDataNotifyVersion = GetBrs021ForwardMeteredDataNotifyVersion(message);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/StartTrigger_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/StartTrigger_Brs_021_ForwardMeteredData_V1.cs
@@ -40,11 +40,9 @@ public class StartTrigger_Brs_021_ForwardMeteredData_V1(
             Connection = ServiceBusNamespaceOptions.SectionName)]
         ServiceBusReceivedMessage message)
     {
-        // Provides structured telemetry data that Application Insights uses to display request details,
-        // including duration, success/failure, and associated dependencies.
-        // Distributed Tracing: Enables distributed tracing, allowing correlation of this request
-        // with other telemetry (e.g., dependencies, exceptions) in the same operation.
-        // Automatic Metrics: Automatically tracks metrics like request count, duration, and failure rate for RequestTelemetry.
+        // Tracks structured telemetry data for Application Insights, including request details such as duration, success/failure, and dependencies.
+        // Enables distributed tracing, allowing correlation of this request with related telemetry (e.g., dependencies, exceptions, custom metrics) in the same operation.
+        // Automatically tracks metrics like request count, duration, and failure rate for RequestTelemetry.
         using var operation = _telemetryClient.StartOperation<RequestTelemetry>(nameof(StartTrigger_Brs_021_ForwardMeteredData_V1));
         try
         {

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/TerminateTrigger_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/TerminateTrigger_Brs_021_ForwardMeteredData_V1.cs
@@ -41,7 +41,10 @@ public class TerminateTrigger_Brs_021_ForwardMeteredData_V1(
             Connection = ServiceBusNamespaceOptions.SectionName)]
         string message)
     {
-        using var operation = _telemetryClient.StartOperation<RequestTelemetry>(nameof(StartTrigger_Brs_021_ForwardMeteredData_V1));
+        // Tracks structured telemetry data for Application Insights, including request details such as duration, success/failure, and dependencies.
+        // Enables distributed tracing, allowing correlation of this request with related telemetry (e.g., dependencies, exceptions, custom metrics) in the same operation.
+        // Automatically tracks metrics like request count, duration, and failure rate for RequestTelemetry.
+        using var operation = _telemetryClient.StartOperation<RequestTelemetry>(nameof(TerminateTrigger_Brs_021_ForwardMeteredData_V1));
         try
         {
             var notify = GetNotifyOrchestrationInstanceV1(message);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/TerminateTrigger_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Triggers/TerminateTrigger_Brs_021_ForwardMeteredData_V1.cs
@@ -17,14 +17,18 @@ using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Handlers;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Azure.Functions.Worker;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Triggers;
 
 public class TerminateTrigger_Brs_021_ForwardMeteredData_V1(
-    TerminateForwardMeteredDataHandlerV1 terminateForwardMeteredDataHandlerV1)
+    TerminateForwardMeteredDataHandlerV1 terminateForwardMeteredDataHandlerV1,
+    TelemetryClient telemetryClient)
 {
     private readonly TerminateForwardMeteredDataHandlerV1 _terminateForwardMeteredDataHandlerV1 = terminateForwardMeteredDataHandlerV1;
+    private readonly TelemetryClient _telemetryClient = telemetryClient;
 
     /// <summary>
     /// Terminate a BRS-021 ForwardMeteredData.
@@ -37,13 +41,30 @@ public class TerminateTrigger_Brs_021_ForwardMeteredData_V1(
             Connection = ServiceBusNamespaceOptions.SectionName)]
         string message)
     {
+        using var operation = _telemetryClient.StartOperation<RequestTelemetry>(nameof(StartTrigger_Brs_021_ForwardMeteredData_V1));
+        try
+        {
+            var notify = GetNotifyOrchestrationInstanceV1(message);
+
+            var orchestrationInstanceId = new Core.Domain.OrchestrationInstance.OrchestrationInstanceId(Guid.Parse(notify.OrchestrationInstanceId));
+            await _terminateForwardMeteredDataHandlerV1.HandleAsync(orchestrationInstanceId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            operation.Telemetry.Success = false;
+            _telemetryClient.TrackException(ex);
+            throw;
+        }
+    }
+
+    private static NotifyOrchestrationInstanceV1 GetNotifyOrchestrationInstanceV1(string message)
+    {
         var notify = NotifyOrchestrationInstanceV1.Parser.ParseJson(message);
         if (notify is not { EventName: ForwardMeteredDataNotifyEventV1.OrchestrationInstanceEventName })
         {
             throw new InvalidOperationException("Failed to deserialize message");
         }
 
-        var orchestrationInstanceId = new Core.Domain.OrchestrationInstance.OrchestrationInstanceId(Guid.Parse(notify.OrchestrationInstanceId));
-        await _terminateForwardMeteredDataHandlerV1.HandleAsync(orchestrationInstanceId).ConfigureAwait(false);
+        return notify;
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Added metrics to track performance for executing Brs021-forward:
- Metrics added for each function, automatically tracking values such as request count, duration, and failure rate.
- Metrics also track the duration between when a step is started and when it is terminated.




## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/14738228651
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/715