### PR TITLE
feat: brs021 notify eventhub trigger support batches

### DIFF
--- a/source/ProcessManager.Orchestrations/host.json
+++ b/source/ProcessManager.Orchestrations/host.json
@@ -6,6 +6,10 @@
       "storageProvider": {
         "connectionStringName": "ProcessManagerStorageConnectionString"
       }
+    },
+    "eventHub": {
+      "prefetchCount": 500,  
+      "maxBatchSize": 300
     }
   },
   "logging": {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
The event hub trigger has been refactored to support batching, enabling it to handle the high volume of events for BRS021 more efficiently. Each message will now be processed in its own scope, in parallel, to utilize resources on each instance better.

Right now, we are processing 1 event at a time


## References

Link to assignment:

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/15019104383
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/552
