### PR TITLE
test: Add BRS-021 Send Measurements subsystem test

### DIFF
--- a/source/ProcessManager.Components.Tests/Unit/MeteringPointMasterData/MeteringPointMasterDataProviderTests.cs
+++ b/source/ProcessManager.Components.Tests/Unit/MeteringPointMasterData/MeteringPointMasterDataProviderTests.cs
@@ -52,15 +52,15 @@ public class MeteringPointMasterDataProviderTests
 
         optionsMock.Setup(o => o.Value).Returns(expectedOptions);
 
-        var electricityMarketViewsFactoryMock = new Mock<ElectricityMarketViewsFactory>();
-        electricityMarketViewsFactoryMock.Setup(f => f.Create(It.IsAny<string>()))
-            .Returns(new ElectricityMarketViewsMock());
+        var electricityMarketViewsFactory = new ElectricityMarketViewsFactory(
+            optionsMock.Object,
+            new ElectricityMarketViewsMock());
 
         _sut = new MeteringPointMasterDataProvider(
             new Mock<ILogger<MeteringPointMasterDataProvider>>().Object,
             clock.Object,
             optionsMock.Object,
-            electricityMarketViewsFactoryMock.Object);
+            electricityMarketViewsFactory);
     }
 
     [Fact]

--- a/source/ProcessManager.Components.Tests/Unit/MeteringPointMasterData/MeteringPointMasterDataProviderTests.cs
+++ b/source/ProcessManager.Components.Tests/Unit/MeteringPointMasterData/MeteringPointMasterDataProviderTests.cs
@@ -52,11 +52,15 @@ public class MeteringPointMasterDataProviderTests
 
         optionsMock.Setup(o => o.Value).Returns(expectedOptions);
 
+        var electricityMarketViewsFactoryMock = new Mock<ElectricityMarketViewsFactory>();
+        electricityMarketViewsFactoryMock.Setup(f => f.Create(It.IsAny<string>()))
+            .Returns(new ElectricityMarketViewsMock());
+
         _sut = new MeteringPointMasterDataProvider(
-            new ElectricityMarketViewsMock(),
             new Mock<ILogger<MeteringPointMasterDataProvider>>().Object,
             clock.Object,
-            optionsMock.Object);
+            optionsMock.Object,
+            electricityMarketViewsFactoryMock.Object);
     }
 
     [Fact]

--- a/source/ProcessManager.Components/EnqueueActorMessages/EdiTopicServiceBusSenderFactory.cs
+++ b/source/ProcessManager.Components/EnqueueActorMessages/EdiTopicServiceBusSenderFactory.cs
@@ -27,7 +27,7 @@ public class EdiTopicServiceBusSenderFactory(
     IOptions<ProcessManagerComponentsOptions> options,
     IAzureClientFactory<ServiceBusSender> serviceBusFactory)
 {
-    private readonly IOptions<ProcessManagerComponentsOptions> _options = options;
+    private readonly ProcessManagerComponentsOptions _options = options.Value;
     private readonly IAzureClientFactory<ServiceBusSender> _serviceBusFactory = serviceBusFactory;
 
     /// <summary>
@@ -39,7 +39,7 @@ public class EdiTopicServiceBusSenderFactory(
     /// </summary>
     public ServiceBusSender CreateSender(IEnqueueDataDto data)
     {
-        if (!_options.Value.AllowMockDependenciesForTests)
+        if (!_options.AllowMockDependenciesForTests)
             return CreateEdiServiceBusSender();
 
         var originalActorMessageId = data switch

--- a/source/ProcessManager.Components/Extensions/TestMessageIdExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/TestMessageIdExtensions.cs
@@ -18,6 +18,7 @@ public static class TestMessageIdExtensions
 {
     public const string TestUuidPrefix = "test__";
     public const string PerformanceTestUuidPrefix = "perf_test";
+    public const string TestMeteringPointIdPrefix = "test__";
 
     /// <summary>
     /// Converts the guid to a shorter version, prefixed with the <see cref="TestUuidPrefix"/>.
@@ -37,6 +38,19 @@ public static class TestMessageIdExtensions
     public static bool IsPerformanceTestUuid(this string messageId)
     {
         return messageId.StartsWith(PerformanceTestUuidPrefix);
+    }
+
+    /// <summary>
+    /// Prefixes the metering point id with <see cref="TestMeteringPointIdPrefix"/>.
+    /// </summary>
+    public static string ToTestMeteringPointId(this string meteringPointId)
+    {
+        return $"{TestMeteringPointIdPrefix}{meteringPointId}";
+    }
+
+    public static bool IsTestMeteringPointId(this string meteringPointId)
+    {
+        return meteringPointId.StartsWith(TestMeteringPointIdPrefix);
     }
 
     /// <summary>

--- a/source/ProcessManager.Components/MeteringPointMasterData/ElectricityMarketViewsFactory.cs
+++ b/source/ProcessManager.Components/MeteringPointMasterData/ElectricityMarketViewsFactory.cs
@@ -1,0 +1,90 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ElectricityMarket.Integration;
+using Energinet.DataHub.ElectricityMarket.Integration.Models.Common;
+using Energinet.DataHub.ElectricityMarket.Integration.Models.GridAreas;
+using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
+using Energinet.DataHub.ElectricityMarket.Integration.Models.ProcessDelegation;
+using Energinet.DataHub.ProcessManager.Components.Extensions;
+using Energinet.DataHub.ProcessManager.Components.Extensions.Options;
+using Microsoft.Extensions.Options;
+using NodaTime;
+
+namespace Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData;
+
+public class ElectricityMarketViewsFactory(
+    IOptions<ProcessManagerComponentsOptions> options,
+    IElectricityMarketViews electricityMarketViews)
+{
+    private readonly IElectricityMarketViews _electricityMarketViews = electricityMarketViews;
+    private readonly ProcessManagerComponentsOptions _options = options.Value;
+
+    public IElectricityMarketViews Create(string meteringPointId)
+    {
+        if (!_options.AllowMockDependenciesForTests)
+            return _electricityMarketViews;
+
+        return meteringPointId.IsTestMeteringPointId()
+            ? new ElectricityMarketViewsMock()
+            : _electricityMarketViews;
+    }
+
+    /// <summary>
+    /// An electricity market views mock implementation, that always returns a fixed data set.
+    /// </summary>
+    private class ElectricityMarketViewsMock : IElectricityMarketViews
+    {
+        public Task<IEnumerable<ElectricityMarket.Integration.Models.MasterData.MeteringPointMasterData>>
+            GetMeteringPointMasterDataChangesAsync(MeteringPointIdentification meteringPointId, Interval period)
+        {
+            IEnumerable<ElectricityMarket.Integration.Models.MasterData.MeteringPointMasterData> mockData =
+            [
+                new ElectricityMarket.Integration.Models.MasterData.MeteringPointMasterData
+                {
+                    Identification = meteringPointId,
+                    Type = MeteringPointType.Consumption,
+                    SubType = MeteringPointSubType.Physical,
+                    ConnectionState = ConnectionState.Connected,
+                    ProductId = ProductId.EnergyActive,
+                    Resolution = new Resolution("PT15M"),
+                    Unit = MeasureUnit.kWh,
+                    ParentIdentification = null,
+                    EnergySupplier = "1234567890123",
+                    GridAccessProvider = "1234567890123",
+                    GridAreaCode = new GridAreaCode("001"),
+                    NeighborGridAreaOwners = [],
+                    ValidFrom = period.Start,
+                    ValidTo = period.End,
+                },
+            ];
+
+            return Task.FromResult(mockData);
+        }
+
+        public Task<ProcessDelegationDto?> GetProcessDelegationAsync(
+            string actorNumber,
+            EicFunction actorRole,
+            string gridAreaCode,
+            DelegatedProcess processType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<GridAreaOwnerDto?> GetGridAreaOwnerAsync(string gridAreaCode)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/source/ProcessManager.Components/MeteringPointMasterData/ElectricityMarketViewsFactory.cs
+++ b/source/ProcessManager.Components/MeteringPointMasterData/ElectricityMarketViewsFactory.cs
@@ -31,12 +31,12 @@ public class ElectricityMarketViewsFactory(
     private readonly IElectricityMarketViews _electricityMarketViews = electricityMarketViews;
     private readonly ProcessManagerComponentsOptions _options = options.Value;
 
-    public IElectricityMarketViews Create(string meteringPointId)
+    public IElectricityMarketViews Create(MeteringPointIdentification meteringPointId)
     {
         if (!_options.AllowMockDependenciesForTests)
             return _electricityMarketViews;
 
-        return meteringPointId.IsTestMeteringPointId()
+        return meteringPointId.Value.IsTestMeteringPointId()
             ? new ElectricityMarketViewsMock()
             : _electricityMarketViews;
     }

--- a/source/ProcessManager.Components/MeteringPointMasterData/MeteringPointMasterDataProvider.cs
+++ b/source/ProcessManager.Components/MeteringPointMasterData/MeteringPointMasterDataProvider.cs
@@ -32,16 +32,16 @@ namespace Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData;
     "SA1118:Parameter should not span multiple lines",
     Justification = "Readability")]
 public class MeteringPointMasterDataProvider(
-    IElectricityMarketViews electricityMarketViews,
     ILogger<MeteringPointMasterDataProvider> logger,
     IClock clock,
-    IOptions<ProcessManagerComponentsOptions> options)
+    IOptions<ProcessManagerComponentsOptions> options,
+    ElectricityMarketViewsFactory electricityMarketViewsFactory)
         : IMeteringPointMasterDataProvider
 {
-    private readonly IElectricityMarketViews _electricityMarketViews = electricityMarketViews;
     private readonly ILogger<MeteringPointMasterDataProvider> _logger = logger;
     private readonly IClock _clock = clock;
     private readonly IOptions<ProcessManagerComponentsOptions> _options = options;
+    private readonly ElectricityMarketViewsFactory _electricityMarketViewsFactory = electricityMarketViewsFactory;
 
     public Task<IReadOnlyCollection<Model.MeteringPointMasterData>> GetMasterData(
         string meteringPointId,
@@ -62,6 +62,8 @@ public class MeteringPointMasterDataProvider(
         Instant startDateTime,
         Instant endDateTime)
     {
+        var electricityMarketViews = _electricityMarketViewsFactory.Create(meteringPointId);
+
         var id = new ElectricityMarketModels.MeteringPointIdentification(meteringPointId);
 
         IEnumerable<ElectricityMarketModels.MeteringPointMasterData> masterDataChanges;
@@ -85,12 +87,12 @@ public class MeteringPointMasterDataProvider(
             }
             else
             {
-                masterDataChanges = await _electricityMarketViews
+                masterDataChanges = await electricityMarketViews
                     .GetMeteringPointMasterDataChangesAsync(id, new Interval(startDateTime, endDateTime))
                     .ConfigureAwait(false);
 
                 // Get current master data to get the current grid area owner, and current grid areas neighboring grid area owners.
-                currentMasterDataChanges = (await _electricityMarketViews
+                currentMasterDataChanges = (await electricityMarketViews
                     .GetMeteringPointMasterDataChangesAsync(id, new Interval(_clock.GetCurrentInstant(), _clock.GetCurrentInstant().PlusSeconds(1)))
                     .ConfigureAwait(false)).Single();
             }
@@ -146,7 +148,7 @@ public class MeteringPointMasterDataProvider(
             }
 
             var parentId = meteringPointMasterData.ParentIdentification.Value;
-            var parentMasterData = (await _electricityMarketViews
+            var parentMasterData = (await electricityMarketViews
                     .GetMeteringPointMasterDataChangesAsync(
                         new ElectricityMarketModels.MeteringPointIdentification(parentId),
                         new Interval(from, to))

--- a/source/ProcessManager.Components/MeteringPointMasterData/MeteringPointMasterDataProvider.cs
+++ b/source/ProcessManager.Components/MeteringPointMasterData/MeteringPointMasterDataProvider.cs
@@ -62,9 +62,8 @@ public class MeteringPointMasterDataProvider(
         Instant startDateTime,
         Instant endDateTime)
     {
-        var electricityMarketViews = _electricityMarketViewsFactory.Create(meteringPointId);
-
         var id = new ElectricityMarketModels.MeteringPointIdentification(meteringPointId);
+        var electricityMarketViews = _electricityMarketViewsFactory.Create(id);
 
         IEnumerable<ElectricityMarketModels.MeteringPointMasterData> masterDataChanges;
         ElectricityMarketModels.MeteringPointMasterData currentMasterDataChanges;

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
@@ -36,7 +36,7 @@ public class MeasurementsClientExtensionsTests
     private ServiceCollection Services { get; } = new();
 
     [Fact]
-    public void MeasurementsClientOptionsAreConfigured_WhenAddMeasurementsClient_ClientCanBeCreated()
+    public void Given_MeasurementsClientOptionsAreConfigured_When_AddMeasurementsClient_Then_ClientAndEventHubFactoryCanBeCreated()
     {
         // Arrange
         Services.AddInMemoryConfiguration(new Dictionary<string, string?>()
@@ -53,10 +53,14 @@ public class MeasurementsClientExtensionsTests
 
         var actualClient = serviceProvider.GetRequiredService<IMeasurementsClient>();
         actualClient.Should().BeOfType<MeasurementsClient>();
+
+        var eventHubClientFactory = serviceProvider.GetRequiredService<MeasurementsEventHubProducerClientFactory>();
+        var act = () => eventHubClientFactory.Create("test-metering-point-id");
+        act.Should().NotThrow();
     }
 
     [Fact]
-    public void MeasurementsClientOptionsAreNotConfigured_WhenAddMeasurementsClient_ExceptionIsThrownWhenRequestingClient()
+    public void Given_MeasurementsClientOptionsAreNotConfigured_When_AddMeasurementsClient_Then_ExceptionIsThrownWhenCreatingEventHubClient()
     {
         // Arrange
         Services.AddInMemoryConfiguration([]);
@@ -67,8 +71,10 @@ public class MeasurementsClientExtensionsTests
         // Assert
         var serviceProvider = Services.BuildServiceProvider();
 
-        var clientAct = () => serviceProvider.GetRequiredService<IMeasurementsClient>();
-        clientAct.Should()
+        var eventHubClientFactory = serviceProvider.GetRequiredService<MeasurementsEventHubProducerClientFactory>();
+
+        var act = () => eventHubClientFactory.Create("test-metering-point-id");
+        act.Should()
             .Throw<OptionsValidationException>()
                 .WithMessage("DataAnnotation validation failed for 'MeasurementsClientOptions'*")
             .And.Failures.Should()
@@ -77,7 +83,7 @@ public class MeasurementsClientExtensionsTests
     }
 
     [Fact]
-    public void AzureEventHubHealthCheckAreConfigured_WhenAddMeasurementsClient_MeasurementsEventHubHealthCheckIsRegistered()
+    public void Given_AzureEventHubHealthCheckAreConfigured_When_AddMeasurementsClient_Then_MeasurementsEventHubHealthCheckIsRegistered()
     {
         // Arrange
         Services.AddInMemoryConfiguration(new Dictionary<string, string?>()

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
@@ -36,7 +36,7 @@ public class MeasurementsClientExtensionsTests
     private ServiceCollection Services { get; } = new();
 
     [Fact]
-    public void Given_MeasurementsClientOptionsAreConfigured_When_AddMeasurementsClient_Then_ClientAndEventHubProducerCanBeCreated()
+    public void Given_MeasurementsClientOptionsAreConfigured_When_AddMeasurementsClient_Then_MeasurementsClientAndEventHubClientCanBeCreated()
     {
         // Arrange
         Services.AddInMemoryConfiguration(new Dictionary<string, string?>()

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
@@ -36,7 +36,7 @@ public class MeasurementsClientExtensionsTests
     private ServiceCollection Services { get; } = new();
 
     [Fact]
-    public void Given_MeasurementsClientOptionsAreConfigured_When_AddMeasurementsClient_Then_ClientAndEventHubFactoryCanBeCreated()
+    public void Given_MeasurementsClientOptionsAreConfigured_When_AddMeasurementsClient_Then_ClientAndEventHubProducerCanBeCreated()
     {
         // Arrange
         Services.AddInMemoryConfiguration(new Dictionary<string, string?>()

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/Brs021Extensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/Brs021Extensions.cs
@@ -30,6 +30,8 @@ public static class Brs021Extensions
     {
         services.AddMeasurementsClient(azureCredential);
         services.AddScoped<IMeteringPointMasterDataProvider, MeteringPointMasterDataProvider>();
+        services.AddTransient<ElectricityMarketViewsFactory>();
+        services.AddScoped<MeteringPointReceiversProvider>();
         services.AddScoped<MeteringPointReceiversProvider>();
 
         // Used by BRS-021 ForwardMeteredData process

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/Brs021Extensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/Brs021Extensions.cs
@@ -32,7 +32,6 @@ public static class Brs021Extensions
         services.AddScoped<IMeteringPointMasterDataProvider, MeteringPointMasterDataProvider>();
         services.AddTransient<ElectricityMarketViewsFactory>();
         services.AddScoped<MeteringPointReceiversProvider>();
-        services.AddScoped<MeteringPointReceiversProvider>();
 
         // Used by BRS-021 ForwardMeteredData process
         services.AddScoped<DelegationProvider>();

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/MeasurementsClientExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/MeasurementsClientExtensions.cs
@@ -54,6 +54,7 @@ public static class MeasurementsClientExtensions
             });
 
         services.AddTransient<IMeasurementsClient, MeasurementsClient>();
+        services.AddTransient<MeasurementsEventHubProducerClientFactory>();
 
         services.AddHealthChecks()
             .AddAzureEventHub(

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/IMeasurementsClient.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/IMeasurementsClient.cs
@@ -19,7 +19,7 @@ namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.Forw
 public interface IMeasurementsClient
 {
     /// <summary>
-    /// Responsible for sending measurements for a metering point to Measurements subsytem.
+    /// Responsible for sending measurements for a metering point to Measurements subsystem.
     /// </summary>
     /// <param name="measurementsForMeteringPoint"></param>
     /// <param name="cancellationToken"></param>

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsEventHubProducerClientFactory.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsEventHubProducerClientFactory.cs
@@ -57,7 +57,9 @@ public class MeasurementsEventHubProducerClientFactory(
     /// </summary>
     private class EventHubProducerClientMock : EventHubProducerClient
     {
-        public override Task SendAsync(IEnumerable<EventData> eventBatch, CancellationToken cancellationToken = default)
+        public override Task SendAsync(
+            IEnumerable<EventData> eventBatch,
+            CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -70,7 +72,9 @@ public class MeasurementsEventHubProducerClientFactory(
             return Task.CompletedTask;
         }
 
-        public override Task SendAsync(EventDataBatch eventBatch, CancellationToken cancellationToken = default)
+        public override Task SendAsync(
+            EventDataBatch eventBatch,
+            CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsEventHubProducerClientFactory.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsEventHubProducerClientFactory.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Producer;
+using Energinet.DataHub.ProcessManager.Components.Extensions;
+using Energinet.DataHub.ProcessManager.Components.Extensions.DependencyInjection;
+using Energinet.DataHub.ProcessManager.Components.Extensions.Options;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Options;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.Measurements;
+
+public class MeasurementsEventHubProducerClientFactory(
+    IOptions<ProcessManagerComponentsOptions> options,
+    IAzureClientFactory<EventHubProducerClient> eventHubClientFactory)
+{
+    private readonly ProcessManagerComponentsOptions _options = options.Value;
+    private readonly IAzureClientFactory<EventHubProducerClient> _eventHubProducerFactory = eventHubClientFactory;
+
+    /// <summary>
+    /// Create an Event Hub producer client to messages to the Measurements subsystem.
+    /// <remarks>
+    /// If mocking dependencies are allowed for the current environment, then a mock will be returned
+    /// if the given <paramref name="meteringPointId"/> parameter is a test id.
+    /// </remarks>
+    /// </summary>
+    public EventHubProducerClient Create(string meteringPointId)
+    {
+        if (!_options.AllowMockDependenciesForTests)
+            return CreateMeasurementsEventHubProducerClient();
+
+        if (meteringPointId.IsTestMeteringPointId())
+            return new EventHubProducerClientMock();
+
+        return CreateMeasurementsEventHubProducerClient();
+    }
+
+    private EventHubProducerClient CreateMeasurementsEventHubProducerClient()
+    {
+        return _eventHubProducerFactory.CreateClient(EventHubProducerClientNames.MeasurementsEventHub);
+    }
+
+    /// <summary>
+    /// An Event Hub producer client mock implementation, that does not send any messages.
+    /// </summary>
+    private class EventHubProducerClientMock : EventHubProducerClient
+    {
+        public override Task SendAsync(IEnumerable<EventData> eventBatch, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task SendAsync(
+            IEnumerable<EventData> eventBatch,
+            SendEventOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task SendAsync(EventDataBatch eventBatch, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRule.cs
@@ -43,7 +43,7 @@ public class MeteringPointOwnershipValidationRule(IOptions<ProcessManagerCompone
         ForwardMeteredDataBusinessValidatedDto subject)
     {
         // The performance test uses non-existing metering points, so we must skip this validation
-        if (IsPerformanceTest(subject.Input))
+        if (_options.Value.AllowMockDependenciesForTests && IsTest(subject.Input))
             return Task.FromResult(NoError);
 
         // All the historical metering point master data, have the current grid access provider provided.
@@ -58,9 +58,13 @@ public class MeteringPointOwnershipValidationRule(IOptions<ProcessManagerCompone
         return Task.FromResult(NoError);
     }
 
-    private bool IsPerformanceTest(ForwardMeteredDataInputV1 input)
+    private bool IsTest(ForwardMeteredDataInputV1 input)
     {
-        var isInputTest = input.MeteringPointId?.IsPerformanceTestUuid() ?? false;
-        return _options.Value.AllowMockDependenciesForTests && isInputTest;
+        if (input.MeteringPointId is null)
+            return false;
+
+        var isPerformanceTest = input.MeteringPointId.IsPerformanceTestUuid();
+        var isTest = input.MeteringPointId.IsTestMeteringPointId();
+        return isPerformanceTest || isTest;
     }
 }

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRule.cs
@@ -43,7 +43,7 @@ public class MeteringPointOwnershipValidationRule(IOptions<ProcessManagerCompone
         ForwardMeteredDataBusinessValidatedDto subject)
     {
         // The performance test uses non-existing metering points, so we must skip this validation
-        if (_options.Value.AllowMockDependenciesForTests && IsTest(subject.Input))
+        if (_options.Value.AllowMockDependenciesForTests && IsTestInput(subject.Input))
             return Task.FromResult(NoError);
 
         // All the historical metering point master data, have the current grid access provider provided.
@@ -58,7 +58,7 @@ public class MeteringPointOwnershipValidationRule(IOptions<ProcessManagerCompone
         return Task.FromResult(NoError);
     }
 
-    private bool IsTest(ForwardMeteredDataInputV1 input)
+    private bool IsTestInput(ForwardMeteredDataInputV1 input)
     {
         if (input.MeteringPointId is null)
             return false;

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/BusinessValidation/MeteringPointOwnershipValidationRule.cs
@@ -49,8 +49,8 @@ public class MeteringPointOwnershipValidationRule(IOptions<ProcessManagerCompone
         // All the historical metering point master data, have the current grid access provider provided.
         var meteringPointMasterData = subject.MeteringPointMasterData.FirstOrDefault();
 
-        if (meteringPointMasterData != null && !meteringPointMasterData.CurrentGridAccessProvider.Value
-                .Equals(subject.Input.GridAccessProviderNumber))
+        if (meteringPointMasterData != null &&
+            !meteringPointMasterData.CurrentGridAccessProvider.Value.Equals(subject.Input.GridAccessProviderNumber))
         {
             return Task.FromResult(MeteringPointHasWrongOwnerError);
         }

--- a/source/ProcessManager.SubsystemTests/Fixtures/Extensions/ProcessManagerFixtureExtensions.cs
+++ b/source/ProcessManager.SubsystemTests/Fixtures/Extensions/ProcessManagerFixtureExtensions.cs
@@ -56,7 +56,7 @@ public static class ProcessManagerFixtureExtensions
                 orchestrationInstance = await fixture.ProcessManagerHttpClient
                     .GetOrchestrationInstanceByIdempotencyKeyAsync<TInputParameterDto>(
                         new GetOrchestrationInstanceByIdempotencyKeyQuery(
-                            operatingIdentity: fixture.UserIdentity,
+                            operatingIdentity: fixture.EnergySupplierUserIdentity,
                             idempotencyKey: idempotencyKey),
                         CancellationToken.None);
 
@@ -119,7 +119,7 @@ public static class ProcessManagerFixtureExtensions
                 orchestrationInstance = await fixture.ProcessManagerHttpClient
                     .GetOrchestrationInstanceByIdAsync(
                         new GetOrchestrationInstanceByIdQuery(
-                            operatingIdentity: fixture.UserIdentity,
+                            operatingIdentity: fixture.EnergySupplierUserIdentity,
                             id: orchestrationInstanceId),
                         CancellationToken.None);
 

--- a/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerFixture.cs
+++ b/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerFixture.cs
@@ -157,13 +157,6 @@ public class ProcessManagerFixture<TScenarioState> : IAsyncLifetime
             // Add event hub producer client to fake messages from Measurements to Process Manager
             b.AddEventHubProducerClientWithNamespace(Configuration.EventHubNamespace, Configuration.ProcessManagerEventHubName)
                 .WithName(ProcessManagerEventHubProducerClientName);
-            // b.AddClient<EventHubProducerClient, EventHubProducerClientOptions>(
-            //         (_, _, provider) =>
-            //         {
-            //             var azureCredential = new DefaultAzureCredential();
-            //             return new EventHubProducerClient(Configuration.EventHubNamespace, Configuration.ProcessManagerEventHubName, azureCredential);
-            //         })
-            //     .WithName(ProcessManagerEventHubClientName);
         });
 
         serviceCollection.AddProcessManagerMessageClient();

--- a/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerFixture.cs
+++ b/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerFixture.cs
@@ -59,7 +59,13 @@ public class ProcessManagerFixture<TConfiguration> : IAsyncLifetime
     public ActorIdentityDto? EnergySupplierActorIdentity { get; private set; }
 
     [NotNull]
-    public UserIdentityDto? UserIdentity { get; private set; }
+    public UserIdentityDto? EnergySupplierUserIdentity { get; private set; }
+
+    [NotNull]
+    public ActorIdentityDto? GridAccessProviderActorIdentity { get; private set; }
+
+    [NotNull]
+    public UserIdentityDto? GridAccessProviderUserIdentity { get; private set; }
 
     public async Task InitializeAsync()
     {
@@ -67,10 +73,19 @@ public class ProcessManagerFixture<TConfiguration> : IAsyncLifetime
             ActorNumber.Create(Configuration.EnergySupplierActorNumber),
             ActorRole.EnergySupplier);
 
-        UserIdentity = new UserIdentityDto(
+        EnergySupplierUserIdentity = new UserIdentityDto(
             UserId: _subsystemTestUserId,
             ActorNumber: EnergySupplierActorIdentity.ActorNumber,
             ActorRole: EnergySupplierActorIdentity.ActorRole);
+
+        GridAccessProviderActorIdentity = new ActorIdentityDto(
+            ActorNumber.Create(Configuration.GridAccessProviderActorNumber),
+            ActorRole.GridAccessProvider);
+
+        GridAccessProviderUserIdentity = new UserIdentityDto(
+            UserId: _subsystemTestUserId,
+            ActorNumber: GridAccessProviderActorIdentity.ActorNumber,
+            ActorRole: GridAccessProviderActorIdentity.ActorRole);
 
         await Task.CompletedTask;
     }

--- a/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerSubsystemTestConfiguration.cs
+++ b/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerSubsystemTestConfiguration.cs
@@ -25,6 +25,9 @@ public class ProcessManagerSubsystemTestConfiguration : SubsystemTestConfigurati
         EnergySupplierActorNumber = Root.GetValue<string>("ENERGY_SUPPLIER_ACTOR_NUMBER")
             ?? throw new ArgumentNullException(nameof(EnergySupplierActorNumber), $"Missing configuration value for ENERGY_SUPPLIER_ACTOR_NUMBER");
 
+        GridAccessProviderActorNumber = Root.GetValue<string>("GRID_ACCESS_PROVIDER_ACTOR_NUMBER")
+            ?? throw new ArgumentNullException(nameof(GridAccessProviderActorNumber), $"Missing configuration value for GRID_ACCESS_PROVIDER_ACTOR_NUMBER");
+
         var sharedKeyVaultName = Root.GetValue<string>("SHARED_KEYVAULT_NAME")
                                 ?? throw new NullReferenceException($"Missing configuration value for SHARED_KEYVAULT_NAME");
 
@@ -72,6 +75,8 @@ public class ProcessManagerSubsystemTestConfiguration : SubsystemTestConfigurati
     }
 
     public string EnergySupplierActorNumber { get; }
+
+    public string GridAccessProviderActorNumber { get; }
 
     public string ServiceBusNamespace { get; }
 

--- a/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerSubsystemTestConfiguration.cs
+++ b/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerSubsystemTestConfiguration.cs
@@ -22,56 +22,32 @@ public class ProcessManagerSubsystemTestConfiguration : SubsystemTestConfigurati
 {
     public ProcessManagerSubsystemTestConfiguration()
     {
-        EnergySupplierActorNumber = Root.GetValue<string>("ENERGY_SUPPLIER_ACTOR_NUMBER")
-            ?? throw new ArgumentNullException(nameof(EnergySupplierActorNumber), $"Missing configuration value for ENERGY_SUPPLIER_ACTOR_NUMBER");
+        EnergySupplierActorNumber = GetValueFromConfiguration(Root, "ENERGY_SUPPLIER_ACTOR_NUMBER");
+        GridAccessProviderActorNumber = GetValueFromConfiguration(Root, "GRID_ACCESS_PROVIDER_ACTOR_NUMBER");
 
-        GridAccessProviderActorNumber = Root.GetValue<string>("GRID_ACCESS_PROVIDER_ACTOR_NUMBER")
-            ?? throw new ArgumentNullException(nameof(GridAccessProviderActorNumber), $"Missing configuration value for GRID_ACCESS_PROVIDER_ACTOR_NUMBER");
-
-        var sharedKeyVaultName = Root.GetValue<string>("SHARED_KEYVAULT_NAME")
-                                ?? throw new NullReferenceException($"Missing configuration value for SHARED_KEYVAULT_NAME");
-
-        var internalKeyVaultName = Root.GetValue<string>("INTERNAL_KEYVAULT_NAME")
-                                ?? throw new NullReferenceException($"Missing configuration value for INTERNAL_KEYVAULT_NAME");
+        var sharedKeyVaultName = GetValueFromConfiguration(Root, "SHARED_KEYVAULT_NAME");
+        var internalKeyVaultName = GetValueFromConfiguration(Root, "INTERNAL_KEYVAULT_NAME");
 
         var keyVaultConfiguration = GetKeyVaultConfiguration(sharedKeyVaultName, internalKeyVaultName);
 
-        ServiceBusNamespace = keyVaultConfiguration.GetValue<string>("sb-domain-relay-namespace-endpoint")
-                                       ?? throw new ArgumentNullException(nameof(ServiceBusNamespace), $"Missing configuration value for {nameof(ServiceBusNamespace)}");
-
-        ProcessManagerStartTopicName = keyVaultConfiguration.GetValue<string>("sbt-processmanagerstart-name")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerStartTopicName), $"Missing configuration value for {nameof(ProcessManagerStartTopicName)}");
-
-        ProcessManagerNotifyTopicName = keyVaultConfiguration.GetValue<string>("sbt-processmanagernotify-name")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerNotifyTopicName), $"Missing configuration value for {nameof(ProcessManagerNotifyTopicName)}");
-
-        ProcessManagerBrs021StartTopicName = keyVaultConfiguration.GetValue<string>("sbt-brs021forwardmetereddatastart-name")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerBrs021StartTopicName), $"Missing configuration value for {nameof(ProcessManagerBrs021StartTopicName)}");
-
-        ProcessManagerBrs021NotifyTopicName = keyVaultConfiguration.GetValue<string>("sbt-brs021forwardmetereddatanotify-name")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerBrs021NotifyTopicName), $"Missing configuration value for {nameof(ProcessManagerBrs021NotifyTopicName)}");
-
-        ProcessManagerApplicationIdUri = keyVaultConfiguration.GetValue<string>("processmanager-application-id-uri")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerApplicationIdUri), $"Missing configuration value for {nameof(ProcessManagerApplicationIdUri)}");
+        ServiceBusNamespace = GetValueFromConfiguration(keyVaultConfiguration, "sb-domain-relay-namespace-endpoint");
+        ProcessManagerStartTopicName = GetValueFromConfiguration(keyVaultConfiguration, "sbt-processmanagerstart-name");
+        ProcessManagerNotifyTopicName = GetValueFromConfiguration(keyVaultConfiguration, "sbt-processmanagernotify-name");
+        ProcessManagerBrs021StartTopicName = GetValueFromConfiguration(keyVaultConfiguration, "sbt-brs021forwardmetereddatastart-name");
+        ProcessManagerBrs021NotifyTopicName = GetValueFromConfiguration(keyVaultConfiguration, "sbt-brs021forwardmetereddatanotify-name");
 
         // /.default must be added when running in the CD, else we get the following error: "Client credential flows
         // must have a scope value with /.default suffixed to the resource identifier (application ID URI)"
-        ProcessManagerApplicationIdUri = $"{ProcessManagerApplicationIdUri}/.default";
+        ProcessManagerApplicationIdUri = GetValueFromConfiguration(keyVaultConfiguration, "processmanager-application-id-uri") + "/.default";
+        ProcessManagerGeneralApiBaseAddress = GetValueFromConfiguration(keyVaultConfiguration, "func-api-pmcore-base-url");
+        ProcessManagerOrchestrationsApiBaseAddress = GetValueFromConfiguration(keyVaultConfiguration, "func-orchestrations-pmorch-base-url");
 
-        ProcessManagerGeneralApiBaseAddress = keyVaultConfiguration.GetValue<string>("func-api-pmcore-base-url")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerGeneralApiBaseAddress), $"Missing configuration value for {nameof(ProcessManagerGeneralApiBaseAddress)}");
+        ProcessManagerDatabricksWorkspaceUrl = GetValueFromConfiguration(keyVaultConfiguration, "dbw-workspace-https-url");
+        ProcessManagerDatabricksToken = GetValueFromConfiguration(keyVaultConfiguration, "dbw-workspace-token");
+        ProcessManagerDatabricksSqlWarehouseId = GetValueFromConfiguration(keyVaultConfiguration, "process-manager-warehouse-id");
 
-        ProcessManagerOrchestrationsApiBaseAddress = keyVaultConfiguration.GetValue<string>("func-orchestrations-pmorch-base-url")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerOrchestrationsApiBaseAddress), $"Missing configuration value for {nameof(ProcessManagerOrchestrationsApiBaseAddress)}");
-
-        ProcessManagerDatabricksWorkspaceUrl = keyVaultConfiguration.GetValue<string>("dbw-workspace-https-url")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerDatabricksWorkspaceUrl), $"Missing configuration value for {nameof(ProcessManagerDatabricksWorkspaceUrl)}");
-
-        ProcessManagerDatabricksToken = keyVaultConfiguration.GetValue<string>("dbw-workspace-token")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerDatabricksToken), $"Missing configuration value for {nameof(ProcessManagerDatabricksToken)}");
-
-        ProcessManagerDatabricksSqlWarehouseId = keyVaultConfiguration.GetValue<string>("process-manager-warehouse-id")
-            ?? throw new ArgumentNullException(nameof(ProcessManagerDatabricksSqlWarehouseId), $"Missing configuration value for {nameof(ProcessManagerDatabricksSqlWarehouseId)}");
+        EventHubNamespace = GetValueFromConfiguration(keyVaultConfiguration, "evhns-subsystemrelay-name") + ".servicebus.windows.net";
+        ProcessManagerEventHubName = GetValueFromConfiguration(keyVaultConfiguration, "evh-brs021forwardmetereddatanotify-name");
     }
 
     public string EnergySupplierActorNumber { get; }
@@ -100,6 +76,10 @@ public class ProcessManagerSubsystemTestConfiguration : SubsystemTestConfigurati
 
     public string ProcessManagerDatabricksSqlWarehouseId { get; }
 
+    public string EventHubNamespace { get; }
+
+    public string ProcessManagerEventHubName { get; }
+
     /// <summary>
     /// Build configuration for loading settings from key vault secrets.
     /// </summary>
@@ -112,5 +92,11 @@ public class ProcessManagerSubsystemTestConfiguration : SubsystemTestConfigurati
             .AddAuthenticatedAzureKeyVault(sharedKeyVaultUrl)
             .AddAuthenticatedAzureKeyVault(internalKeyVaultUrl)
             .Build();
+    }
+
+    private string GetValueFromConfiguration(IConfigurationRoot configuration, string key)
+    {
+        return configuration.GetValue<string>(key)
+               ?? throw new NullReferenceException($"Missing configuration value for {key}");
     }
 }

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_021/ElectricalHeatingCalculation/V1/ElectricalHeatingCalculationScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_021/ElectricalHeatingCalculation/V1/ElectricalHeatingCalculationScenario.cs
@@ -58,7 +58,7 @@ public class ElectricalHeatingCalculationScenario
         await _fixture.StartDatabricksSqlWarehouseAsync();
 
         _fixture.TestConfiguration = new ElectricalHeatingCalculationScenarioState(
-            startCommand: new StartElectricalHeatingCalculationCommandV1(_fixture.UserIdentity));
+            startCommand: new StartElectricalHeatingCalculationCommandV1(_fixture.EnergySupplierUserIdentity));
     }
 
     [SubsystemFact]

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_021/NetConsumptionCalculation/V1/NetConsumptionCalculationScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_021/NetConsumptionCalculation/V1/NetConsumptionCalculationScenario.cs
@@ -59,7 +59,7 @@ public class NetConsumptionCalculationScenario
         await _fixture.StartDatabricksSqlWarehouseAsync();
 
         _fixture.ScenarioState = new CalculationScenarioState(
-            startCommand: new StartNetConsumptionCalculationCommandV1(_fixture.UserIdentity));
+            startCommand: new StartNetConsumptionCalculationCommandV1(_fixture.EnergySupplierUserIdentity));
     }
 
     [SubsystemFact]

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenario.cs
@@ -143,6 +143,9 @@ public class SendMeasurementsScenario
         if (businessValidationStep?.CustomState.Length > 0)
             _fixture.Logger.WriteLine($"Business validation step custom state: {businessValidationStep?.CustomState}.");
 
+        if (businessValidationStep?.Lifecycle.TerminationState != StepInstanceTerminationState.Succeeded)
+            _fixture.ScenarioState.BusinessValidationFailed = true;
+
         Assert.Multiple(
             () => Assert.True(success, $"Business validation step should be terminated."),
             () => Assert.Equal(StepInstanceLifecycleState.Terminated, businessValidationStep?.Lifecycle.State),
@@ -154,6 +157,7 @@ public class SendMeasurementsScenario
     public async Task AndThen_MeasurementsAreSentToMeasurementsSubsystem()
     {
         Assert.NotNull(_fixture.ScenarioState.OrchestrationInstance); // If orchestration instance wasn't found in earlier test, end test early.
+        Assert.False(_fixture.ScenarioState.BusinessValidationFailed); // If business validation failed, end test early.
 
         var (success, orchestrationInstance, forwardToMeasurementsStep) =
             await _fixture.WaitForOrchestrationInstanceByIdempotencyKeyAsync<
@@ -175,6 +179,7 @@ public class SendMeasurementsScenario
     public async Task AndThen_ReceivedSendMeasurementsNotifyFromMeasurementsTransitionsForwardToMeasurementsToSuccessful()
     {
         Assert.NotNull(_fixture.ScenarioState.OrchestrationInstance); // If orchestration instance wasn't found in earlier test, end test early.
+        Assert.False(_fixture.ScenarioState.BusinessValidationFailed); // If business validation failed, end test early.
 
         // Simulate "ForwardMeteredDataNotifyV1" message from Measurements to Process Manager event hub
         var notifyFromMeasurementsMessage = new Brs021ForwardMeteredDataNotifyV1
@@ -207,6 +212,7 @@ public class SendMeasurementsScenario
     public async Task AndThen_EnqueueActorMessagesIsSentToEDI()
     {
         Assert.NotNull(_fixture.ScenarioState.OrchestrationInstance); // If orchestration instance wasn't found in earlier test, end test early.
+        Assert.False(_fixture.ScenarioState.BusinessValidationFailed); // If business validation failed, end test early.
 
         var (success, orchestrationInstance, enqueueActorMessagesStep) =
             await _fixture.WaitForOrchestrationInstanceByIdempotencyKeyAsync<
@@ -228,6 +234,7 @@ public class SendMeasurementsScenario
     public async Task AndThen_ReceivingNotifyEnqueueActorMessagesCompletedTransitionsEnqueueActorMessagesStepToSuccessful()
     {
         Assert.NotNull(_fixture.ScenarioState.OrchestrationInstance); // If orchestration instance wasn't found in earlier test, end test early.
+        Assert.False(_fixture.ScenarioState.BusinessValidationFailed); // If business validation failed, end test early.
 
         // Send notify "EnqueueActorMessagesCompleted" message to the orchestration instance
         await _fixture.ProcessManagerMessageClient.NotifyOrchestrationInstanceAsync(
@@ -256,6 +263,7 @@ public class SendMeasurementsScenario
     public async Task AndThen_OrchestrationInstanceIsTerminatedWithSuccess()
     {
         Assert.NotNull(_fixture.ScenarioState.OrchestrationInstance); // If orchestration instance wasn't found in earlier test, end test early.
+        Assert.False(_fixture.ScenarioState.BusinessValidationFailed); // If business validation failed, end test early.
 
         var (success, orchestrationInstance, _) =
             await _fixture.WaitForOrchestrationInstanceByIdempotencyKeyAsync<

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenario.cs
@@ -1,0 +1,151 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.TestCommon.Xunit.Attributes;
+using Energinet.DataHub.Core.TestCommon.Xunit.Orderers;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.Extensions;
+using Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData.Extensions;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.SendMeasurements.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
+using Energinet.DataHub.ProcessManager.SubsystemTests.Fixtures;
+using Energinet.DataHub.ProcessManager.SubsystemTests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.SubsystemTests.Processes.BRS_026_028.BRS_026.V1;
+using NodaTime;
+using NodaTime.Text;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.ProcessManager.SubsystemTests.Processes.BRS_021.SendMeasurements.V1;
+
+[TestCaseOrderer(
+    ordererTypeName: TestCaseOrdererLocation.OrdererTypeName,
+    ordererAssemblyName: TestCaseOrdererLocation.OrdererAssemblyName)]
+public class SendMeasurementsScenario
+    : IClassFixture<ProcessManagerFixture<SendMeasurementsScenarioState>>,
+        IAsyncLifetime
+{
+    private readonly ProcessManagerFixture<SendMeasurementsScenarioState> _fixture;
+
+    public SendMeasurementsScenario(
+        ProcessManagerFixture<SendMeasurementsScenarioState> fixture,
+        ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _fixture.SetTestOutputHelper(null);
+        return Task.CompletedTask;
+    }
+
+    [SubsystemFact]
+    [ScenarioStep(1)]
+    public void Given_ValidSendMeasurementsCommand()
+    {
+        var start = Instant.FromUtc(2025, 05, 21, 23, 00, 00);
+        var end = start.Plus(Duration.FromDays(1));
+        var periodDuration = end - start;
+        var resolution = Resolution.QuarterHourly;
+        var numberOfMeasurements = (int)(periodDuration.TotalMinutes / 15); // Resolution = QuarterHourly = 15 minutes
+
+        var actorMessageId = Guid.NewGuid().ToTestMessageUuid();
+        var transactionId = Guid.NewGuid().ToTestMessageUuid();
+        _fixture.TestConfiguration = new SendMeasurementsScenarioState(
+            Command: new SendMeasurementsCommandV1(
+                operatingIdentity: _fixture.GridAccessProviderActorIdentity,
+                inputParameter: new SendMeasurementsInputV1(
+                    ActorMessageId: actorMessageId,
+                    TransactionId: transactionId,
+                    ActorNumber: _fixture.GridAccessProviderActorIdentity.ActorNumber.Value,
+                    ActorRole: _fixture.GridAccessProviderActorIdentity.ActorRole.Name,
+                    BusinessReason: BusinessReason.PeriodicMetering.Name,
+                    MeteringPointId: "123456789012345678",
+                    MeteringPointType: MeteringPointType.Consumption.Name,
+                    ProductNumber: null,
+                    MeasureUnit: MeasurementUnit.KilowattHour.Name,
+                    RegistrationDateTime: InstantPattern.General.Format(end),
+                    Resolution: resolution.Name,
+                    StartDateTime: InstantPattern.General.Format(start),
+                    EndDateTime: InstantPattern.General.Format(end),
+                    GridAccessProviderNumber: _fixture.GridAccessProviderActorIdentity.ActorNumber.Value,
+                    MeteredDataList: Enumerable.Range(0, numberOfMeasurements)
+                        .Select(
+                            i => new SendMeasurementsInputV1.MeteredData(
+                                Position: (i + 1).ToString(), // Position is 1 based
+                                EnergyQuantity: "42.0",
+                                QuantityQuality: Quality.AsProvided.Name))
+                        .ToList()),
+                idempotencyKey: transactionId));
+    }
+
+    [SubsystemFact]
+    [ScenarioStep(2)]
+    public async Task AndGiven_StartNewOrchestrationInstanceIsSent()
+    {
+        await _fixture.ProcessManagerMessageClient.StartNewOrchestrationInstanceAsync(
+            _fixture.TestConfiguration.Command,
+            CancellationToken.None);
+    }
+
+    [SubsystemFact]
+    [ScenarioStep(3)]
+    public async Task When_OrchestrationInstanceIsRunning()
+    {
+        var (success, orchestrationInstance, _) =
+            await _fixture.WaitForOrchestrationInstanceByIdempotencyKeyAsync<
+                SendMeasurementsInputV1, SendMeasurementsScenarioState>(
+                _fixture.TestConfiguration.Command.IdempotencyKey,
+                OrchestrationInstanceLifecycleState.Running);
+
+        Assert.Multiple(
+            () => Assert.True(
+                success,
+                $"An orchestration instance for idempotency key \"{_fixture.TestConfiguration.Command.IdempotencyKey}\" should have been found"),
+            () => Assert.NotNull(orchestrationInstance));
+
+        _fixture.TestConfiguration.OrchestrationInstance = orchestrationInstance;
+    }
+
+    [SubsystemFact]
+    [ScenarioStep(4)]
+    public async Task Then_BusinessValidationIsSuccessful()
+    {
+        Assert.NotNull(_fixture.TestConfiguration.OrchestrationInstance); // If orchestration instance wasn't found in earlier test, end test early.
+
+        var (success, orchestrationInstance, businessValidationStep) =
+            await _fixture.WaitForOrchestrationInstanceByIdempotencyKeyAsync<
+                SendMeasurementsInputV1, SendMeasurementsScenarioState>(
+                idempotencyKey: _fixture.TestConfiguration.Command.IdempotencyKey,
+                stepSequence: Orchestrations.Processes.BRS_021.SendMeasurements.V1.OrchestrationDescriptionBuilder.BusinessValidationStep,
+                stepState: StepInstanceLifecycleState.Terminated);
+
+        _fixture.TestConfiguration.OrchestrationInstance = orchestrationInstance;
+
+        if (businessValidationStep?.CustomState.Length > 0)
+            _fixture.Logger.WriteLine($"Business validation step custom state: {businessValidationStep?.CustomState}.");
+
+        Assert.Multiple(
+            () => Assert.True(success, $"Business validation step should be terminated."),
+            () => Assert.Equal(StepInstanceLifecycleState.Terminated, businessValidationStep?.Lifecycle.State),
+            () => Assert.Equal(StepInstanceTerminationState.Succeeded, businessValidationStep?.Lifecycle.TerminationState));
+    }
+}

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenario.cs
@@ -78,7 +78,7 @@ public class SendMeasurementsScenario
                     ActorNumber: _fixture.GridAccessProviderActorIdentity.ActorNumber.Value,
                     ActorRole: _fixture.GridAccessProviderActorIdentity.ActorRole.Name,
                     BusinessReason: BusinessReason.PeriodicMetering.Name,
-                    MeteringPointId: "123456789012345678",
+                    MeteringPointId: "123456789012345678".ToTestMeteringPointId(),
                     MeteringPointType: MeteringPointType.Consumption.Name,
                     ProductNumber: null,
                     MeasureUnit: MeasurementUnit.KilowattHour.Name,

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenarioState.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenarioState.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.SendMeasurements.V1.Model;
+
+namespace Energinet.DataHub.ProcessManager.SubsystemTests.Processes.BRS_021.SendMeasurements.V1;
+
+public record SendMeasurementsScenarioState(
+    SendMeasurementsCommandV1 Command)
+{
+    public OrchestrationInstanceTypedDto<SendMeasurementsInputV1>? OrchestrationInstance { get; set; }
+}

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenarioState.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenarioState.cs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
-using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.SendMeasurements.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 
 namespace Energinet.DataHub.ProcessManager.SubsystemTests.Processes.BRS_021.SendMeasurements.V1;
 
 public record SendMeasurementsScenarioState(
-    SendMeasurementsCommandV1 Command)
+    ForwardMeteredDataCommandV1 Command)
 {
-    public OrchestrationInstanceTypedDto<SendMeasurementsInputV1>? OrchestrationInstance { get; set; }
+    public OrchestrationInstanceTypedDto<ForwardMeteredDataInputV1>? OrchestrationInstance { get; set; }
 }

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenarioState.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_021/SendMeasurements/V1/SendMeasurementsScenarioState.cs
@@ -21,4 +21,6 @@ public record SendMeasurementsScenarioState(
     ForwardMeteredDataCommandV1 Command)
 {
     public OrchestrationInstanceTypedDto<ForwardMeteredDataInputV1>? OrchestrationInstance { get; set; }
+
+    public bool BusinessValidationFailed { get; set; } = false;
 }

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/MissingMeasurementsLogCalculationScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/MissingMeasurementsLogCalculationScenario.cs
@@ -59,7 +59,7 @@ public class MissingMeasurementsLogCalculationScenario
         await _fixture.StartDatabricksSqlWarehouseAsync();
 
         _fixture.ScenarioState = new CalculationScenarioState(
-            startCommand: new StartMissingMeasurementsLogCalculationCommandV1(_fixture.UserIdentity));
+            startCommand: new StartMissingMeasurementsLogCalculationCommandV1(_fixture.EnergySupplierUserIdentity));
     }
 
     [SubsystemFact]

--- a/source/ProcessManager.SubsystemTests/Processes/BRS_045/MissingMeasurementsLogOnDemand/V1/MissingMeasurementsLogOnDemandCalculationScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_045/MissingMeasurementsLogOnDemand/V1/MissingMeasurementsLogOnDemandCalculationScenario.cs
@@ -66,7 +66,7 @@ public class MissingMeasurementsLogOnDemandCalculationScenario
 
         _fixture.ScenarioState = new CalculationScenarioState(
             startCommand: new StartMissingMeasurementsLogOnDemandCalculationCommandV1(
-                _fixture.UserIdentity,
+                _fixture.EnergySupplierUserIdentity,
                 new CalculationInputV1(periodStart.ToDateTimeOffset(), periodEnd.ToDateTimeOffset(), gridAreaCodes)));
 
         return Task.CompletedTask;

--- a/source/ProcessManager.SubsystemTests/subsystemtest.local.settings.sample.json
+++ b/source/ProcessManager.SubsystemTests/subsystemtest.local.settings.sample.json
@@ -4,5 +4,6 @@
   // github.com/Energinet-DataHub/dh3-dev-secrets/blob/main/opengeh-process-manager/SubsystemTests/subsystemtest.dev002.settings.json
   "SHARED_KEYVAULT_NAME": "<shared keyvault name>",
   "ENERGY_SUPPLIER_ACTOR_NUMBER": "<energy supplier actor number, used to make requests to the Process Manager>",
+  "GRID_ACCESS_PROVIDER_ACTOR_NUMBER": "<grid access provider actor number, used to make requests to the Process Manager>",
   "SUBSYSTEMFACT_SKIP": "false"
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

- Add BRS-021 Send Measurements subsystem test.
- Mock Electricity Market Views when running subsystem tests.
- Mock Measurements Event Hub producer client when running subsystem tests.
- Fix tests.

## References

- Requires Environments PR: https://github.com/Energinet-DataHub/dh3-environments/pull/1492
- Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/657
- D002 run: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/15250693606/job/42887179794

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task
