### PR TITLE
refac: Changed missing measurement logs activation time

### DIFF
--- a/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/Orchestration/OrchestrationDescriptionBuilder.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/Orchestration/OrchestrationDescriptionBuilder.cs
@@ -32,8 +32,8 @@ internal class OrchestrationDescriptionBuilder : IOrchestrationDescriptionBuilde
             functionName: nameof(Orchestration_Brs_045_MissingMeasurementsLogCalculation_V1));
 
         description.RecurringCronExpression = string.Empty;
-        // Runs at 04:00 every day
-        description.RecurringCronExpression = "0 4 * * *";
+        // Runs at 02:00 on weekdays
+        description.RecurringCronExpression = "0 2 * * 1-5";
 
         description.AppendStepDescription(CalculationStep.StepDescription);
         description.AppendStepDescription(EnqueueActorMessagesStep.StepDescription);


### PR DESCRIPTION
## Description
Changed missing measurement logs activation time.
Now it runs at 2AM on weeksday.

## References

Link to assignment:
https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/team-mandalorian/706

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
