### PR TITLE
fix: avoid throwing ex when start orch insta message is handled

### DIFF
--- a/source/ProcessManager.Components/MeteringPointMasterData/MeteringPointMasterDataProvider.cs
+++ b/source/ProcessManager.Components/MeteringPointMasterData/MeteringPointMasterDataProvider.cs
@@ -95,7 +95,7 @@ public class MeteringPointMasterDataProvider(
         }
         catch (Exception e)
         {
-            // The performance test uses non-existing metering points, so we must fake a succesful
+            // The performance test uses non-existing metering points, so we must fake a successful
             // master data response from Electricity Market
             if (IsPerformanceTest(meteringPointId))
             {

--- a/source/ProcessManager.Core.Tests/Unit/Application/Handlers/StartOrchestrationInstanceFromMessageHandlerTests.cs
+++ b/source/ProcessManager.Core.Tests/Unit/Application/Handlers/StartOrchestrationInstanceFromMessageHandlerTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
+using Energinet.DataHub.ProcessManager.Core.Application.Api.Handlers;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Google.Protobuf;
+using Moq;
+
+namespace Energinet.DataHub.ProcessManager.Core.Tests.Unit.Application.Handlers;
+
+public class StartOrchestrationInstanceFromMessageHandlerTests
+{
+    [Fact]
+    public async Task Given_ValidMajorVersion_When_HandleAsync_Then_DelegatesToCorrectHandler()
+    {
+        // Arrange
+        var validMajorVersion = nameof(StartOrchestrationInstanceV1);
+
+        var handlerMock = new Mock<IStartOrchestrationInstanceHandler>();
+        var startOrchestrationInstance = new StartOrchestrationInstanceV1();
+
+        var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            subject: "Brs_021_ForwardMeteredData",
+            messageId: Guid.NewGuid().ToString(),
+            body: new BinaryData(JsonFormatter.Default.Format(startOrchestrationInstance)),
+            contentType: "application/json",
+            properties: new Dictionary<string, object>
+            {
+                { "MajorVersion", validMajorVersion },
+                { "BodyFormat", "Json" },
+            });
+
+        handlerMock.Setup(h => h.CanHandle(startOrchestrationInstance)).Returns(true);
+
+        var handlers = new[] { handlerMock.Object };
+        var sut = new StartOrchestrationInstanceFromMessageHandler(handlers);
+
+        // Act
+        await sut.HandleAsync(serviceBusReceivedMessage);
+
+        // Assert
+        handlerMock.Verify(
+            h => h.HandleAsync(
+                startOrchestrationInstance,
+                It.IsAny<IdempotencyKey>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Given_InvalidMajorVersion_When_HandleAsync_Then_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var invalidMajorVersion = "invalidMajorVersion";
+        var handlerMock = new Mock<IStartOrchestrationInstanceHandler>();
+        var startOrchestrationInstance = new StartOrchestrationInstanceV1();
+
+        var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            subject: "Brs_021_ForwardMeteredData",
+            messageId: Guid.NewGuid().ToString(),
+            body: new BinaryData(JsonFormatter.Default.Format(startOrchestrationInstance)),
+            contentType: "application/json",
+            properties: new Dictionary<string, object>
+            {
+                { "MajorVersion", invalidMajorVersion },
+                { "BodyFormat", "Json" },
+            });
+
+        handlerMock.Setup(h => h.CanHandle(startOrchestrationInstance)).Returns(true);
+
+        var handlers = new[] { handlerMock.Object };
+        var sut = new StartOrchestrationInstanceFromMessageHandler(handlers);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => sut.HandleAsync(serviceBusReceivedMessage));
+    }
+}

--- a/source/ProcessManager.Core/Application/Api/Handlers/StartOrchestrationInstanceFromMessageHandler.cs
+++ b/source/ProcessManager.Core/Application/Api/Handlers/StartOrchestrationInstanceFromMessageHandler.cs
@@ -35,6 +35,7 @@ internal class StartOrchestrationInstanceFromMessageHandler : IStartOrchestratio
         if (majorVersion == StartOrchestrationInstanceV1.MajorVersion)
         {
             await HandleV1Async(message).ConfigureAwait(false);
+            return;
         }
 
         throw new ArgumentOutOfRangeException(

--- a/source/ProcessManager.Core/Application/Api/Handlers/StartOrchestrationInstanceFromMessageHandler.cs
+++ b/source/ProcessManager.Core/Application/Api/Handlers/StartOrchestrationInstanceFromMessageHandler.cs
@@ -35,13 +35,14 @@ internal class StartOrchestrationInstanceFromMessageHandler : IStartOrchestratio
         if (majorVersion == StartOrchestrationInstanceV1.MajorVersion)
         {
             await HandleV1Async(message).ConfigureAwait(false);
-            return;
         }
-
-        throw new ArgumentOutOfRangeException(
+        else
+        {
+            throw new ArgumentOutOfRangeException(
                 nameof(majorVersion),
                 majorVersion,
                 $"Unhandled major version in the received start orchestration service bus message (Subject={message.Subject}, MessageId={message.MessageId}).");
+        }
     }
 
     private async Task HandleV1Async(ServiceBusReceivedMessage message)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
In StartOrchestrationInstanceFromMessageHandler, we throw an ArgumentOutOfRangeException after handling a ServiceBusReceivedMessage for all received messages, even when the message contains a valid MajorVersion.

## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
