### PR TITLE
fix: Added grid area codes to missing measurements log on demand 

### DIFF
--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
+## Version 2.2.5
+
+- Changed List to IReadOnlyCollection type in `MissingMeasurementsLogOnDemandCalculation/V1/Model/CalculationInputV1.cs` to be more generic.
+
 ## Version 2.2.4
 
 - Update `EnqueueMissingMeasurementsLogHttpV1` to contain a idempotency key.

--- a/source/ProcessManager.Components/Time/TimeHelper.cs
+++ b/source/ProcessManager.Components/Time/TimeHelper.cs
@@ -23,11 +23,11 @@ public class TimeHelper(DateTimeZone dateTimeZone)
     /// <summary>
     /// Transforms the given instant to midnight of the same day in the injected timezone.
     /// </summary>
-    /// <param name="instantInUtc">The instant (in UTC) to transformed.</param>
+    /// <param name="instant">The instant to transformed.</param>
     /// <returns>The new transformed instant.</returns>
-    public Instant GetMidnightZonedDateTime(Instant instantInUtc)
+    public Instant GetMidnightZonedDateTime(Instant instant)
     {
-        var zonedDateTimeAtMidnight = instantInUtc
+        var zonedDateTimeAtMidnight = instant
             .InZone(_dateTimeZone)
             .Date
             .AtMidnight();

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>2.2.4$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.2.5$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Model/CalculationInputV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Model/CalculationInputV1.cs
@@ -22,5 +22,5 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes
 public record CalculationInputV1(
     DateTimeOffset PeriodStartDate,
     DateTimeOffset PeriodEndDate,
-    List<string> GridAreaCodes)
+    IReadOnlyCollection<string> GridAreaCodes)
         : IInputParameterDto;

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementLogsCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementLogsCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
@@ -14,6 +14,7 @@
 
 using Energinet.DataHub.ProcessManager.Components.Databricks.Jobs;
 using Energinet.DataHub.ProcessManager.Components.Databricks.Jobs.Model;
+using Energinet.DataHub.ProcessManager.Components.Time;
 using Energinet.DataHub.ProcessManager.Components.WorkingDays;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_045.MissingMeasurementsLogCalculation.V1.Activities.CalculationStep;
@@ -65,6 +66,9 @@ public class CalculationStepStartJobActivityBrs045MissingMeasurementsLogCalculat
         var jobRunId = new JobRunId(42);
         var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!;
         var date = Instant.FromUtc(actualYear, actualMonth, actualDay, actualHour, actualMinute, actualSecond);
+        var timeHelper = new TimeHelper(zone);
+        var periodStartDate = timeHelper.GetMidnightZonedDateTime(date.Plus(Duration.FromDays(-93)));
+        var periodEndDate = timeHelper.GetMidnightZonedDateTime(date.Plus(Duration.FromDays(daysBack)));
         var orchestrationInstanceId = new OrchestrationInstanceId(Guid.NewGuid());
         var activityInput =
             new CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.ActivityInput(
@@ -72,8 +76,8 @@ public class CalculationStepStartJobActivityBrs045MissingMeasurementsLogCalculat
         var jobParameters = new List<string>
         {
             $"--orchestration-instance-id={orchestrationInstanceId.Value}",
-            $"--period-start-datetime={date.Plus(Duration.FromDays(-93)).InZone(zone).Date.AtMidnight().InZoneStrictly(zone).ToInstant()}",
-            $"--period-end-datetime={date.Plus(Duration.FromDays(daysBack)).InZone(zone).Date.AtMidnight().InZoneStrictly(zone).ToInstant()}",
+            $"--period-start-datetime={periodStartDate}",
+            $"--period-end-datetime={periodEndDate}",
         };
 
         var clientMock = new Mock<IDatabricksJobsClient>();

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementLogsCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementLogsCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
@@ -19,7 +19,6 @@ using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_045.MissingMeasurementsLogCalculation.V1.Activities.CalculationStep;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using Moq;
 using NodaTime;
 

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementLogsCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementLogsCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
@@ -14,7 +14,6 @@
 
 using Energinet.DataHub.ProcessManager.Components.Databricks.Jobs;
 using Energinet.DataHub.ProcessManager.Components.Databricks.Jobs.Model;
-using Energinet.DataHub.ProcessManager.Components.Time;
 using Energinet.DataHub.ProcessManager.Components.WorkingDays;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_045.MissingMeasurementsLogCalculation.V1.Activities.CalculationStep;
@@ -66,9 +65,6 @@ public class CalculationStepStartJobActivityBrs045MissingMeasurementsLogCalculat
         var jobRunId = new JobRunId(42);
         var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!;
         var date = Instant.FromUtc(actualYear, actualMonth, actualDay, actualHour, actualMinute, actualSecond);
-        var timeHelper = new TimeHelper(zone);
-        var periodStartDate = timeHelper.GetMidnightZonedDateTime(date.Plus(Duration.FromDays(-93)));
-        var periodEndDate = timeHelper.GetMidnightZonedDateTime(date.Plus(Duration.FromDays(daysBack)));
         var orchestrationInstanceId = new OrchestrationInstanceId(Guid.NewGuid());
         var activityInput =
             new CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.ActivityInput(
@@ -76,8 +72,8 @@ public class CalculationStepStartJobActivityBrs045MissingMeasurementsLogCalculat
         var jobParameters = new List<string>
         {
             $"--orchestration-instance-id={orchestrationInstanceId.Value}",
-            $"--period-start-datetime={periodStartDate}",
-            $"--period-end-datetime={periodEndDate}",
+            $"--period-start-datetime={date.Plus(Duration.FromDays(-93)).InZone(zone).Date.AtMidnight().InZoneStrictly(zone).ToInstant()}",
+            $"--period-end-datetime={date.Plus(Duration.FromDays(daysBack)).InZone(zone).Date.AtMidnight().InZoneStrictly(zone).ToInstant()}",
         };
 
         var clientMock = new Mock<IDatabricksJobsClient>();

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivityBrs045MissingMsLogCalOnDemandV1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivityBrs045MissingMsLogCalOnDemandV1Tests.cs
@@ -34,7 +34,7 @@ public class CalculationStepStartJobActivityBrs045MissingMsLogCalOnDemandV1Tests
     private readonly DateTimeZone _zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!;
 
     [Fact]
-    public async Task Given_CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCal_V1_WhenRun_ThenJobIdIsCorrect()
+    public async Task Given_CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCal_V1_When_Run_Then_JobIdIsCorrect()
     {
         // Arrange
         var jobRunId = new JobRunId(42);

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivityBrs045MissingMsLogCalOnDemandV1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivityBrs045MissingMsLogCalOnDemandV1Tests.cs
@@ -29,12 +29,12 @@ using NodaTime;
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_045.MissingMeasurementsLogOnDemandCalculation.V1.Activities.CalculationStep;
 
 [ParallelWorkflow(WorkflowBucket.Bucket05)]
-public class CalculationStepStartJobActivityBrs045MissingMeasurementsLogCalculationOnDemandV1Tests
+public class CalculationStepStartJobActivityBrs045MissingMsLogCalOnDemandV1Tests
 {
     private readonly DateTimeZone _zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!;
 
     [Fact]
-    public async Task Given_CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCalculation_V1_When_RunWithInput_ThenJobIdIsCorrect()
+    public async Task Given_CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCal_V1_WhenRun_ThenJobIdIsCorrect()
     {
         // Arrange
         var jobRunId = new JobRunId(42);

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
@@ -1,0 +1,111 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
+using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.Databricks.Jobs;
+using Energinet.DataHub.ProcessManager.Components.Databricks.Jobs.Model;
+using Energinet.DataHub.ProcessManager.Components.Time;
+using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationDescription;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_045.MissingMeasurementsLogOnDemandCalculation.V1.Activities.CalculationStep;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
+using FluentAssertions;
+using Moq;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_045.MissingMeasurementsLogOnDemandCalculation.V1.Activities.CalculationStep;
+
+[ParallelWorkflow(WorkflowBucket.Bucket05)]
+public class CalculationStepStartJobActivityBrs045MissingMeasurementsLogCalculationOnDemandV1Tests
+{
+    private readonly DateTimeZone _zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!;
+
+    [Fact]
+    public async Task Given_CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCalculation_V1_When_RunWithInput()
+    {
+        // Arrange
+        var jobRunId = new JobRunId(42);
+        var gridAreaCodes = new List<string> { "300, 301" };
+        var date = Instant.FromUtc(2025, 1, 1, 0, 0, 0);
+        var timeHelper = new TimeHelper(_zone);
+        var periodStartDate = timeHelper.GetMidnightZonedDateTime(date.Plus(Duration.FromDays(-30)));
+        var periodEndDate = timeHelper.GetMidnightZonedDateTime(date.Plus(Duration.FromDays(-9)));
+        var orchestrationInstanceId = new OrchestrationInstanceId(Guid.NewGuid());
+        var activityInput =
+            new CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCalculation_V1.ActivityInput(
+                orchestrationInstanceId);
+        var jobParameters = new List<string>
+        {
+            $"--orchestration-instance-id={orchestrationInstanceId.Value}",
+            $"--period-start-datetime={periodStartDate}",
+            $"--period-end-datetime={periodEndDate}",
+            $"--grid-area-codes={string.Join(",", gridAreaCodes)}",
+        };
+
+        var clientMock = new Mock<IDatabricksJobsClient>();
+        clientMock
+            .Setup(x => x.StartJobAsync("MissingMeasurementsLogOnDemand", jobParameters))
+            .ReturnsAsync(jobRunId);
+        var repositoryMock = new Mock<IOrchestrationInstanceProgressRepository>();
+        repositoryMock
+            .Setup(x => x.GetAsync(orchestrationInstanceId))
+            .Returns(CreateOrchestrationInstance(periodStartDate, periodEndDate, gridAreaCodes));
+        var sut = new CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCalculation_V1(
+            repositoryMock.Object,
+            clientMock.Object);
+
+        // Act
+        var actual = await sut.Run(activityInput);
+
+        // Assert
+        actual.Should().Be(jobRunId);
+    }
+
+    private Task<OrchestrationInstance> CreateOrchestrationInstance(
+        Instant periodsStartDate,
+        Instant periodEndDate,
+        IReadOnlyCollection<string> gridAreaCodes)
+    {
+        var orchestrationInstance = OrchestrationInstance.CreateFromDescription(
+            new ActorIdentity(new Actor(ActorNumber.Create("1234567891111"), ActorRole.DataHubAdministrator)),
+            new OrchestrationDescription(new OrchestrationDescriptionUniqueName("test", 1), false, "test"),
+            skipStepsBySequence: [],
+            clock: SystemClock.Instance,
+            runAt: null,
+            idempotencyKey: new IdempotencyKey("123"),
+            actorMessageId: new ActorMessageId(Guid.NewGuid().ToString()),
+            transactionId: new TransactionId(Guid.NewGuid().ToString()),
+            meteringPointId: new MeteringPointId(Guid.NewGuid().ToString()));
+
+        orchestrationInstance.ParameterValue.SetFromInstance(new TestOrchestrationParameter
+        {
+            PeriodStartDate = periodsStartDate.ToDateTimeOffset(),
+            PeriodEndDate = periodEndDate.ToDateTimeOffset(),
+            GridAreaCodes = gridAreaCodes,
+        });
+
+        return Task.FromResult(orchestrationInstance);
+    }
+
+    private class TestOrchestrationParameter : IInputParameterDto
+    {
+        public DateTimeOffset PeriodStartDate { get; set; }
+
+        public DateTimeOffset PeriodEndDate { get; set; }
+
+        public IReadOnlyCollection<string> GridAreaCodes { get; set; } = [];
+    }
+}

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogCalculation_V1.cs
@@ -34,7 +34,7 @@ public class CalculationStepStartJobActivityBrs045MissingMeasurementsLogCalculat
     private readonly DateTimeZone _zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!;
 
     [Fact]
-    public async Task Given_CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCalculation_V1_When_RunWithInput()
+    public async Task Given_CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCalculation_V1_When_RunWithInput_ThenJobIdIsCorrect()
     {
         // Arrange
         var jobRunId = new JobRunId(42);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCalculation_V1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/Activities/CalculationStep/CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnDemandCalculation_V1.cs
@@ -20,6 +20,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.Extensions.DependencyInjection;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
+using NodaTime.Extensions;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_045.MissingMeasurementsLogOnDemandCalculation.V1.Activities.CalculationStep;
 
@@ -43,8 +44,9 @@ internal class CalculationStepStartJobActivity_Brs_045_MissingMeasurementsLogOnD
         var jobParameters = new List<string>
         {
             $"--orchestration-instance-id={input.OrchestrationInstanceId.Value}",
-            $"--period-start-datetime={orchestrationInstanceInput.PeriodStartDate}",
-            $"--period-end-datetime={orchestrationInstanceInput.PeriodEndDate}",
+            $"--period-start-datetime={orchestrationInstanceInput.PeriodStartDate.ToInstant()}",
+            $"--period-end-datetime={orchestrationInstanceInput.PeriodEndDate.ToInstant()}",
+            $"--grid-area-codes={string.Join(",", orchestrationInstanceInput.GridAreaCodes)}",
         };
 
         return await _client.StartJobAsync("MissingMeasurementsLogOnDemand", jobParameters).ConfigureAwait(false);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Added grid area codes to missing measurements log on demand. They were missing.

## References

Link to assignment:
https://github.com/Energinet-DataHub/opengeh-process-manager/pull/400

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
