### PR TITLE
refac: Use token credential factory

### DIFF
--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -101,7 +101,7 @@ jobs:
           azure_functions_core_tools_version: 4.0.5455
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@v14
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@dstenroejl/run-tests # TODO: Revert to v14
         with:
           solution_file_path: ./source/ProcessManager.NuGet.Filtered.slnf
           azure_tenant_id: ${{ vars.integration_test_azure_tenant_id }}

--- a/.github/workflows/processmanager-client-bundle-publish.yml
+++ b/.github/workflows/processmanager-client-bundle-publish.yml
@@ -101,7 +101,7 @@ jobs:
           azure_functions_core_tools_version: 4.0.5455
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@dstenroejl/run-tests # TODO: Revert to v14
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@v14
         with:
           solution_file_path: ./source/ProcessManager.NuGet.Filtered.slnf
           azure_tenant_id: ${{ vars.integration_test_azure_tenant_id }}

--- a/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Client Release Notes
 
+## Version 5.1.1
+
+- Updated `AddProcessManagerHttpClients` to use `AddTokenCredentialProvider` from `Energinet.DataHub.Core.App.Common` package.
+
 ## Version 5.1.0
 
 - Updated `AddProcessManagerHttpClients` to use `AddAuthorizationHeaderProvider` from `Energinet.DataHub.Core.App.Common` package.

--- a/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,8 +1,8 @@
 # ProcessManager.Client Release Notes
 
-## Version 5.1.1
+## Version 6.0.0
 
-- Updated `AddProcessManagerHttpClients` to use `AddTokenCredentialProvider` from `Energinet.DataHub.Core.App.Common` package.
+- Updated `AddProcessManagerHttpClients` to expect `AddTokenCredentialProvider` from `Energinet.DataHub.Core.App.Common` package has been called.
 
 ## Version 5.1.0
 

--- a/docs/ProcessManager.Components.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Components.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Components.Abstractions Release Notes
 
+## Version 2.0.6
+
+- No functional changes.
+
 ## Version 2.0.5
 
 - No functional changes.

--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
+## Version 2.3.1
+
+- No functional changes.
+
 ## Version 2.3.0
 
 - Add `MissingMeasurementsLogCalculationResultV1`

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Abstractions</PackageId>
-    <PackageVersion>5.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>5.1.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -52,8 +52,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Google.Protobuf" Version="3.30.2" />
-    <PackageReference Include="Grpc.Tools" Version="2.71.0">
+    <PackageReference Include="Google.Protobuf" Version="3.31.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.72.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
+++ b/source/ProcessManager.Abstractions/ProcessManager.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Abstractions</PackageId>
-    <PackageVersion>5.1.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.0.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
+++ b/source/ProcessManager.Client.Tests/ProcessManager.Client.Tests.csproj
@@ -20,9 +20,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/ProcessManager.Client.Tests/Unit/Extensions/DependencyInjection/ClientExtensionsTests.cs
+++ b/source/ProcessManager.Client.Tests/Unit/Extensions/DependencyInjection/ClientExtensionsTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Client;
 using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
@@ -48,12 +49,14 @@ public class ClientExtensionsTests
     public void OptionsAreConfigured_WhenAddProcessManagerHttpClients_ClientCanBeCreated()
     {
         // Arrange
-        Services.AddInMemoryConfiguration(new Dictionary<string, string?>()
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"] = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"] = GeneralApiBaseAddressFake,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"] = OrchestrationsApiBaseAddressFake,
-        });
+        Services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>()
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"] = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"] = GeneralApiBaseAddressFake,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"] = OrchestrationsApiBaseAddressFake,
+            });
 
         // Act
         Services.AddProcessManagerHttpClients();
@@ -69,7 +72,9 @@ public class ClientExtensionsTests
     public void OptionsAreNotConfigured_WhenAddProcessManagerHttpClients_ExceptionIsThrownWhenRequestingClient()
     {
         // Arrange
-        Services.AddInMemoryConfiguration([]);
+        Services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration([]);
 
         // Act
         Services.AddProcessManagerHttpClients();
@@ -91,12 +96,14 @@ public class ClientExtensionsTests
     public void OptionsAreConfiguredAndAddProcessManagerHttpClients_WhenCreatingEachHttpClient_HttpClientCanBeCreatedWithExpectedBaseAddress()
     {
         // Arrange
-        Services.AddInMemoryConfiguration(new Dictionary<string, string?>()
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"] = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"] = GeneralApiBaseAddressFake,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"] = OrchestrationsApiBaseAddressFake,
-        });
+        Services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>()
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"] = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"] = GeneralApiBaseAddressFake,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"] = OrchestrationsApiBaseAddressFake,
+            });
 
         Services.AddProcessManagerHttpClients();
 

--- a/source/ProcessManager.Client.Tests/Unit/Extensions/DependencyInjection/ClientExtensionsTests.cs
+++ b/source/ProcessManager.Client.Tests/Unit/Extensions/DependencyInjection/ClientExtensionsTests.cs
@@ -46,7 +46,7 @@ public class ClientExtensionsTests
     private ServiceCollection Services { get; }
 
     [Fact]
-    public void OptionsAreConfigured_WhenAddProcessManagerHttpClients_ClientCanBeCreated()
+    public void Given_TokenCredentialIsRegisteredAndOptionsAreConfigured_When_AddProcessManagerHttpClients_Then_ClientCanBeCreated()
     {
         // Arrange
         Services
@@ -69,7 +69,7 @@ public class ClientExtensionsTests
     }
 
     [Fact]
-    public void OptionsAreNotConfigured_WhenAddProcessManagerHttpClients_ExceptionIsThrownWhenRequestingClient()
+    public void Given_TokenCredentialIsRegisteredAndOptionsAreNotConfigured_When_AddProcessManagerHttpClients_Then_ExceptionIsThrownWhenRequestingClient()
     {
         // Arrange
         Services
@@ -93,7 +93,7 @@ public class ClientExtensionsTests
     }
 
     [Fact]
-    public void OptionsAreConfiguredAndAddProcessManagerHttpClients_WhenCreatingEachHttpClient_HttpClientCanBeCreatedWithExpectedBaseAddress()
+    public void Given_TokenCredentialIsRegisteredAndOptionsAreConfiguredAndAddProcessManagerHttpClients_When_CreatingEachHttpClient_Then_HttpClientCanBeCreatedWithExpectedBaseAddress()
     {
         // Arrange
         Services
@@ -124,7 +124,7 @@ public class ClientExtensionsTests
     }
 
     [Fact]
-    public void ServiceBusClientIsRegisteredAndOptionsAreConfigured_WhenAddProcessManagerMessageClient_ClientAndOptionsAndSenderClientsCanBeCreated()
+    public void Given_ServiceBusClientIsRegisteredAndOptionsAreConfigured_When_AddProcessManagerMessageClient_Then_ClientAndOptionsAndSenderClientsCanBeCreated()
     {
         // Arrange
         Services.AddAzureClients(
@@ -163,7 +163,7 @@ public class ClientExtensionsTests
     }
 
     [Fact]
-    public void ServiceBusClientIsRegisteredAndOptionsAreNotConfigured_WhenAddProcessManagerMessageClient_ExceptionIsThrownWhenRequestingOptions()
+    public void Given_ServiceBusClientIsRegisteredAndOptionsAreNotConfigured_When_AddProcessManagerMessageClient_Then_ExceptionIsThrownWhenRequestingOptions()
     {
         // Arrange
         Services.AddAzureClients(
@@ -189,7 +189,7 @@ public class ClientExtensionsTests
     }
 
     [Fact]
-    public void ServiceBusClientIsNotRegisteredAndOptionsAreConfigured_WhenAddProcessManagerMessageClient_ExceptionIsThrownWhenRequestingSenderClient()
+    public void Given_ServiceBusClientIsNotRegisteredAndOptionsAreConfigured_When_AddProcessManagerMessageClient_Then_ExceptionIsThrownWhenRequestingSenderClient()
     {
         // Arrange
         Services.AddInMemoryConfiguration(new Dictionary<string, string?>()

--- a/source/ProcessManager.Client.Tests/Unit/Extensions/DependencyInjection/ClientExtensionsTests.cs
+++ b/source/ProcessManager.Client.Tests/Unit/Extensions/DependencyInjection/ClientExtensionsTests.cs
@@ -46,6 +46,30 @@ public class ClientExtensionsTests
     private ServiceCollection Services { get; }
 
     [Fact]
+    public void Given_TokenCredentialIsNotRegisteredAndOptionsAreConfigured_When_AddProcessManagerHttpClients_Then_ExceptionIsThrownWhenRequestingClient()
+    {
+        // Arrange
+        Services
+            .AddInMemoryConfiguration(new Dictionary<string, string?>()
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"] = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"] = GeneralApiBaseAddressFake,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"] = OrchestrationsApiBaseAddressFake,
+            });
+
+        // Act
+        Services.AddProcessManagerHttpClients();
+
+        // Assert
+        var serviceProvider = Services.BuildServiceProvider();
+
+        var clientAct = () => serviceProvider.GetRequiredService<IProcessManagerClient>();
+        clientAct.Should()
+            .Throw<InvalidOperationException>()
+                .WithMessage("No service for type 'Energinet.DataHub.Core.App.Common.Identity.TokenCredentialProvider' has been registered*");
+    }
+
+    [Fact]
     public void Given_TokenCredentialIsRegisteredAndOptionsAreConfigured_When_AddProcessManagerHttpClients_Then_ClientCanBeCreated()
     {
         // Arrange
@@ -69,11 +93,10 @@ public class ClientExtensionsTests
     }
 
     [Fact]
-    public void Given_TokenCredentialIsRegisteredAndOptionsAreNotConfigured_When_AddProcessManagerHttpClients_Then_ExceptionIsThrownWhenRequestingClient()
+    public void Given_OptionsAreNotConfigured_When_AddProcessManagerHttpClients_Then_ExceptionIsThrownWhenRequestingClient()
     {
         // Arrange
         Services
-            .AddTokenCredentialProvider()
             .AddInMemoryConfiguration([]);
 
         // Act

--- a/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
+++ b/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
@@ -44,8 +44,7 @@ public static class ClientExtensions
             .BindConfiguration(ProcessManagerHttpClientsOptions.SectionName)
             .ValidateDataAnnotations();
 
-        services
-            .AddAuthorizationHeaderProvider();
+        services.AddAuthorizationHeaderProvider();
 
         services.AddHttpClient(HttpClientNames.GeneralApi, (sp, httpClient) =>
         {

--- a/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
+++ b/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
@@ -41,7 +41,9 @@ public static class ClientExtensions
             .BindConfiguration(ProcessManagerHttpClientsOptions.SectionName)
             .ValidateDataAnnotations();
 
-        services.AddAuthorizationHeaderProvider();
+        services
+            .AddTokenCredentialProvider()
+            .AddAuthorizationHeaderProvider();
 
         services.AddHttpClient(HttpClientNames.GeneralApi, (sp, httpClient) =>
         {

--- a/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
+++ b/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
@@ -34,6 +34,9 @@ public static class ClientExtensions
     /// Configures http clients with an "Authorization" header value and
     /// forward it to the Process Manager API for authentication/authorization.
     /// </summary>
+    /// <remarks>
+    /// Expects "AddTokenCredentialProvider" has been called to register <see cref="TokenCredentialProvider"/>.
+    /// </remarks>
     public static IServiceCollection AddProcessManagerHttpClients(this IServiceCollection services)
     {
         services
@@ -42,7 +45,6 @@ public static class ClientExtensions
             .ValidateDataAnnotations();
 
         services
-            .AddTokenCredentialProvider()
             .AddAuthorizationHeaderProvider();
 
         services.AddHttpClient(HttpClientNames.GeneralApi, (sp, httpClient) =>

--- a/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
+++ b/source/ProcessManager.Client/Extensions/DependencyInjection/ClientExtensions.cs
@@ -64,8 +64,10 @@ public static class ClientExtensions
 
     /// <summary>
     /// Register Process Manager message client for use in applications.
-    /// <remarks>The application must register the <see cref="ServiceBusClient"/> and contain configuration for <see cref="ProcessManagerServiceBusClientOptions"/></remarks>
     /// </summary>
+    /// <remarks>
+    /// The application must register the <see cref="ServiceBusClient"/> and contain configuration for <see cref="ProcessManagerServiceBusClientOptions"/>
+    /// </remarks>
     public static IServiceCollection AddProcessManagerMessageClient(this IServiceCollection services)
     {
         services

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Client</PackageId>
-    <PackageVersion>5.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>5.1.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -50,7 +50,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.19.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.5.0-alpha-461" />
+    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -50,7 +50,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.19.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.4.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.5.0-alpha-461" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -52,9 +52,9 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.19.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/ProcessManager.Client/ProcessManager.Client.csproj
+++ b/source/ProcessManager.Client/ProcessManager.Client.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Client</PackageId>
-    <PackageVersion>5.1.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.0.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Components.Abstractions/ProcessManager.Components.Abstractions.csproj
+++ b/source/ProcessManager.Components.Abstractions/ProcessManager.Components.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Components.Abstractions</PackageId>
-    <PackageVersion>2.0.5$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.6$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Components Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
+++ b/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
@@ -14,7 +14,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Azure.Messaging.ServiceBus.Administration;
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.WebApp.Extensions.Builder;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;

--- a/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
+++ b/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Azure.Messaging.ServiceBus.Administration;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.WebApp.Extensions.Builder;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
@@ -141,7 +142,9 @@ public sealed class IntegrationEventPublisherFixture : IAsyncLifetime
             .Build();
 
         services.AddScoped<IConfiguration>(_ => configuration);
-        services.AddServiceBusClientForApplication(configuration);
+        services.AddServiceBusClientForApplication(
+            configuration,
+            _ => IntegrationTestConfiguration.Credential);
         services.AddIntegrationEventPublisher();
     }
 

--- a/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
+++ b/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
@@ -142,7 +142,7 @@ public sealed class IntegrationEventPublisherFixture : IAsyncLifetime
 
         services.AddScoped<IConfiguration>(_ => configuration);
         services.AddServiceBusClientForApplication(configuration);
-        services.AddIntegrationEventPublisher(IntegrationTestConfiguration.Credential);
+        services.AddIntegrationEventPublisher();
     }
 
     private async Task<(TopicResource TopicResource, SubscriptionProperties SubscriptionProperties)> CreateServiceBusTopic()

--- a/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
+++ b/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Azure.Messaging.ServiceBus.Administration;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.WebApp.Extensions.Builder;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
@@ -140,11 +141,13 @@ public sealed class IntegrationEventPublisherFixture : IAsyncLifetime
             .AddInMemoryCollection(configurations)
             .Build();
 
-        services.AddScoped<IConfiguration>(_ => configuration);
-        services.AddServiceBusClientForApplication(
-            configuration,
-            _ => IntegrationTestConfiguration.Credential);
-        services.AddIntegrationEventPublisher();
+        services
+            .AddScoped<IConfiguration>(_ => configuration)
+            .AddTokenCredentialProvider()
+            .AddServiceBusClientForApplication(
+                configuration,
+                _ => IntegrationTestConfiguration.Credential)
+            .AddIntegrationEventPublisher();
     }
 
     private async Task<(TopicResource TopicResource, SubscriptionProperties SubscriptionProperties)> CreateServiceBusTopic()

--- a/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
+++ b/source/ProcessManager.Components.Tests/Fixtures/IntegrationEventPublisherFixture.cs
@@ -129,16 +129,14 @@ public sealed class IntegrationEventPublisherFixture : IAsyncLifetime
 
     private void ConfigureServices(IServiceCollection services)
     {
-        var configurations = new Dictionary<string, string?>
-        {
-            [$"{ServiceBusNamespaceOptions.SectionName}:{nameof(ServiceBusNamespaceOptions.FullyQualifiedNamespace)}"]
-                = IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace,
-            [$"{IntegrationEventTopicOptions.SectionName}:{nameof(IntegrationEventTopicOptions.Name)}"]
-                = IntegrationEventTopic.Name,
-        };
-
         var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(configurations)
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{ServiceBusNamespaceOptions.SectionName}:{nameof(ServiceBusNamespaceOptions.FullyQualifiedNamespace)}"]
+                = IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace,
+                [$"{IntegrationEventTopicOptions.SectionName}:{nameof(IntegrationEventTopicOptions.Name)}"]
+                = IntegrationEventTopic.Name,
+            })
             .Build();
 
         services

--- a/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
+++ b/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="15.5.0-alpha-461" />
+    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="15.5.0" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="8.2.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
+++ b/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="15.4.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="15.5.0-alpha-461" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="8.2.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
+++ b/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.31.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.71.0">
+    <PackageReference Include="Grpc.Tools" Version="2.72.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
+++ b/source/ProcessManager.Components.Tests/ProcessManager.Components.Tests.csproj
@@ -24,21 +24,21 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="WireMock.Net" Version="1.7.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.30.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.31.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/ProcessManager.Components.Tests/Unit/EnqueueActorMessages/EnqueueActorMessagesHttpClientTests.cs
+++ b/source/ProcessManager.Components.Tests/Unit/EnqueueActorMessages/EnqueueActorMessagesHttpClientTests.cs
@@ -37,20 +37,21 @@ public class EnqueueActorMessagesHttpClientTests : IAsyncLifetime
         MockServer = WireMockServer.Start(port: 8989);
         Services = new ServiceCollection();
 
-        var configuration = new Dictionary<string, string?>()
-        {
-            [$"{EnqueueActorMessagesHttpClientOptions.SectionName}:{nameof(EnqueueActorMessagesHttpClientOptions.BaseUrl)}"] =
-                MockServer.Url,
-            [$"{EnqueueActorMessagesHttpClientOptions.SectionName}:{nameof(EnqueueActorMessagesHttpClientOptions.ApplicationIdUri)}"] =
-                SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{EnqueueActorMessagesHttpClientOptions.SectionName}:{nameof(EnqueueActorMessagesHttpClientOptions.BaseUrl)}"] =
+                    MockServer.Url,
+                [$"{EnqueueActorMessagesHttpClientOptions.SectionName}:{nameof(EnqueueActorMessagesHttpClientOptions.ApplicationIdUri)}"] =
+                    SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+            })
+            .Build();
 
         Services
-            .AddInMemoryConfiguration(configuration)
+            .AddScoped<IConfiguration>(_ => configuration)
             .AddTokenCredentialProvider();
 
-        Services.AddEnqueueActorMessagesHttp(
-            new ConfigurationBuilder().AddInMemoryCollection(configuration).Build());
+        Services.AddEnqueueActorMessagesHttp(configuration);
         ServiceProvider = Services.BuildServiceProvider();
         Sut = ServiceProvider.GetRequiredService<IEnqueueActorMessagesHttpClient>();
     }

--- a/source/ProcessManager.Components.Tests/Unit/EnqueueActorMessages/EnqueueActorMessagesHttpClientTests.cs
+++ b/source/ProcessManager.Components.Tests/Unit/EnqueueActorMessages/EnqueueActorMessagesHttpClientTests.cs
@@ -15,6 +15,7 @@
 using System.Net;
 using Azure.Core;
 using Azure.Identity;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Components.Abstractions.EnqueueActorMessages;
 using Energinet.DataHub.ProcessManager.Components.EnqueueActorMessages;
@@ -44,7 +45,9 @@ public class EnqueueActorMessagesHttpClientTests : IAsyncLifetime
                 SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
         };
 
-        Services.AddInMemoryConfiguration(configuration);
+        Services
+            .AddInMemoryConfiguration(configuration)
+            .AddTokenCredentialProvider();
 
         Services.AddEnqueueActorMessagesHttp(
             new ConfigurationBuilder().AddInMemoryCollection(configuration).Build());

--- a/source/ProcessManager.Components.Tests/Unit/EnqueueActorMessages/EnqueueActorMessagesHttpClientTests.cs
+++ b/source/ProcessManager.Components.Tests/Unit/EnqueueActorMessages/EnqueueActorMessagesHttpClientTests.cs
@@ -37,10 +37,10 @@ public class EnqueueActorMessagesHttpClientTests : IAsyncLifetime
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                [$"{EnqueueActorMessagesHttpClientOptions.SectionName}:{nameof(EnqueueActorMessagesHttpClientOptions.BaseUrl)}"] =
-                    MockServer.Url,
-                [$"{EnqueueActorMessagesHttpClientOptions.SectionName}:{nameof(EnqueueActorMessagesHttpClientOptions.ApplicationIdUri)}"] =
-                    SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{EnqueueActorMessagesHttpClientOptions.SectionName}:{nameof(EnqueueActorMessagesHttpClientOptions.BaseUrl)}"]
+                    = MockServer.Url,
+                [$"{EnqueueActorMessagesHttpClientOptions.SectionName}:{nameof(EnqueueActorMessagesHttpClientOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
             })
             .Build();
 

--- a/source/ProcessManager.Components.Tests/Unit/EnqueueActorMessages/EnqueueActorMessagesHttpClientTests.cs
+++ b/source/ProcessManager.Components.Tests/Unit/EnqueueActorMessages/EnqueueActorMessagesHttpClientTests.cs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 using System.Net;
-using Azure.Core;
-using Azure.Identity;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Components.Abstractions.EnqueueActorMessages;
@@ -24,7 +22,6 @@ using Energinet.DataHub.ProcessManager.Components.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using WireMock.Server;
 using Xunit;
 

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesExtensions.cs
@@ -26,6 +26,12 @@ namespace Energinet.DataHub.ProcessManager.Components.Extensions.DependencyInjec
 
 public static class EnqueueActorMessagesExtensions
 {
+    /// <summary>
+    /// Register services and health checks for enqueue actor messages over service bus.
+    /// </summary>
+    /// <remarks>
+    /// Expects "AddTokenCredentialProvider" has been called to register <see cref="TokenCredentialProvider"/>.
+    /// </remarks>
     public static IServiceCollection AddEnqueueActorMessages(this IServiceCollection services)
     {
         services
@@ -43,7 +49,6 @@ public static class EnqueueActorMessagesExtensions
             .ValidateDataAnnotations();
 
         services
-            .AddTokenCredentialProvider()
             .AddHealthChecks()
             .AddAzureServiceBusTopic(
                 sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesExtensions.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Core;
 using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesExtensions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Azure.Messaging.ServiceBus;
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Components.EnqueueActorMessages;

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesHttpExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesHttpExtensions.cs
@@ -40,8 +40,7 @@ public static class EnqueueActorMessagesHttpExtensions
             .BindConfiguration(EnqueueActorMessagesHttpClientOptions.SectionName)
             .ValidateDataAnnotations();
 
-        services
-            .AddAuthorizationHeaderProvider();
+        services.AddAuthorizationHeaderProvider();
 
         services.AddHttpClient(
             HttpClientNames.EdiEnqueueActorMessagesClientName,

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesHttpExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesHttpExtensions.cs
@@ -35,7 +35,9 @@ public static class EnqueueActorMessagesHttpExtensions
             .BindConfiguration(EnqueueActorMessagesHttpClientOptions.SectionName)
             .ValidateDataAnnotations();
 
-        services.AddAuthorizationHeaderProvider();
+        services
+            .AddTokenCredentialProvider()
+            .AddAuthorizationHeaderProvider();
 
         services.AddHttpClient(
             HttpClientNames.EdiEnqueueActorMessagesClientName,

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesHttpExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesHttpExtensions.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Core;
 using Energinet.DataHub.Core.App.Common.Extensions.Builder;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesHttpExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/EnqueueActorMessagesHttpExtensions.cs
@@ -25,6 +25,12 @@ namespace Energinet.DataHub.ProcessManager.Components.Extensions.DependencyInjec
 
 public static class EnqueueActorMessagesHttpExtensions
 {
+    /// <summary>
+    /// Register services and health checks for enqueue actor messages over http.
+    /// </summary>
+    /// <remarks>
+    /// Expects "AddTokenCredentialProvider" has been called to register <see cref="TokenCredentialProvider"/>.
+    /// </remarks>
     public static IServiceCollection AddEnqueueActorMessagesHttp(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -35,7 +41,6 @@ public static class EnqueueActorMessagesHttpExtensions
             .ValidateDataAnnotations();
 
         services
-            .AddTokenCredentialProvider()
             .AddAuthorizationHeaderProvider();
 
         services.AddHttpClient(

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/IntegrationEventPublisherExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/IntegrationEventPublisherExtensions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Azure.Messaging.ServiceBus;
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Options;
 using Energinet.DataHub.Core.Messaging.Communication.Publisher;

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/IntegrationEventPublisherExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/IntegrationEventPublisherExtensions.cs
@@ -14,6 +14,8 @@
 
 using Azure.Core;
 using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
+using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Options;
 using Energinet.DataHub.Core.Messaging.Communication.Publisher;
 using Energinet.DataHub.ProcessManager.Components.Extensions.Options;
@@ -26,7 +28,7 @@ namespace Energinet.DataHub.ProcessManager.Components.Extensions.DependencyInjec
 
 public static class IntegrationEventPublisherExtensions
 {
-        public static IServiceCollection AddIntegrationEventPublisher(this IServiceCollection services, TokenCredential azureCredential)
+        public static IServiceCollection AddIntegrationEventPublisher(this IServiceCollection services)
     {
         services.AddOptions<ServiceBusNamespaceOptions>()
             .BindConfiguration(ServiceBusNamespaceOptions.SectionName)
@@ -37,11 +39,12 @@ public static class IntegrationEventPublisherExtensions
             .ValidateDataAnnotations();
 
         services
+            .AddTokenCredentialProvider()
             .AddHealthChecks()
             .AddAzureServiceBusTopic(
                 sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 sp => sp.GetRequiredService<IOptions<IntegrationEventTopicOptions>>().Value.Name,
-                tokenCredentialFactory: _ => azureCredential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "Integration Event topic");
 
         services.AddAzureClients(

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/IntegrationEventPublisherExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/IntegrationEventPublisherExtensions.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Core;
 using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;

--- a/source/ProcessManager.Components/Extensions/DependencyInjection/IntegrationEventPublisherExtensions.cs
+++ b/source/ProcessManager.Components/Extensions/DependencyInjection/IntegrationEventPublisherExtensions.cs
@@ -27,7 +27,13 @@ namespace Energinet.DataHub.ProcessManager.Components.Extensions.DependencyInjec
 
 public static class IntegrationEventPublisherExtensions
 {
-        public static IServiceCollection AddIntegrationEventPublisher(this IServiceCollection services)
+    /// <summary>
+    /// Register services and health checks for integration event publisher.
+    /// </summary>
+    /// <remarks>
+    /// Expects "AddTokenCredentialProvider" has been called to register <see cref="TokenCredentialProvider"/>.
+    /// </remarks>
+    public static IServiceCollection AddIntegrationEventPublisher(this IServiceCollection services)
     {
         services.AddOptions<ServiceBusNamespaceOptions>()
             .BindConfiguration(ServiceBusNamespaceOptions.SectionName)
@@ -38,7 +44,6 @@ public static class IntegrationEventPublisherExtensions
             .ValidateDataAnnotations();
 
         services
-            .AddTokenCredentialProvider()
             .AddHealthChecks()
             .AddAzureServiceBusTopic(
                 sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,

--- a/source/ProcessManager.Components/MeteringPointMasterData/MeteringPointMasterDataProvider.cs
+++ b/source/ProcessManager.Components/MeteringPointMasterData/MeteringPointMasterDataProvider.cs
@@ -69,23 +69,7 @@ public class MeteringPointMasterDataProvider(
 
         try
         {
-            if (IsPerformanceTest(meteringPointId))
-            {
-                // Ensure we request a valid metering point id for the performance test
-                // to test the performance of the master data provider
-                id = new ElectricityMarketModels.MeteringPointIdentification("571313115200462957");
-            }
-
-            masterDataChanges = await _electricityMarketViews
-                .GetMeteringPointMasterDataChangesAsync(id, new Interval(startDateTime, endDateTime))
-                .ConfigureAwait(false);
-
-            // Get current master data to get the current grid area owner, and current grid areas neighboring grid area owners.
-            currentMasterDataChanges = (await _electricityMarketViews
-                .GetMeteringPointMasterDataChangesAsync(id, new Interval(_clock.GetCurrentInstant(), _clock.GetCurrentInstant().PlusSeconds(1)))
-                .ConfigureAwait(false)).Single();
-
-            // The performance test uses non-existing metering points, so we must fake a succesful
+            // The performance test uses non-existing metering points, so we must fake a successful
             // master data response from Electricity Market
             if (IsPerformanceTest(meteringPointId))
             {
@@ -98,6 +82,17 @@ public class MeteringPointMasterDataProvider(
                     meteringPointId,
                     _clock.GetCurrentInstant(),
                     _clock.GetCurrentInstant().PlusSeconds(1)).Single();
+            }
+            else
+            {
+                masterDataChanges = await _electricityMarketViews
+                    .GetMeteringPointMasterDataChangesAsync(id, new Interval(startDateTime, endDateTime))
+                    .ConfigureAwait(false);
+
+                // Get current master data to get the current grid area owner, and current grid areas neighboring grid area owners.
+                currentMasterDataChanges = (await _electricityMarketViews
+                    .GetMeteringPointMasterDataChangesAsync(id, new Interval(_clock.GetCurrentInstant(), _clock.GetCurrentInstant().PlusSeconds(1)))
+                    .ConfigureAwait(false)).Single();
             }
         }
         catch (Exception e)

--- a/source/ProcessManager.Components/ProcessManager.Components.csproj
+++ b/source/ProcessManager.Components/ProcessManager.Components.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="13.0.0" />
     <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.5" />
     <PackageReference Include="Microsoft.Azure.Databricks.Client" Version="2.8.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.5" />

--- a/source/ProcessManager.Components/ProcessManager.Components.csproj
+++ b/source/ProcessManager.Components/ProcessManager.Components.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Messaging.EventHubs" Version="9.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.1" />
-    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.5.0-alpha-461" />
+    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.5.0" />
     <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="13.0.0" />
     <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />

--- a/source/ProcessManager.Components/ProcessManager.Components.csproj
+++ b/source/ProcessManager.Components/ProcessManager.Components.csproj
@@ -17,11 +17,11 @@
     <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="13.0.0" />
     <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.4" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.5" />
     <PackageReference Include="Microsoft.Azure.Databricks.Client" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.5" />
     <PackageReference Include="NodaTime" Version="3.2.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/source/ProcessManager.Components/ProcessManager.Components.csproj
+++ b/source/ProcessManager.Components/ProcessManager.Components.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Messaging.EventHubs" Version="9.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.1" />
-    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.4.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.5.0-alpha-461" />
     <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="13.0.0" />
     <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />

--- a/source/ProcessManager.Core.Tests/ProcessManager.Core.Tests.csproj
+++ b/source/ProcessManager.Core.Tests/ProcessManager.Core.Tests.csproj
@@ -27,12 +27,12 @@
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="8.2.1" />
     <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="8.2.1" />
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="9.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/ProcessManager.Core/ProcessManager.Core.csproj
+++ b/source/ProcessManager.Core/ProcessManager.Core.csproj
@@ -16,10 +16,10 @@
   <ItemGroup>
     <PackageReference Include="DarkLoop.Azure.Functions.Authorization.Isolated" Version="4.2.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.19.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.5" />
     <PackageReference Include="Microsoft.FeatureManagement" Version="4.0.0" />
     <PackageReference Include="NCrontab.Signed" Version="3.3.3" />
     <PackageReference Include="NJsonSchema" Version="11.2.0" />

--- a/source/ProcessManager.Example.Consumer/ProcessManager.Example.Consumer.csproj
+++ b/source/ProcessManager.Example.Consumer/ProcessManager.Example.Consumer.csproj
@@ -12,7 +12,7 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
-        <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.4.0" />
+        <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0-alpha-461" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\ProcessManager.Client\ProcessManager.Client.csproj" />

--- a/source/ProcessManager.Example.Consumer/ProcessManager.Example.Consumer.csproj
+++ b/source/ProcessManager.Example.Consumer/ProcessManager.Example.Consumer.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
+        <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
         <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />
     </ItemGroup>

--- a/source/ProcessManager.Example.Consumer/ProcessManager.Example.Consumer.csproj
+++ b/source/ProcessManager.Example.Consumer/ProcessManager.Example.Consumer.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
+        <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
         <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />
     </ItemGroup>

--- a/source/ProcessManager.Example.Consumer/ProcessManager.Example.Consumer.csproj
+++ b/source/ProcessManager.Example.Consumer/ProcessManager.Example.Consumer.csproj
@@ -12,7 +12,7 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
-        <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0-alpha-461" />
+        <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\ProcessManager.Client\ProcessManager.Client.csproj" />

--- a/source/ProcessManager.Example.Consumer/Program.cs
+++ b/source/ProcessManager.Example.Consumer/Program.cs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
+using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.Builder;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.DependencyInjection;
 using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var host = new HostBuilder()
@@ -25,13 +27,16 @@ var host = new HostBuilder()
         // Common
         services.AddApplicationInsightsForIsolatedWorker("ProcessManager.Example.Consumer");
         services.AddHealthChecksForIsolatedWorker();
+        services.AddTokenCredentialProvider();
         services.AddNodaTimeForApplication();
 
         // => Add Process Manager HTTP clients
         services.AddProcessManagerHttpClients();
 
         // => Add Process Manager message client
-        services.AddServiceBusClientForApplication(context.Configuration);
+        services.AddServiceBusClientForApplication(
+            context.Configuration,
+            sp => sp.GetRequiredService<TokenCredentialProvider>().Credential);
         services.AddProcessManagerMessageClient();
     })
     .ConfigureFunctionsWebApplication()

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/CustomQueries/Examples/V1/SearchTrigger_ExampleById_V1Tests.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/CustomQueries/Examples/V1/SearchTrigger_ExampleById_V1Tests.cs
@@ -55,6 +55,7 @@ public class SearchTrigger_ExampleById_V1Tests : IAsyncLifetime
                     = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
             });
 
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
 
         ServiceProvider = services.BuildServiceProvider();

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/CustomQueries/Examples/V1/SearchTrigger_ExampleById_V1Tests.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/CustomQueries/Examples/V1/SearchTrigger_ExampleById_V1Tests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Client;
 using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
@@ -41,17 +42,21 @@ public class SearchTrigger_ExampleById_V1Tests : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
         services.AddProcessManagerHttpClients();
+
         ServiceProvider = services.BuildServiceProvider();
 
         ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/CustomQueries/Examples/V1/SearchTrigger_Examples_V1Tests.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/CustomQueries/Examples/V1/SearchTrigger_Examples_V1Tests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Client;
@@ -42,17 +43,22 @@ public class SearchTrigger_Examples_V1Tests : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
+
         ServiceProvider = services.BuildServiceProvider();
 
         ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/CustomQueries/Examples/V1/SearchTrigger_Examples_V1Tests.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/CustomQueries/Examples/V1/SearchTrigger_Examples_V1Tests.cs
@@ -12,18 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Abstractions.CustomQueries.Examples.V1.Model;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Fixtures;
-using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Integration.CustomQueries.Examples.V1;
@@ -41,34 +34,9 @@ public class SearchTrigger_Examples_V1Tests : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                // Process Manager HTTP client
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        ServiceProvider = services.BuildServiceProvider();
-
-        ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
     }
 
     private ExampleOrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
-
-    private IProcessManagerClient ProcessManagerClient { get; }
 
     public Task InitializeAsync()
     {
@@ -78,12 +46,12 @@ public class SearchTrigger_Examples_V1Tests : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         Fixture.ExampleOrchestrationsAppManager.SetTestOutputHelper(null!);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -96,7 +64,7 @@ public class SearchTrigger_Examples_V1Tests : IAsyncLifetime
 
         // => Brs X01 Input example
         // Start new orchestration instance (we don't have to wait for it, we just need data in the database)
-        await ProcessManagerClient
+        await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new Abstractions.Processes.BRS_X01.InputExample.V1.Model.StartInputExampleCommandV1(
                     Fixture.DefaultUserIdentity,
@@ -106,7 +74,7 @@ public class SearchTrigger_Examples_V1Tests : IAsyncLifetime
 
         // => Brs X01 No Input example
         // Start new orchestration instance (we don't have to wait for it, we just need data in the database)
-        await ProcessManagerClient
+        await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new Abstractions.Processes.BRS_X01.NoInputExample.V1.Model.StartNoInputExampleCommandV1(
                     Fixture.DefaultUserIdentity),
@@ -122,7 +90,7 @@ public class SearchTrigger_Examples_V1Tests : IAsyncLifetime
         };
 
         // Act
-        var actual = await ProcessManagerClient
+        var actual = await Fixture.ProcessManagerClient
             .SearchOrchestrationInstancesByCustomQueryAsync(
                 customQuery,
                 CancellationToken.None);

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_101/UpdateMeteringPointsConnectionState/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_101/UpdateMeteringPointsConnectionState/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,22 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Abstractions.Processes.BRS_101.UpdateMeteringPointConnectionState;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Abstractions.Processes.BRS_101.UpdateMeteringPointConnectionState.V1.Model;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Integration.Processes.BRS_101.UpdateMeteringPointsConnectionState.V1;

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_101/UpdateMeteringPointsConnectionState/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_101/UpdateMeteringPointsConnectionState/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -51,26 +52,28 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
 
-            // Process Manager message client
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                = Fixture.ExampleOrchestrationsAppManager.ProcessManagerStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                = Fixture.ExampleOrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                = Fixture.ExampleOrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-        });
+                // Process Manager message client
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.ProcessManagerStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
+                    = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
+            });
 
         // Process Manager HTTP client
         services.AddProcessManagerHttpClients();

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/InputExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/InputExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.FunctionAppHost;
 using Energinet.DataHub.Core.TestCommon;
@@ -51,16 +52,21 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
+
         ServiceProvider = services.BuildServiceProvider();
     }
 

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/InputExample/V1/MonitorOrchestrationUsingDurableClient.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/InputExample/V1/MonitorOrchestrationUsingDurableClient.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.DurableFunctionApp.TestCommon.DurableTask;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -46,16 +47,21 @@ public class MonitorOrchestrationUsingDurableClient : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
+
         ServiceProvider = services.BuildServiceProvider();
     }
 

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/NoInputExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/NoInputExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -12,21 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.TestCommon;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Abstractions.Processes.BRS_X01.NoInputExample;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Abstractions.Processes.BRS_X01.NoInputExample.V1.Model;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Fixtures;
-using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Integration.Processes.BRS_X01.NoInputExample.V1;
@@ -44,29 +37,9 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        ServiceProvider = services.BuildServiceProvider();
     }
 
     private ExampleOrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
 
     public Task InitializeAsync()
     {
@@ -76,26 +49,24 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         Fixture.ExampleOrchestrationsAppManager.SetTestOutputHelper(null!);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     [Fact]
     public async Task NoInputExampleOrchestration_WhenStarted_CanMonitorLifecycle()
     {
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
-
         var userIdentity = new UserIdentityDto(
             UserId: Guid.NewGuid(),
             ActorNumber: ActorNumber.Create("1234567891234"),
             ActorRole: ActorRole.EnergySupplier);
 
         // Step 1: Start new orchestration instance
-        var orchestrationInstanceId = await processManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new StartNoInputExampleCommandV1(
                     userIdentity),
@@ -105,7 +76,7 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         var isTerminated = await Awaiter.TryWaitUntilConditionAsync(
             async () =>
             {
-                var orchestrationInstance = await processManagerClient
+                var orchestrationInstance = await Fixture.ProcessManagerClient
                     .GetOrchestrationInstanceByIdAsync(
                         new GetOrchestrationInstanceByIdQuery(
                             userIdentity,
@@ -125,7 +96,7 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         isTerminated.Should().BeTrue("because we expects the orchestration instance can complete within given wait time");
 
         // Step 3: General search using name and termination state
-        var orchestrationInstancesGeneralSearch = await processManagerClient
+        var orchestrationInstancesGeneralSearch = await Fixture.ProcessManagerClient
             .SearchOrchestrationInstancesByNameAsync(
                 new SearchOrchestrationInstancesByNameQuery(
                     userIdentity,

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/NoInputExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/NoInputExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -139,8 +139,7 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
                 CancellationToken.None);
 
         orchestrationInstancesGeneralSearch.Should().Contain(x => x.Id == orchestrationInstanceId);
-        orchestrationInstancesGeneralSearch.Should().ContainSingle();
-        var orchestrationInstance = orchestrationInstancesGeneralSearch.Single();
+        var orchestrationInstance = orchestrationInstancesGeneralSearch.First(x => x.Id == orchestrationInstanceId);
         orchestrationInstance.ActorMessageId.Should().BeNull();
         orchestrationInstance.TransactionId.Should().BeNull();
         orchestrationInstance.MeteringPointId.Should().BeNull();

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/NoInputExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/NoInputExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.TestCommon;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
@@ -45,16 +46,21 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
+
         ServiceProvider = services.BuildServiceProvider();
     }
 

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/NoInputExample/V1/MonitorOrchestrationUsingDurableClient.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X01/NoInputExample/V1/MonitorOrchestrationUsingDurableClient.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.DurableFunctionApp.TestCommon.DurableTask;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -41,16 +42,21 @@ public class MonitorOrchestrationUsingDurableClient : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
+
         ServiceProvider = services.BuildServiceProvider();
     }
 

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/ActorRequestProcessExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/ActorRequestProcessExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Text.Json;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Client;
@@ -47,16 +48,18 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
 
         // Process Manager HTTP client
         services.AddProcessManagerHttpClients();

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/ActorRequestProcessExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/ActorRequestProcessExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -13,12 +13,8 @@
 // limitations under the License.
 
 using System.Text.Json;
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
 using Energinet.DataHub.ProcessManager.Example.Consumer.Functions.BRS_X02.ActorRequestProcessExample;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Abstractions.Processes.BRS_X02.ActorRequestProcessExample.V1.Model;
@@ -28,7 +24,6 @@ using Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Integration.Processes.BRS_X02.ActorRequestProcessExample.V1;
@@ -46,30 +41,9 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                // Process Manager HTTP client
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        ServiceProvider = services.BuildServiceProvider();
     }
 
     private ExampleOrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
 
     public Task InitializeAsync()
     {
@@ -80,11 +54,11 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.SetTestOutputHelper(null);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -99,8 +73,6 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
     [Fact]
     public async Task Given_ConsumerApp_When_BRS_X02_ActorRequestProcessExample_OrchestrationInstanceStartedByConsumer_Then_OrchestrationTerminatesSuccessfully()
     {
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
-
         // Step 1: Start new BRS-X02 ActorRequestProcessExample using the Example.Consumer app
         var idempotencyKey = Guid.NewGuid().ToString();
         var startTriggerInput = new StartTrigger_Brs_X02_ActorRequestProcessExample.StartTriggerInput(
@@ -111,7 +83,7 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
             value: startTriggerInput);
 
         // Step 2: Query until terminated with succeeded
-        var (isTerminated, succeededOrchestrationInstance) = await processManagerClient
+        var (isTerminated, succeededOrchestrationInstance) = await Fixture.ProcessManagerClient
             .TryWaitForOrchestrationInstance<ActorRequestProcessExampleInputV1>(
                 idempotencyKey: idempotencyKey,
                 (oi) => oi is
@@ -150,8 +122,6 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
     [Fact]
     public async Task Given_ConsumerApp_AndGiven_InvalidBusinessReasonInput_When_BRS_X02_ActorRequestProcessExample_OrchestrationInstanceStartedByConsumer_Then_OrchestrationTerminatesWithFailed_AndThen_ValidationStepTerminatesWithFailed()
     {
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
-
         // Step 1: Start new BRS-X02 ActorRequestProcessExample using the Example.Consumer app, with an invalid business reason (empty string)
         var idempotencyKey = Guid.NewGuid().ToString();
         var startTriggerInput = new StartTrigger_Brs_X02_ActorRequestProcessExample.StartTriggerInput(
@@ -162,7 +132,7 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
             value: startTriggerInput);
 
         // Step 2: Query until terminated
-        var (isTerminated, orchestrationInstance) = await processManagerClient
+        var (isTerminated, orchestrationInstance) = await Fixture.ProcessManagerClient
             .TryWaitForOrchestrationInstance<ActorRequestProcessExampleInputV1>(
                 idempotencyKey: idempotencyKey,
                 (oi) => oi is

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/NotifyOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/NotifyOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Text.Json;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
@@ -49,26 +50,28 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
 
-            // Process Manager message client
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                = Fixture.ExampleOrchestrationsAppManager.ProcessManagerStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                = Fixture.ExampleOrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                = Fixture.ExampleOrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-        });
+                // Process Manager message client
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.ProcessManagerStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
+                    = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
+            });
 
         // Process Manager HTTP client
         services.AddProcessManagerHttpClients();

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/NotifyOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/NotifyOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -13,20 +13,14 @@
 // limitations under the License.
 
 using System.Text.Json;
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
 using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Abstractions.Processes.BRS_X02.NotifyOrchestrationInstanceExample.V1.Model;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Processes.BRS_X02.NotifyOrchestrationInstanceExample.V1.Orchestration.Steps;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Example.Orchestrations.Tests.Integration.Processes.BRS_X02.NotifyOrchestrationInstanceExample.V1;

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/NotifyOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X02/NotifyOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -77,8 +77,8 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         services.AddProcessManagerHttpClients();
 
         // Process Manager message client
-        services.AddAzureClients(b =>
-            b.AddServiceBusClientWithNamespace(Fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
+        services.AddAzureClients(
+            builder => builder.AddServiceBusClientWithNamespace(Fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
         services.AddProcessManagerMessageClient();
 
         ServiceProvider = services.BuildServiceProvider();

--- a/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X03/FailingOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
+++ b/source/ProcessManager.Example.Orchestrations.Tests/Integration/Processes/BRS_X03/FailingOrchestrationInstanceExample/V1/MonitorOrchestrationUsingClientScenario.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using DurableTask.Core.Exceptions;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.TestCommon;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
@@ -44,16 +45,18 @@ public class MonitorOrchestrationUsingClientScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.ExampleOrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
 
         // Process Manager HTTP client
         services.AddProcessManagerHttpClients();

--- a/source/ProcessManager.Example.Orchestrations.Tests/ProcessManager.Example.Orchestrations.Tests.csproj
+++ b/source/ProcessManager.Example.Orchestrations.Tests/ProcessManager.Example.Orchestrations.Tests.csproj
@@ -32,9 +32,9 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="8.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/source/ProcessManager.Example.Orchestrations/ProcessManager.Example.Orchestrations.csproj
+++ b/source/ProcessManager.Example.Orchestrations/ProcessManager.Example.Orchestrations.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
+        <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
         <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />

--- a/source/ProcessManager.Example.Orchestrations/ProcessManager.Example.Orchestrations.csproj
+++ b/source/ProcessManager.Example.Orchestrations/ProcessManager.Example.Orchestrations.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
-        <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0-alpha-461" />
+        <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\ProcessManager.Components\ProcessManager.Components.csproj" />

--- a/source/ProcessManager.Example.Orchestrations/ProcessManager.Example.Orchestrations.csproj
+++ b/source/ProcessManager.Example.Orchestrations/ProcessManager.Example.Orchestrations.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
-        <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.4.0" />
+        <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0-alpha-461" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\ProcessManager.Components\ProcessManager.Components.csproj" />

--- a/source/ProcessManager.Example.Orchestrations/ProcessManager.Example.Orchestrations.csproj
+++ b/source/ProcessManager.Example.Orchestrations/ProcessManager.Example.Orchestrations.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
+        <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
         <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />

--- a/source/ProcessManager.Example.Orchestrations/Program.cs
+++ b/source/ProcessManager.Example.Orchestrations/Program.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
+using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.Builder;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.DependencyInjection;
@@ -22,6 +23,7 @@ using Energinet.DataHub.ProcessManager.Core.Infrastructure.Extensions.Startup;
 using Energinet.DataHub.ProcessManager.Example.Orchestrations.Abstractions.Processes.BRS_X02.ActorRequestProcessExample.V1.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.FeatureManagement;
 
@@ -31,6 +33,7 @@ var host = new HostBuilder()
         // Common
         services.AddApplicationInsightsForIsolatedWorker("ProcessManager.Example");
         services.AddHealthChecksForIsolatedWorker();
+        services.AddTokenCredentialProvider();
         services.AddNodaTimeForApplication();
         services.AddSubsystemAuthenticationForIsolatedWorker(context.Configuration);
         // => Feature management
@@ -42,7 +45,9 @@ var host = new HostBuilder()
         services.AddProcessManagerForOrchestrations(typeof(Program).Assembly);
 
         // => Add EnqueueActorMessages client
-        services.AddServiceBusClientForApplication(context.Configuration);
+        services.AddServiceBusClientForApplication(
+            context.Configuration,
+            sp => sp.GetRequiredService<TokenCredentialProvider>().Credential);
         services.AddEnqueueActorMessages();
 
         // Add BusinessValidation

--- a/source/ProcessManager.Example.Orchestrations/Program.cs
+++ b/source/ProcessManager.Example.Orchestrations/Program.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Identity;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.Builder;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.DependencyInjection;

--- a/source/ProcessManager.Example.Orchestrations/Program.cs
+++ b/source/ProcessManager.Example.Orchestrations/Program.cs
@@ -29,8 +29,6 @@ using Microsoft.FeatureManagement;
 var host = new HostBuilder()
     .ConfigureServices((context, services) =>
     {
-        var azureCredential = new DefaultAzureCredential();
-
         // Common
         services.AddApplicationInsightsForIsolatedWorker("ProcessManager.Example");
         services.AddHealthChecksForIsolatedWorker();
@@ -46,7 +44,7 @@ var host = new HostBuilder()
 
         // => Add EnqueueActorMessages client
         services.AddServiceBusClientForApplication(context.Configuration);
-        services.AddEnqueueActorMessages(azureCredential);
+        services.AddEnqueueActorMessages();
 
         // Add BusinessValidation
         var orchestrationsExampleAssembly = typeof(Program).Assembly;

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>2.3.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.3.1$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -48,8 +48,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.30.2" />
-    <PackageReference Include="Grpc.Tools" Version="2.71.0">
+    <PackageReference Include="Google.Protobuf" Version="3.31.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.72.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/OrchestrationsAppFixture.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/OrchestrationsAppFixture.cs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using AutoFixture;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.DurableFunctionApp.TestCommon.DurableTask;
-using Energinet.DataHub.Core.FunctionApp.TestCommon;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ListenerMock;
@@ -23,8 +24,14 @@ using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ResourceProvider;
 using Energinet.DataHub.Core.TestCommon.Diagnostics;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
+using Energinet.DataHub.ProcessManager.Client;
+using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
+using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures;
+using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
@@ -119,14 +126,26 @@ public class OrchestrationsAppFixture : IAsyncLifetime
 
     public ServiceBusListenerMock IntegrationEventServiceBusListener { get; }
 
-    public ActorIdentityDto DefaultActorIdentity => new ActorIdentityDto(
+    public ActorIdentityDto DefaultActorIdentity => new(
         ActorNumber.Create("1234567890123"),
         ActorRole.EnergySupplier);
 
-    public UserIdentityDto DefaultUserIdentity => new UserIdentityDto(
+    public UserIdentityDto DefaultUserIdentity => new(
         Guid.NewGuid(),
         DefaultActorIdentity.ActorNumber,
         DefaultActorIdentity.ActorRole);
+
+    /// <summary>
+    /// Process Manager http client.
+    /// </summary>
+    [NotNull]
+    public IProcessManagerClient? ProcessManagerClient { get; private set; }
+
+    /// <summary>
+    /// Process Manager messages client.
+    /// </summary>
+    [NotNull]
+    public IProcessManagerMessageClient? ProcessManagerMessageClient { get; private set; }
 
     private ProcessManagerDatabaseManager DatabaseManager { get; }
 
@@ -135,6 +154,9 @@ public class OrchestrationsAppFixture : IAsyncLifetime
     private DurableTaskManager DurableTaskManager { get; }
 
     private ServiceBusResourceProvider ServiceBusResourceProvider { get; }
+
+    [NotNull]
+    private ServiceProvider? ServiceProvider { get; set; }
 
     public async Task InitializeAsync()
     {
@@ -184,10 +206,16 @@ public class OrchestrationsAppFixture : IAsyncLifetime
             blobContainerName: "container-01",
             credential: IntegrationTestConfiguration.Credential);
         await EventHubListener.InitializeAsync();
+
+        // Prepare clients
+        ServiceProvider = ConfigureProcessManagerClients();
+        ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
+        ProcessManagerMessageClient = ServiceProvider.GetRequiredService<IProcessManagerMessageClient>();
     }
 
     public async Task DisposeAsync()
     {
+        await ServiceProvider.DisposeAsync();
         await EventHubListener.DisposeAsync();
         await OrchestrationsAppManager.DisposeAsync();
         await ProcessManagerAppManager.DisposeAsync();
@@ -205,5 +233,45 @@ public class OrchestrationsAppFixture : IAsyncLifetime
     {
         OrchestrationsAppManager.SetTestOutputHelper(testOutputHelper);
         ProcessManagerAppManager.SetTestOutputHelper(testOutputHelper);
+    }
+
+    /// <summary>
+    /// Register and configure services for Process Manager http and messages clients.
+    /// </summary>
+    private ServiceProvider ConfigureProcessManagerClients()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+
+                // Process Manager message client
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
+                    = OrchestrationsAppManager.ProcessManagerStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
+                    = ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
+                    = OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
+                    = OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
+            });
+
+        // Process Manager HTTP client
+        services.AddProcessManagerHttpClients();
+
+        // Process Manager message client
+        services.AddAzureClients(
+            builder => builder.AddServiceBusClientWithNamespace(IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
+        services.AddProcessManagerMessageClient();
+
+        return services.BuildServiceProvider();
     }
 }

--- a/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_CalculationById_V1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_CalculationById_V1Tests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Client;
 using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
@@ -45,16 +46,19 @@ public class SearchTrigger_CalculationById_V1Tests : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
         services.AddProcessManagerHttpClients();
         ServiceProvider = services.BuildServiceProvider();
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_CalculationById_V1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_CalculationById_V1Tests.cs
@@ -12,20 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.CustomQueries.Calculations.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
-using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Azure.Databricks.Client.Models;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.CustomQueries.Calculations.V1;
@@ -44,32 +37,9 @@ public class SearchTrigger_CalculationById_V1Tests : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                // Process Manager HTTP client
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            });
-
-        services.AddProcessManagerHttpClients();
-        ServiceProvider = services.BuildServiceProvider();
-
-        ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
     }
 
     private OrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
-
-    private IProcessManagerClient ProcessManagerClient { get; }
 
     public Task InitializeAsync()
     {
@@ -81,12 +51,12 @@ public class SearchTrigger_CalculationById_V1Tests : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         Fixture.OrchestrationsAppManager.SetTestOutputHelper(null!);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -102,7 +72,7 @@ public class SearchTrigger_CalculationById_V1Tests : IAsyncLifetime
             RunLifeCycleState.TERMINATED,
             "ElectricalHeating");
         // Start new orchestration instance (we don't have to wait for it, we just need data in the database)
-        var orchestrationInstanceId = await ProcessManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model.StartElectricalHeatingCalculationCommandV1(
                     Fixture.DefaultUserIdentity),
@@ -114,7 +84,7 @@ public class SearchTrigger_CalculationById_V1Tests : IAsyncLifetime
             orchestrationInstanceId);
 
         // When
-        var actual = await ProcessManagerClient
+        var actual = await Fixture.ProcessManagerClient
             .SearchOrchestrationInstanceByCustomQueryAsync(
                 customQuery,
                 CancellationToken.None);
@@ -139,7 +109,7 @@ public class SearchTrigger_CalculationById_V1Tests : IAsyncLifetime
             RunLifeCycleState.TERMINATED,
             "MissingMeasurementsLogOnDemand");
         // Start new orchestration instance (we don't have to wait for it, we just need data in the database)
-        var orchestrationInstanceId = await ProcessManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new Abstractions.Processes.BRS_045.MissingMeasurementsLogOnDemandCalculation.V1.Model.
                     StartMissingMeasurementsLogOnDemandCalculationCommandV1(
@@ -157,7 +127,7 @@ public class SearchTrigger_CalculationById_V1Tests : IAsyncLifetime
             orchestrationInstanceId);
 
         // When
-        var actual = await ProcessManagerClient
+        var actual = await Fixture.ProcessManagerClient
             .SearchOrchestrationInstanceByCustomQueryAsync(
                 customQuery,
                 CancellationToken.None);

--- a/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_Calculations_V1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_Calculations_V1Tests.cs
@@ -12,21 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.CustomQueries.Calculations.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
-using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Azure.Databricks.Client.Models;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.CustomQueries.Calculations.V1;
@@ -45,32 +38,9 @@ public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                // Process Manager HTTP client
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            });
-
-        services.AddProcessManagerHttpClients();
-        ServiceProvider = services.BuildServiceProvider();
-
-        ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
     }
 
     private OrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
-
-    private IProcessManagerClient ProcessManagerClient { get; }
 
     public Task InitializeAsync()
     {
@@ -82,12 +52,12 @@ public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         Fixture.OrchestrationsAppManager.SetTestOutputHelper(null!);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -104,7 +74,7 @@ public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
             RunLifeCycleState.TERMINATED,
             "CalculatorJob");
         // Start new orchestration instance (we don't have to wait for it, we just need data in the database)
-        await ProcessManagerClient
+        await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new Abstractions.Processes.BRS_023_027.V1.Model.StartCalculationCommandV1(
                     Fixture.DefaultUserIdentity,
@@ -122,7 +92,7 @@ public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
             RunLifeCycleState.TERMINATED,
             "ElectricalHeating");
         // Start new orchestration instance (we don't have to wait for it, we just need data in the database)
-        await ProcessManagerClient
+        await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model.StartElectricalHeatingCalculationCommandV1(
                     Fixture.DefaultUserIdentity),
@@ -134,7 +104,7 @@ public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
             RunLifeCycleState.TERMINATED,
             "CapacitySettlement");
         // Start new orchestration instance (we don't have to wait for it, we just need data in the database)
-        await ProcessManagerClient
+        await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new Abstractions.Processes.BRS_021.CapacitySettlementCalculation.V1.Model.StartCapacitySettlementCalculationCommandV1(
                     Fixture.DefaultUserIdentity,
@@ -149,7 +119,7 @@ public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
             RunLifeCycleState.TERMINATED,
             "NetConsumptionGroup6");
         // Start new orchestration instance (we don't have to wait for it, we just need data in the database)
-        await ProcessManagerClient
+        await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new Abstractions.Processes.BRS_021.NetConsumptionCalculation.V1.Model.StartNetConsumptionCalculationCommandV1(
                     Fixture.DefaultUserIdentity),
@@ -161,7 +131,7 @@ public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
             RunLifeCycleState.TERMINATED,
             "MissingMeasurementsLog");
         // Start new orchestration instance (we don't have to wait for it, we just need data in the database)
-        await ProcessManagerClient
+        await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new Abstractions.Processes.BRS_045.MissingMeasurementsLogCalculation.V1.Model.
                     StartMissingMeasurementsLogCalculationCommandV1(
@@ -178,7 +148,7 @@ public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
         };
 
         // Act
-        var actual = await ProcessManagerClient
+        var actual = await Fixture.ProcessManagerClient
             .SearchOrchestrationInstancesByCustomQueryAsync(
                 customQuery,
                 CancellationToken.None);

--- a/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_Calculations_V1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/CustomQueries/Calculations/V1/SearchTrigger_Calculations_V1Tests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Client;
@@ -46,16 +47,19 @@ public class SearchTrigger_Calculations_V1Tests : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
         services.AddProcessManagerHttpClients();
         ServiceProvider = services.BuildServiceProvider();
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/CapacitySettlementCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/CapacitySettlementCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.CapacitySettlementCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.Shared.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
@@ -28,7 +23,6 @@ using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Azure.Databricks.Client.Models;
-using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Xunit.Abstractions;
 
@@ -50,29 +44,9 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        ServiceProvider = services.BuildServiceProvider();
     }
 
     private OrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
 
     public Task InitializeAsync()
     {
@@ -85,12 +59,12 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         Fixture.OrchestrationsAppManager.SetTestOutputHelper(null!);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     [Fact]
@@ -128,10 +102,8 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             },
         ]);
 
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
-
         // Step 1: Start new calculation orchestration instance
-        var orchestrationInstanceId = await processManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new StartCapacitySettlementCalculationCommandV1(
                     Fixture.DefaultUserIdentity, new CalculationInputV1(2025, 1)),
@@ -152,7 +124,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             ]);
 
         // Step 2: Query until terminated
-        var (isTerminated, terminatedOrchestrationInstance) = await processManagerClient
+        var (isTerminated, terminatedOrchestrationInstance) = await Fixture.ProcessManagerClient
             .WaitForOrchestrationInstanceTerminated(
                 orchestrationInstanceId: orchestrationInstanceId);
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/CapacitySettlementCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/CapacitySettlementCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -51,15 +52,19 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
 
         ServiceProvider = services.BuildServiceProvider();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ElectricalHeatingCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.Shared.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
@@ -28,7 +23,6 @@ using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Azure.Databricks.Client.Models;
-using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Xunit.Abstractions;
 
@@ -50,29 +44,9 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        ServiceProvider = services.BuildServiceProvider();
     }
 
     private OrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
 
     public Task InitializeAsync()
     {
@@ -85,12 +59,12 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         Fixture.OrchestrationsAppManager.SetTestOutputHelper(null!);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     [Fact]
@@ -128,10 +102,8 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             },
         ]);
 
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
-
         // Step 1: Start new calculation orchestration instance
-        var orchestrationInstanceId = await processManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new StartElectricalHeatingCalculationCommandV1(
                     Fixture.DefaultUserIdentity),
@@ -152,7 +124,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             ]);
 
         // Step 2: Query until terminated
-        var (isTerminated, terminatedOrchestrationInstance) = await processManagerClient
+        var (isTerminated, terminatedOrchestrationInstance) = await Fixture.ProcessManagerClient
             .WaitForOrchestrationInstanceTerminated(
                 orchestrationInstanceId: orchestrationInstanceId);
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ElectricalHeatingCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -51,15 +52,19 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
 
         ServiceProvider = services.BuildServiceProvider();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -16,6 +16,7 @@ using System.Net;
 using System.Text.Json;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.EventHub.ListenerMock;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
@@ -94,6 +95,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         _fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
+        services.AddTokenCredentialProvider();
         services.AddInMemoryConfiguration(new Dictionary<string, string?>
         {
             // Process Manager HTTP client

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/NetConsumptionCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/NetConsumptionCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -51,15 +52,19 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
 
         ServiceProvider = services.BuildServiceProvider();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/NetConsumptionCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/NetConsumptionCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.NetConsumptionCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.Shared.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
@@ -28,7 +23,6 @@ using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Azure.Databricks.Client.Models;
-using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Xunit.Abstractions;
 
@@ -50,29 +44,9 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        ServiceProvider = services.BuildServiceProvider();
     }
 
     private OrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
 
     public Task InitializeAsync()
     {
@@ -85,12 +59,12 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         Fixture.OrchestrationsAppManager.SetTestOutputHelper(null!);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     [Fact]
@@ -128,10 +102,8 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             },
         ]);
 
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
-
         // Step 1: Start new calculation orchestration instance
-        var orchestrationInstanceId = await processManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new StartNetConsumptionCalculationCommandV1(
                     Fixture.DefaultUserIdentity),
@@ -152,7 +124,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             ]);
 
         // Step 2: Query until terminated
-        var (isTerminated, terminatedOrchestrationInstance) = await processManagerClient
+        var (isTerminated, terminatedOrchestrationInstance) = await Fixture.ProcessManagerClient
             .WaitForOrchestrationInstanceTerminated(
                 orchestrationInstanceId: orchestrationInstanceId);
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.FunctionAppHost;
 using Energinet.DataHub.Core.TestCommon;
@@ -53,6 +54,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
+        services.AddTokenCredentialProvider();
         services.AddInMemoryConfiguration(new Dictionary<string, string?>
         {
             // Process Manager HTTP client

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -54,31 +54,37 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddTokenCredentialProvider();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
 
-            // Process Manager message client
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                = Fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-        });
+                // Process Manager message client
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
+                    = Fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
+                    = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
+                    = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
+                    = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
+            });
+
+        // Process Manager HTTP client
+        services.AddProcessManagerHttpClients();
+
+        // Process Manager message client
         services.AddAzureClients(
             builder => builder.AddServiceBusClientWithNamespace(Fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
-        services.AddProcessManagerHttpClients();
         services.AddProcessManagerMessageClient();
+
         ServiceProvider = services.BuildServiceProvider();
 
         ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,25 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.FunctionAppHost;
 using Energinet.DataHub.Core.TestCommon;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Extensions;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attributes;
-using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using Microsoft.Azure.Databricks.Client.Models;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 using Proto = Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_023_027.V1.Contracts;
 
@@ -52,52 +44,9 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                // Process Manager HTTP client
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-
-                // Process Manager message client
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                    = Fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                    = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                    = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                    = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        // Process Manager message client
-        services.AddAzureClients(
-            builder => builder.AddServiceBusClientWithNamespace(Fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
-        services.AddProcessManagerMessageClient();
-
-        ServiceProvider = services.BuildServiceProvider();
-
-        ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
-        ProcessManagerMessageClient = ServiceProvider.GetRequiredService<IProcessManagerMessageClient>();
     }
 
     private OrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
-
-    private IProcessManagerClient ProcessManagerClient { get; }
-
-    private IProcessManagerMessageClient ProcessManagerMessageClient { get; }
 
     public Task InitializeAsync()
     {
@@ -112,12 +61,12 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         Fixture.OrchestrationsAppManager.SetTestOutputHelper(null!);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     [Fact]
@@ -137,7 +86,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             PeriodStartDate: new DateTimeOffset(2023, 1, 31, 23, 0, 0, TimeSpan.Zero),
             PeriodEndDate: new DateTimeOffset(2023, 2, 28, 23, 0, 0, TimeSpan.Zero),
             IsInternalCalculation: false);
-        var orchestrationInstanceId = await ProcessManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new StartCalculationCommandV1(
                     Fixture.DefaultUserIdentity,
@@ -146,7 +95,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 
         // Step 2.0: Wait for service bus message to EDI and mock a response
         await Fixture.EnqueueBrs023027ServiceBusListener.WaitAndMockServiceBusMessageToAndFromEdi(
-            ProcessManagerMessageClient,
+            Fixture.ProcessManagerMessageClient,
             orchestrationInstanceId);
 
         // step 2.5: Wait for the integration event to be published
@@ -158,7 +107,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         var isTerminated = await Awaiter.TryWaitUntilConditionAsync(
             async () =>
             {
-                var orchestrationInstance = await ProcessManagerClient
+                var orchestrationInstance = await Fixture.ProcessManagerClient
                     .GetOrchestrationInstanceByIdAsync<CalculationInputV1>(
                         new GetOrchestrationInstanceByIdQuery(
                             Fixture.DefaultUserIdentity,
@@ -175,7 +124,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         isTerminated.Should().BeTrue("because we expects the orchestration instance can complete within given wait time");
 
         // Step 4: General search using name and termination state
-        var orchestrationInstancesGeneralSearch = await ProcessManagerClient
+        var orchestrationInstancesGeneralSearch = await Fixture.ProcessManagerClient
             .SearchOrchestrationInstancesByNameAsync<CalculationInputV1>(
                 new SearchOrchestrationInstancesByNameQuery(
                     Fixture.DefaultUserIdentity,
@@ -200,7 +149,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             CalculationJobName);
 
         // Step 1: Schedule new calculation orchestration instance
-        var orchestrationInstanceId = await ProcessManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .ScheduleNewOrchestrationInstanceAsync(
                 new ScheduleCalculationCommandV1(
                     Fixture.DefaultUserIdentity,
@@ -219,7 +168,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
 
         // Step 3.0: Wait for service bus message to EDI and mock a response
         await Fixture.EnqueueBrs023027ServiceBusListener.WaitAndMockServiceBusMessageToAndFromEdi(
-            ProcessManagerMessageClient,
+            Fixture.ProcessManagerMessageClient,
             orchestrationInstanceId);
 
         // step 3.5: Wait for the integration event to be published
@@ -231,7 +180,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         var isTerminated = await Awaiter.TryWaitUntilConditionAsync(
             async () =>
             {
-                var orchestrationInstance = await ProcessManagerClient
+                var orchestrationInstance = await Fixture.ProcessManagerClient
                     .GetOrchestrationInstanceByIdAsync<CalculationInputV1>(
                         new GetOrchestrationInstanceByIdQuery(
                             Fixture.DefaultUserIdentity,
@@ -252,7 +201,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     public async Task CalculationScheduledToRunInTheFuture_WhenCanceled_CanMonitorLifecycle()
     {
         // Step 1: Schedule new calculation orchestration instance
-        var orchestrationInstanceId = await ProcessManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .ScheduleNewOrchestrationInstanceAsync(
                 new ScheduleCalculationCommandV1(
                     Fixture.DefaultUserIdentity,
@@ -266,7 +215,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
                 CancellationToken.None);
 
         // Step 2: Cancel the calculation orchestration instance
-        await ProcessManagerClient
+        await Fixture.ProcessManagerClient
             .CancelScheduledOrchestrationInstanceAsync(
                 new CancelScheduledOrchestrationInstanceCommand(
                     Fixture.DefaultUserIdentity,
@@ -277,7 +226,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         var isTerminated = await Awaiter.TryWaitUntilConditionAsync(
             async () =>
             {
-                var orchestrationInstance = await ProcessManagerClient
+                var orchestrationInstance = await Fixture.ProcessManagerClient
                     .GetOrchestrationInstanceByIdAsync<CalculationInputV1>(
                         new GetOrchestrationInstanceByIdQuery(
                             Fixture.DefaultUserIdentity,
@@ -310,7 +259,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             PeriodEndDate: new DateTimeOffset(2023, 2, 28, 23, 0, 0, TimeSpan.Zero),
             IsInternalCalculation: false);
 
-        var orchestrationInstanceId = await ProcessManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new StartCalculationCommandV1(
                     Fixture.DefaultUserIdentity,
@@ -321,7 +270,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         var isTerminatedWithFailed = await Awaiter.TryWaitUntilConditionAsync(
             async () =>
             {
-                var orchestrationInstance = await ProcessManagerClient
+                var orchestrationInstance = await Fixture.ProcessManagerClient
                     .GetOrchestrationInstanceByIdAsync<CalculationInputV1>(
                         new GetOrchestrationInstanceByIdQuery(
                             Fixture.DefaultUserIdentity,

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingDurableClient.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingDurableClient.cs
@@ -63,31 +63,37 @@ public class MonitorOrchestrationUsingDurableClient : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddTokenCredentialProvider();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
 
-            // Process Manager message client
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                = Fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-        });
+                // Process Manager message client
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
+                    = Fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
+                    = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
+                    = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
+                    = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
+            });
+
+        // Process Manager HTTP client
+        services.AddProcessManagerHttpClients();
+
+        // Process Manager message client
         services.AddAzureClients(
             builder => builder.AddServiceBusClientWithNamespace(Fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
-        services.AddProcessManagerHttpClients();
         services.AddProcessManagerMessageClient();
+
         ServiceProvider = services.BuildServiceProvider();
 
         ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingDurableClient.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_023_027/V1/MonitorOrchestrationUsingDurableClient.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.DurableFunctionApp.TestCommon.DurableTask;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.TestCommon;
@@ -62,6 +63,7 @@ public class MonitorOrchestrationUsingDurableClient : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
+        services.AddTokenCredentialProvider();
         services.AddInMemoryConfiguration(new Dictionary<string, string?>
         {
             // Process Manager HTTP client

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -52,6 +53,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         _fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
+        services.AddTokenCredentialProvider();
         services.AddInMemoryConfiguration(new Dictionary<string, string?>
         {
             // Process Manager HTTP client

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -53,31 +53,37 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         _fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddTokenCredentialProvider();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = _fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = _fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = _fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = _fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
 
-            // Process Manager message client
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                = _fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                = _fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-        });
+                // Process Manager message client
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
+                    = _fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
+                    = _fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
+                    = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
+                    = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
+            });
+
+        // Process Manager HTTP client
+        services.AddProcessManagerHttpClients();
+
+        // Process Manager message client
         services.AddAzureClients(
             builder => builder.AddServiceBusClientWithNamespace(_fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
         services.AddProcessManagerMessageClient();
-        services.AddProcessManagerHttpClients();
+
         ServiceProvider = services.BuildServiceProvider();
     }
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_026/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
@@ -29,8 +24,6 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attri
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Processes.BRS_026_028.BRS_026.V1;
@@ -51,43 +44,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     {
         _fixture = fixture;
         _fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                // Process Manager HTTP client
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = _fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = _fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-
-                // Process Manager message client
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                    = _fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                    = _fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                    = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                    = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        // Process Manager message client
-        services.AddAzureClients(
-            builder => builder.AddServiceBusClientWithNamespace(_fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
-        services.AddProcessManagerMessageClient();
-
-        ServiceProvider = services.BuildServiceProvider();
     }
-
-    private ServiceProvider ServiceProvider { get; }
 
     public Task InitializeAsync()
     {
@@ -98,13 +55,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         _fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         _fixture.OrchestrationsAppManager.SetTestOutputHelper(null!);
         _fixture.EnqueueBrs026ServiceBusListener.ResetMessageHandlersAndReceivedMessages();
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -113,20 +70,18 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     [Fact]
     public async Task Given_ValidRequestCalculatedEnergyTimeSeries_When_Started_Then_OrchestrationInstanceTerminatesWithSuccess()
     {
-        var processManagerMessageClient = ServiceProvider.GetRequiredService<IProcessManagerMessageClient>();
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
         const string gridAreaCode = "804";
         _fixture.OrchestrationsAppManager.MockServer.MockGetGridAreaOwner(gridAreaCode);
 
         // Step 1: Start new orchestration instance
         var requestCommand = GivenRequestCalculatedEnergyTimeSeries(gridAreaCode);
 
-        await processManagerMessageClient.StartNewOrchestrationInstanceAsync(
+        await _fixture.ProcessManagerMessageClient.StartNewOrchestrationInstanceAsync(
             requestCommand,
             CancellationToken.None);
 
         // Step 2a: Query until waiting for EnqueueActorMessagesCompleted notify event
-        var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
+        var (isWaitingForNotify, orchestrationInstance) = await _fixture.ProcessManagerClient
             .WaitForStepToBeRunning<RequestCalculatedEnergyTimeSeriesInputV1>(
                 requestCommand.IdempotencyKey,
                 EnqueueActorMessagesStep.StepSequence);
@@ -151,13 +106,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         enqueueMessageFound.Should().BeTrue($"because a {nameof(RequestCalculatedEnergyTimeSeriesAcceptedV1)} service bus message should have been sent");
 
         // Step 3: Send EnqueueActorMessagesCompleted event
-        await processManagerMessageClient.NotifyOrchestrationInstanceAsync(
+        await _fixture.ProcessManagerMessageClient.NotifyOrchestrationInstanceAsync(
             new RequestCalculatedEnergyTimeSeriesNotifyEventV1(
                 OrchestrationInstanceId: orchestrationInstance!.Id.ToString()),
             CancellationToken.None);
 
         // Step 4: Query until terminated
-        var (orchestrationTerminated, terminatedOrchestrationInstance) = await processManagerClient
+        var (orchestrationTerminated, terminatedOrchestrationInstance) = await _fixture.ProcessManagerClient
             .WaitForOrchestrationInstanceTerminated<RequestCalculatedEnergyTimeSeriesInputV1>(
                 requestCommand.IdempotencyKey);
 
@@ -187,20 +142,18 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     [Fact]
     public async Task Given_InvalidRequestCalculatedEnergyTimeSeries_When_Started_Then_OrchestrationInstanceTerminatesWithFailed_AndThen_BusinessValidationStepFailed()
     {
-        var processManagerMessageClient = ServiceProvider.GetRequiredService<IProcessManagerMessageClient>();
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
         const string gridAreaCode = "804";
         _fixture.OrchestrationsAppManager.MockServer.MockGetGridAreaOwner(gridAreaCode);
 
         // Step 1: Start new orchestration instance
         var invalidRequestCommand = GivenRequestCalculatedEnergyTimeSeries(gridAreaCode, shouldFailBusinessValidation: true);
 
-        await processManagerMessageClient.StartNewOrchestrationInstanceAsync(
+        await _fixture.ProcessManagerMessageClient.StartNewOrchestrationInstanceAsync(
             invalidRequestCommand,
             CancellationToken.None);
 
         // Step 2a: Query until waiting for EnqueueActorMessagesCompleted notify event
-        var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
+        var (isWaitingForNotify, orchestrationInstance) = await _fixture.ProcessManagerClient
             .WaitForStepToBeRunning<RequestCalculatedEnergyTimeSeriesInputV1>(
                 idempotencyKey: invalidRequestCommand.IdempotencyKey,
                 stepSequence: EnqueueActorMessagesStep.StepSequence);
@@ -230,13 +183,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         enqueueMessageFound.Should().BeTrue($"because a {nameof(RequestCalculatedEnergyTimeSeriesRejectedV1)} service bus message should have been sent");
 
         // Step 3: Send EnqueueActorMessagesCompleted event
-        await processManagerMessageClient.NotifyOrchestrationInstanceAsync(
+        await _fixture.ProcessManagerMessageClient.NotifyOrchestrationInstanceAsync(
             new RequestCalculatedEnergyTimeSeriesNotifyEventV1(
                 OrchestrationInstanceId: orchestrationInstance!.Id.ToString()),
             CancellationToken.None);
 
         // Step 4: Query until terminated
-        var (orchestrationWasTerminated, terminatedOrchestrationInstance) = await processManagerClient
+        var (orchestrationWasTerminated, terminatedOrchestrationInstance) = await _fixture.ProcessManagerClient
             .WaitForOrchestrationInstanceTerminated<RequestCalculatedEnergyTimeSeriesInputV1>(
                 idempotencyKey: invalidRequestCommand.IdempotencyKey);
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -52,6 +53,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         _fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
+        services.AddTokenCredentialProvider();
         services.AddInMemoryConfiguration(new Dictionary<string, string?>
         {
             // Process Manager HTTP client

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -53,31 +53,37 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         _fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddTokenCredentialProvider();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = _fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = _fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = _fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = _fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
 
-            // Process Manager message client
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                = _fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                = _fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-        });
+                // Process Manager message client
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
+                    = _fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
+                    = _fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
+                    = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
+                    = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
+            });
+
+        // Process Manager HTTP client
+        services.AddProcessManagerHttpClients();
+
+        // Process Manager message client
         services.AddAzureClients(
             builder => builder.AddServiceBusClientWithNamespace(_fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
         services.AddProcessManagerMessageClient();
-        services.AddProcessManagerHttpClients();
+
         ServiceProvider = services.BuildServiceProvider();
     }
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/BRS_028/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
@@ -29,8 +24,6 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures.Xunit.Attri
 using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Processes.BRS_026_028.BRS_028.V1;
@@ -51,43 +44,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     {
         _fixture = fixture;
         _fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                // Process Manager HTTP client
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = _fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = _fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-
-                // Process Manager message client
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                    = _fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                    = _fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                    = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                    = _fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        // Process Manager message client
-        services.AddAzureClients(
-            builder => builder.AddServiceBusClientWithNamespace(_fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
-        services.AddProcessManagerMessageClient();
-
-        ServiceProvider = services.BuildServiceProvider();
     }
-
-    private ServiceProvider ServiceProvider { get; }
 
     public Task InitializeAsync()
     {
@@ -98,13 +55,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         _fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         _fixture.OrchestrationsAppManager.SetTestOutputHelper(null!);
         _fixture.EnqueueBrs028ServiceBusListener.ResetMessageHandlersAndReceivedMessages();
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -113,20 +70,18 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     [Fact]
     public async Task Given_ValidRequestCalculatedWholesaleServices_When_Started_Then_OrchestrationInstanceTerminatesWithSuccess()
     {
-        var processManagerMessageClient = ServiceProvider.GetRequiredService<IProcessManagerMessageClient>();
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
         const string gridAreaCode = "804";
         _fixture.OrchestrationsAppManager.MockServer.MockGetGridAreaOwner(gridAreaCode);
 
         // Step 1: Start new orchestration instance
         var requestCommand = GivenRequestCalculatedWholesaleServices(gridAreaCode);
 
-        await processManagerMessageClient.StartNewOrchestrationInstanceAsync(
+        await _fixture.ProcessManagerMessageClient.StartNewOrchestrationInstanceAsync(
             requestCommand,
             CancellationToken.None);
 
         // Step 2a: Query until waiting for EnqueueActorMessagesCompleted notify event
-        var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
+        var (isWaitingForNotify, orchestrationInstance) = await _fixture.ProcessManagerClient
             .WaitForStepToBeRunning<RequestCalculatedWholesaleServicesInputV1>(
                 idempotencyKey: requestCommand.IdempotencyKey,
                 stepSequence: EnqueueActorMessagesStep.StepSequence);
@@ -150,13 +105,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         enqueueMessageFound.Should().BeTrue($"because a {nameof(RequestCalculatedWholesaleServicesAcceptedV1)} service bus message should have been sent");
 
         // Step 3: Send EnqueueActorMessagesCompleted event
-        await processManagerMessageClient.NotifyOrchestrationInstanceAsync(
+        await _fixture.ProcessManagerMessageClient.NotifyOrchestrationInstanceAsync(
             new RequestCalculatedWholesaleServicesNotifyEventV1(
                 OrchestrationInstanceId: orchestrationInstance!.Id.ToString()),
             CancellationToken.None);
 
         // Step 4: Query until terminated
-        var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await processManagerClient
+        var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await _fixture.ProcessManagerClient
             .WaitForOrchestrationInstanceTerminated<RequestCalculatedWholesaleServicesInputV1>(
                 idempotencyKey: requestCommand.IdempotencyKey);
 
@@ -186,20 +141,18 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     [Fact]
     public async Task Given_InvalidRequestCalculatedWholesaleServices_When_Started_Then_OrchestrationInstanceTerminatesWithFailed_AndThen_BusinessValidationStepFailed()
     {
-        var processManagerMessageClient = ServiceProvider.GetRequiredService<IProcessManagerMessageClient>();
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
         const string gridAreaCode = "804";
         _fixture.OrchestrationsAppManager.MockServer.MockGetGridAreaOwner(gridAreaCode);
 
         // Step 1: Start new orchestration instance
         var invalidRequestCommand = GivenRequestCalculatedWholesaleServices(gridAreaCode, shouldFailBusinessValidation: true);
 
-        await processManagerMessageClient.StartNewOrchestrationInstanceAsync(
+        await _fixture.ProcessManagerMessageClient.StartNewOrchestrationInstanceAsync(
             invalidRequestCommand,
             CancellationToken.None);
 
         // Step 2a: Query until waiting for EnqueueActorMessagesCompleted notify event
-        var (isWaitingForNotify, orchestrationInstance) = await processManagerClient
+        var (isWaitingForNotify, orchestrationInstance) = await _fixture.ProcessManagerClient
             .WaitForStepToBeRunning<RequestCalculatedWholesaleServicesInputV1>(
                 idempotencyKey: invalidRequestCommand.IdempotencyKey,
                 stepSequence: EnqueueActorMessagesStep.StepSequence);
@@ -229,13 +182,13 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         enqueueMessageFound.Should().BeTrue($"because a {nameof(RequestCalculatedWholesaleServicesInputV1)} service bus message should have been sent");
 
         // Step 3: Send EnqueueActorMessagesCompleted event
-        await processManagerMessageClient.NotifyOrchestrationInstanceAsync(
+        await _fixture.ProcessManagerMessageClient.NotifyOrchestrationInstanceAsync(
             new RequestCalculatedWholesaleServicesNotifyEventV1(
                 OrchestrationInstanceId: orchestrationInstance!.Id.ToString()),
             CancellationToken.None);
 
         // Step 4: Query until terminated
-        var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await processManagerClient
+        var (orchestrationTerminatedWithSucceeded, terminatedOrchestrationInstance) = await _fixture.ProcessManagerClient
             .WaitForOrchestrationInstanceTerminated<RequestCalculatedWholesaleServicesInputV1>(
                 idempotencyKey: invalidRequestCommand.IdempotencyKey);
 

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/CustomQueries/SearchTrigger_Brs_026_028Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/CustomQueries/SearchTrigger_Brs_026_028Tests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.DurableFunctionApp.TestCommon.DurableTask;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -51,6 +52,7 @@ public class SearchTrigger_Brs_026_028Tests : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
+        services.AddTokenCredentialProvider();
         services.AddInMemoryConfiguration(new Dictionary<string, string?>
         {
             // Process Manager HTTP client

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/CustomQueries/SearchTrigger_Brs_026_028Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_026_028/CustomQueries/SearchTrigger_Brs_026_028Tests.cs
@@ -52,31 +52,37 @@ public class SearchTrigger_Brs_026_028Tests : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddTokenCredentialProvider();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            // Process Manager HTTP client
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                // Process Manager HTTP client
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
 
-            // Process Manager message client
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
-                = Fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
-                = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
-                = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
-            [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
-                = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
-        });
+                // Process Manager message client
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"]
+                    = Fixture.OrchestrationsAppManager.ProcessManagerStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}"]
+                    = Fixture.ProcessManagerAppManager.ProcessManagerNotifyTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}"]
+                    = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataStartTopic.Name,
+                [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}"]
+                    = Fixture.OrchestrationsAppManager.Brs021ForwardMeteredDataNotifyTopic.Name,
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
+
+        // Process Manager message client
         services.AddAzureClients(
             builder => builder.AddServiceBusClientWithNamespace(Fixture.IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace));
         services.AddProcessManagerMessageClient();
+
         ServiceProvider = services.BuildServiceProvider();
 
         ProcessManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -51,15 +52,19 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
 
         ServiceProvider = services.BuildServiceProvider();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
@@ -51,15 +52,19 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         Fixture.SetTestOutputHelper(testOutputHelper);
 
         var services = new ServiceCollection();
-        services.AddInMemoryConfiguration(new Dictionary<string, string?>
-        {
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-        });
+        services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>
+            {
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
+                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
+                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
+                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
+            });
+
+        // Process Manager HTTP client
         services.AddProcessManagerHttpClients();
 
         ServiceProvider = services.BuildServiceProvider();

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_045/MissingMeasurementsLogOnDemandCalculation/V1/MonitorOrchestrationUsingClientsScenario.cs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Client.Extensions.DependencyInjection;
-using Energinet.DataHub.ProcessManager.Client.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_045.MissingMeasurementsLogOnDemandCalculation.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_045.Shared;
 using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
@@ -28,7 +23,6 @@ using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Azure.Databricks.Client.Models;
-using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Xunit.Abstractions;
 
@@ -50,29 +44,9 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
     {
         Fixture = fixture;
         Fixture.SetTestOutputHelper(testOutputHelper);
-
-        var services = new ServiceCollection();
-        services
-            .AddTokenCredentialProvider()
-            .AddInMemoryConfiguration(new Dictionary<string, string?>
-            {
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.ApplicationIdUri)}"]
-                    = SubsystemAuthenticationOptionsForTests.ApplicationIdUri,
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.GeneralApiBaseAddress)}"]
-                    = Fixture.ProcessManagerAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-                [$"{ProcessManagerHttpClientsOptions.SectionName}:{nameof(ProcessManagerHttpClientsOptions.OrchestrationsApiBaseAddress)}"]
-                    = Fixture.OrchestrationsAppManager.AppHostManager.HttpClient.BaseAddress!.ToString(),
-            });
-
-        // Process Manager HTTP client
-        services.AddProcessManagerHttpClients();
-
-        ServiceProvider = services.BuildServiceProvider();
     }
 
     private OrchestrationsAppFixture Fixture { get; }
-
-    private ServiceProvider ServiceProvider { get; }
 
     public Task InitializeAsync()
     {
@@ -84,12 +58,12 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         Fixture.ProcessManagerAppManager.SetTestOutputHelper(null!);
         Fixture.OrchestrationsAppManager.SetTestOutputHelper(null!);
 
-        await ServiceProvider.DisposeAsync();
+        return Task.CompletedTask;
     }
 
     [Fact]
@@ -127,10 +101,8 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             },
         ]);
 
-        var processManagerClient = ServiceProvider.GetRequiredService<IProcessManagerClient>();
-
         // Step 1: Start new calculation orchestration instance
-        var orchestrationInstanceId = await processManagerClient
+        var orchestrationInstanceId = await Fixture.ProcessManagerClient
             .StartNewOrchestrationInstanceAsync(
                 new StartMissingMeasurementsLogOnDemandCalculationCommandV1(
                     Fixture.DefaultUserIdentity,
@@ -151,7 +123,7 @@ public class MonitorOrchestrationUsingClientsScenario : IAsyncLifetime
             ]);
 
         // Step 2: Query until terminated
-        var (isTerminated, terminatedOrchestrationInstance) = await processManagerClient
+        var (isTerminated, terminatedOrchestrationInstance) = await Fixture.ProcessManagerClient
             .WaitForOrchestrationInstanceTerminated(
                 orchestrationInstanceId: orchestrationInstanceId);
 

--- a/source/ProcessManager.Orchestrations.Tests/ProcessManager.Orchestrations.Tests.csproj
+++ b/source/ProcessManager.Orchestrations.Tests/ProcessManager.Orchestrations.Tests.csproj
@@ -35,10 +35,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="8.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="WireMock.Net" Version="1.7.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
@@ -31,8 +31,6 @@ public class MeasurementsClientExtensionsTests
     private const string EventHubName = "event-hub-name";
     private const string FullyQualifiedNamespace = "namespace.eventhub.windows.net";
 
-    private static readonly TokenCredential _azureCredential = new DefaultAzureCredential();
-
     private ServiceCollection Services { get; } = new();
 
     [Fact]
@@ -46,7 +44,7 @@ public class MeasurementsClientExtensionsTests
         });
 
         // Act
-        Services.AddMeasurementsClient(_azureCredential);
+        Services.AddMeasurementsClient();
 
         // Assert
         var serviceProvider = Services.BuildServiceProvider();
@@ -62,7 +60,7 @@ public class MeasurementsClientExtensionsTests
         Services.AddInMemoryConfiguration([]);
 
         // Act
-        Services.AddMeasurementsClient(_azureCredential);
+        Services.AddMeasurementsClient();
 
         // Assert
         var serviceProvider = Services.BuildServiceProvider();
@@ -85,7 +83,7 @@ public class MeasurementsClientExtensionsTests
             [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.FullyQualifiedNamespace)}"] = FullyQualifiedNamespace,
             [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.EventHubName)}"] = EventHubName,
         });
-        Services.AddMeasurementsClient(_azureCredential);
+        Services.AddMeasurementsClient();
         var serviceProvider = Services.BuildServiceProvider();
 
         // Act

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
@@ -33,11 +33,6 @@ public class MeasurementsClientExtensionsTests
 
     private static readonly TokenCredential _azureCredential = new DefaultAzureCredential();
 
-    public MeasurementsClientExtensionsTests()
-    {
-        Services.AddLogging();
-    }
-
     private ServiceCollection Services { get; } = new();
 
     [Fact]

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Extensions/DependencyInjection/MeasurementsClientExtensionsTests.cs
@@ -14,6 +14,7 @@
 
 using Azure.Core;
 using Azure.Identity;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.ProcessManager.Orchestrations.Extensions.DependencyInjection;
 using Energinet.DataHub.ProcessManager.Orchestrations.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.Measurements;
@@ -37,11 +38,13 @@ public class MeasurementsClientExtensionsTests
     public void Given_MeasurementsClientOptionsAreConfigured_When_AddMeasurementsClient_Then_MeasurementsClientAndEventHubClientCanBeCreated()
     {
         // Arrange
-        Services.AddInMemoryConfiguration(new Dictionary<string, string?>()
-        {
-            [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.FullyQualifiedNamespace)}"] = FullyQualifiedNamespace,
-            [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.EventHubName)}"] = EventHubName,
-        });
+        Services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>()
+            {
+                [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.FullyQualifiedNamespace)}"] = FullyQualifiedNamespace,
+                [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.EventHubName)}"] = EventHubName,
+            });
 
         // Act
         Services.AddMeasurementsClient();
@@ -61,7 +64,9 @@ public class MeasurementsClientExtensionsTests
     public void Given_MeasurementsClientOptionsAreNotConfigured_When_AddMeasurementsClient_Then_ExceptionIsThrownWhenCreatingEventHubClient()
     {
         // Arrange
-        Services.AddInMemoryConfiguration([]);
+        Services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration([]);
 
         // Act
         Services.AddMeasurementsClient();
@@ -84,11 +89,13 @@ public class MeasurementsClientExtensionsTests
     public void Given_AzureEventHubHealthCheckAreConfigured_When_AddMeasurementsClient_Then_MeasurementsEventHubHealthCheckIsRegistered()
     {
         // Arrange
-        Services.AddInMemoryConfiguration(new Dictionary<string, string?>()
-        {
-            [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.FullyQualifiedNamespace)}"] = FullyQualifiedNamespace,
-            [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.EventHubName)}"] = EventHubName,
-        });
+        Services
+            .AddTokenCredentialProvider()
+            .AddInMemoryConfiguration(new Dictionary<string, string?>()
+            {
+                [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.FullyQualifiedNamespace)}"] = FullyQualifiedNamespace,
+                [$"{MeasurementsClientOptions.SectionName}:{nameof(MeasurementsClientOptions.EventHubName)}"] = EventHubName,
+            });
         Services.AddMeasurementsClient();
         var serviceProvider = Services.BuildServiceProvider();
 

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsClientTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsClientTests.cs
@@ -34,13 +34,12 @@ public class MeasurementsClientTests
     {
         var eventHubClientFactory = new Mock<IAzureClientFactory<EventHubProducerClient>>();
         EventHubProducerClientMock = new Mock<EventHubProducerClient>();
-        var loggerMock = new Mock<ILogger<MeasurementsClient>>();
 
         eventHubClientFactory
             .Setup(factory => factory.CreateClient(EventHubProducerClientNames.MeasurementsEventHub))
             .Returns(EventHubProducerClientMock.Object);
 
-        Sut = new MeasurementsClient(eventHubClientFactory.Object, loggerMock.Object);
+        Sut = new MeasurementsClient(eventHubClientFactory.Object);
     }
 
     internal Mock<EventHubProducerClient> EventHubProducerClientMock { get; }

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/Brs021Extensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/Brs021Extensions.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Identity;
 using Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Handlers;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,10 +24,9 @@ public static class Brs021Extensions
     /// Add required dependencies for BRS-021 Send Measurements.
     /// </summary>
     public static IServiceCollection AddBrs021(
-        this IServiceCollection services,
-        DefaultAzureCredential azureCredential)
+        this IServiceCollection services)
     {
-        services.AddMeasurementsClient(azureCredential);
+        services.AddMeasurementsClient();
         services.AddScoped<IMeteringPointMasterDataProvider, MeteringPointMasterDataProvider>();
         services.AddScoped<MeteringPointReceiversProvider>();
 

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/MeasurementsClientExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/MeasurementsClientExtensions.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Core;
 using Azure.Messaging.EventHubs.Producer;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/MeasurementsClientExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/MeasurementsClientExtensions.cs
@@ -33,6 +33,9 @@ public static class MeasurementsClientExtensions
     /// <summary>
     /// Register Measurements client.
     /// </summary>
+    /// <remarks>
+    /// Expects "AddTokenCredentialProvider" has been called to register <see cref="TokenCredentialProvider"/>.
+    /// </remarks>
     public static IServiceCollection AddMeasurementsClient(this IServiceCollection services)
     {
         services
@@ -41,7 +44,6 @@ public static class MeasurementsClientExtensions
             .ValidateDataAnnotations();
 
         services
-            .AddTokenCredentialProvider()
             .AddAzureClients(builder =>
             {
                 builder.UseCredential(sp => sp.GetRequiredService<TokenCredentialProvider>().Credential);
@@ -58,11 +60,13 @@ public static class MeasurementsClientExtensions
         services.AddTransient<IMeasurementsClient, MeasurementsClient>();
         services.AddTransient<MeasurementsEventHubProducerClientFactory>();
 
-        services.AddHealthChecks()
+        services
+            .AddHealthChecks()
             .AddAzureEventHub(
                 clientFactory: sp => sp.GetRequiredService<IAzureClientFactory<EventHubProducerClient>>().CreateClient(EventHubProducerClientNames.MeasurementsEventHub),
                 name: EventHubProducerClientNames.MeasurementsEventHub,
                 HealthStatus.Unhealthy);
+
         return services;
     }
 }

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/MeasurementsClientExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/MeasurementsClientExtensions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Azure.Messaging.EventHubs.Producer;
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.ProcessManager.Components.Extensions.DependencyInjection;
 using Energinet.DataHub.ProcessManager.Orchestrations.Extensions.Options;

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.App.Common.Diagnostics.HealthChecks;
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Builder;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Options;

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
@@ -28,6 +28,9 @@ public static class ProcessManagerTopicExtensions
     /// <summary>
     /// Add required dependencies to use the Process Manager Service Bus topic.
     /// </summary>
+    /// <remarks>
+    /// Expects "AddTokenCredentialProvider" has been called to register <see cref="TokenCredentialProvider"/>.
+    /// </remarks>
     public static IServiceCollection AddProcessManagerTopic(this IServiceCollection services)
     {
         services.AddOptions<ServiceBusNamespaceOptions>()
@@ -45,7 +48,6 @@ public static class ProcessManagerTopicExtensions
             .ValidateDataAnnotations();
 
         services
-            .AddTokenCredentialProvider()
             .AddHealthChecks()
             .AddAzureServiceBusTopic(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,

--- a/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Extensions/DependencyInjection/ProcessManagerTopicExtensions.cs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Core;
 using Energinet.DataHub.Core.App.Common.Diagnostics.HealthChecks;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
+using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Builder;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Options;
 using Energinet.DataHub.ProcessManager.Orchestrations.Extensions.Options;
@@ -27,7 +28,7 @@ public static class ProcessManagerTopicExtensions
     /// <summary>
     /// Add required dependencies to use the Process Manager Service Bus topic.
     /// </summary>
-    public static IServiceCollection AddProcessManagerTopic(this IServiceCollection services, TokenCredential credential)
+    public static IServiceCollection AddProcessManagerTopic(this IServiceCollection services)
     {
         services.AddOptions<ServiceBusNamespaceOptions>()
             .BindConfiguration(ServiceBusNamespaceOptions.SectionName)
@@ -43,74 +44,76 @@ public static class ProcessManagerTopicExtensions
             .BindConfiguration(Brs021ForwardMeteredDataTopicOptions.SectionName)
             .ValidateDataAnnotations();
 
-        services.AddHealthChecks()
+        services
+            .AddTokenCredentialProvider()
+            .AddHealthChecks()
             .AddAzureServiceBusTopic(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.TopicName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "Process Manager Start Topic")
             .AddAzureServiceBusSubscription(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.TopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.Brs026SubscriptionName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-026 Subscription")
             .AddServiceBusTopicSubscriptionDeadLetter(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.TopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.Brs026SubscriptionName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-026 Dead-letter",
                 [HealthChecksConstants.StatusHealthCheckTag])
             .AddAzureServiceBusSubscription(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.TopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.Brs028SubscriptionName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-028 Subscription")
             .AddServiceBusTopicSubscriptionDeadLetter(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.TopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<ProcessManagerStartTopicOptions>>().Value.Brs028SubscriptionName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-028 Dead-letter",
                 [HealthChecksConstants.StatusHealthCheckTag])
             // Add health check for the Brs021ForwardMeteredData start Topic and subscription
             .AddAzureServiceBusTopic(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartTopicName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-021-ForwardMeteredData Start Topic")
             .AddAzureServiceBusSubscription(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartTopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartSubscriptionName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-021-ForwardMeteredData Start Subscription")
             .AddServiceBusTopicSubscriptionDeadLetter(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartTopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.StartSubscriptionName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-021-ForwardMeteredData Start Dead-letter",
                 [HealthChecksConstants.StatusHealthCheckTag])
             // Add health check for the Brs021ForwardMeteredData notify Topic and subscription
             .AddAzureServiceBusTopic(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifyTopicName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-021-ForwardMeteredData Notify Topic")
             .AddAzureServiceBusSubscription(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifyTopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifySubscriptionName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-021-ForwardMeteredData Notify Subscription")
             .AddServiceBusTopicSubscriptionDeadLetter(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 topicNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifyTopicName,
                 subscriptionNameFactory: sp => sp.GetRequiredService<IOptions<Brs021ForwardMeteredDataTopicOptions>>().Value.NotifySubscriptionName,
-                tokenCredentialFactory: _ => credential,
+                tokenCredentialFactory: sp => sp.GetRequiredService<TokenCredentialProvider>().Credential,
                 name: "BRS-021-ForwardMeteredData Notify Dead-letter",
                 [HealthChecksConstants.StatusHealthCheckTag]);
 

--- a/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
+++ b/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.3.0" />
     <PackageReference Include="Google.Protobuf" Version="3.31.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.71.0">
+    <PackageReference Include="Grpc.Tools" Version="2.72.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
+++ b/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.4.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0-alpha-461" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.3.0" />
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0">

--- a/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
+++ b/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0-alpha-461" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.3.0" />
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0">

--- a/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
+++ b/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="DurableFunctionsMonitor.DotNetIsolated" Version="6.6.0" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0" />
     <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.6" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />

--- a/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
+++ b/source/ProcessManager.Orchestrations/ProcessManager.Orchestrations.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="DurableFunctionsMonitor.DotNetIsolated" Version="6.6.0" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
     <PackageReference Include="Energinet.DataHub.ElectricityMarket.Integration" Version="4.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.6" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.3.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.30.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.31.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsClient.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/Measurements/MeasurementsClient.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Diagnostics;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
 using Energinet.DataHub.Measurements.Contracts;
@@ -22,19 +21,15 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardM
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.Logging;
 using NodaTime;
 using Point = Energinet.DataHub.Measurements.Contracts.Point;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.Measurements;
 
 public class MeasurementsClient(
-    IAzureClientFactory<EventHubProducerClient> eventHubClientFactory,
-    ILogger<MeasurementsClient> logger)
+    IAzureClientFactory<EventHubProducerClient> eventHubClientFactory)
         : IMeasurementsClient
 {
-    private readonly ILogger<MeasurementsClient> _logger = logger;
-
     private readonly EventHubProducerClient _measurementEventHubProducerClient =
         eventHubClientFactory.CreateClient(EventHubProducerClientNames.MeasurementsEventHub);
 
@@ -66,11 +61,9 @@ public class MeasurementsClient(
                     Quality = MeasurementsMapper.Quality.Map(p.Quality),
                 }));
 
-        var stopwatch = Stopwatch.StartNew();
         // Serialize the data to a byte array
         var eventData = new EventData(data.ToByteArray());
         await _measurementEventHubProducerClient.SendAsync([eventData], cancellationToken).ConfigureAwait(false);
-        _logger.LogInformation($"SendAsync to Event Hub took {stopwatch.ElapsedMilliseconds} ms");
     }
 
     private static Timestamp MapDateTime(Instant instant) => Timestamp.FromDateTimeOffset(instant.ToDateTimeOffset());

--- a/source/ProcessManager.Orchestrations/Program.cs
+++ b/source/ProcessManager.Orchestrations/Program.cs
@@ -35,8 +35,6 @@ var host = new HostBuilder()
     {
         services.AddTransient<IConfiguration>(_ => context.Configuration);
 
-        var azureCredential = new DefaultAzureCredential();
-
         // Common
         services.AddApplicationInsightsForIsolatedWorker(TelemetryConstants.SubsystemName);
         services.AddHealthChecksForIsolatedWorker();
@@ -54,11 +52,11 @@ var host = new HostBuilder()
         services.AddDatabricksSqlStatementApi(context.Configuration);
 
         // Enqueue Messages in EDI
-        services.AddEnqueueActorMessages(azureCredential);
+        services.AddEnqueueActorMessages();
         services.AddEnqueueActorMessagesHttp(context.Configuration);
 
         // Integration event publisher
-        services.AddIntegrationEventPublisher(azureCredential);
+        services.AddIntegrationEventPublisher();
 
         // Business validation
         var orchestrationsAssembly = typeof(Program).Assembly;
@@ -72,12 +70,12 @@ var host = new HostBuilder()
         services.AddDataHubCalendarComponent();
 
         // ProcessManager
-        services.AddProcessManagerTopic(azureCredential);
+        services.AddProcessManagerTopic();
         // => Auto register Orchestration Descriptions builders and custom handlers
         services.AddProcessManagerForOrchestrations(typeof(Program).Assembly);
 
         // BRS-021 (ForwardMeteredData, ElectricalHeatingCalculation, CapacitySettlementCalculation & NetConsumptionCalculation)
-        services.AddBrs021(azureCredential);
+        services.AddBrs021();
     })
     .ConfigureFunctionsWebApplication(builder =>
     {

--- a/source/ProcessManager.Orchestrations/Program.cs
+++ b/source/ProcessManager.Orchestrations/Program.cs
@@ -14,6 +14,7 @@
 
 using DurableFunctionsMonitor.DotNetIsolated;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
+using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.Builder;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.DependencyInjection;
@@ -37,9 +38,12 @@ var host = new HostBuilder()
         // Common
         services.AddApplicationInsightsForIsolatedWorker(TelemetryConstants.SubsystemName);
         services.AddHealthChecksForIsolatedWorker();
+        services.AddTokenCredentialProvider();
         services.AddNodaTimeForApplication();
         services.AddSubsystemAuthenticationForIsolatedWorker(context.Configuration);
-        services.AddServiceBusClientForApplication(context.Configuration);
+        services.AddServiceBusClientForApplication(
+            context.Configuration,
+            sp => sp.GetRequiredService<TokenCredentialProvider>().Credential);
         // => Feature management
         services
             .AddAzureAppConfiguration()

--- a/source/ProcessManager.Orchestrations/Program.cs
+++ b/source/ProcessManager.Orchestrations/Program.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Identity;
 using DurableFunctionsMonitor.DotNetIsolated;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.Builder;

--- a/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerFixture.cs
+++ b/source/ProcessManager.SubsystemTests/Fixtures/ProcessManagerFixture.cs
@@ -15,6 +15,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Azure.Identity;
 using Azure.Messaging.EventHubs.Producer;
+using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.TestCommon.Diagnostics;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
@@ -115,6 +116,7 @@ public class ProcessManagerFixture<TScenarioState> : IAsyncLifetime
     {
         var serviceCollection = new ServiceCollection();
 
+        serviceCollection.AddTokenCredentialProvider();
         serviceCollection.AddInMemoryConfiguration(new Dictionary<string, string?>
         {
             // Message client options

--- a/source/ProcessManager.SubsystemTests/ProcessManager.SubsystemTests.csproj
+++ b/source/ProcessManager.SubsystemTests/ProcessManager.SubsystemTests.csproj
@@ -18,9 +18,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/ProcessManager.Tests/ProcessManager.Tests.csproj
+++ b/source/ProcessManager.Tests/ProcessManager.Tests.csproj
@@ -24,9 +24,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/ProcessManager/Extensions/DependencyInjection/ServiceBusExtensions.cs
+++ b/source/ProcessManager/Extensions/DependencyInjection/ServiceBusExtensions.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.App.Common.Diagnostics.HealthChecks;
-using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Builder;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.Options;

--- a/source/ProcessManager/Extensions/DependencyInjection/ServiceBusExtensions.cs
+++ b/source/ProcessManager/Extensions/DependencyInjection/ServiceBusExtensions.cs
@@ -27,11 +27,12 @@ public static class ServiceBusExtensions
 {
     /// <summary>
     /// Add required services for handling notify orchestration instance Service Bus messages.
+    /// </summary>
     /// <remarks>
     /// Requires <see cref="ProcessManagerNotifyTopicOptions"/> to be present in the app settings.
     /// Requires <see cref="ServiceBusNamespaceOptions"/> to be present in the app settings.
+    /// Expects "AddTokenCredentialProvider" has been called to register <see cref="TokenCredentialProvider"/>.
     /// </remarks>
-    /// </summary>
     public static IServiceCollection AddNotifyOrchestrationInstance(this IServiceCollection serviceCollection)
     {
         serviceCollection
@@ -45,7 +46,6 @@ public static class ServiceBusExtensions
             .ValidateDataAnnotations();
 
         serviceCollection
-            .AddTokenCredentialProvider()
             .AddHealthChecks()
             .AddAzureServiceBusTopic(
                 fullyQualifiedNamespaceFactory: sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,

--- a/source/ProcessManager/Extensions/DependencyInjection/ServiceBusExtensions.cs
+++ b/source/ProcessManager/Extensions/DependencyInjection/ServiceBusExtensions.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Core;
-using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.Core.App.Common.Diagnostics.HealthChecks;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.Common.Identity;

--- a/source/ProcessManager/ProcessManager.csproj
+++ b/source/ProcessManager/ProcessManager.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />

--- a/source/ProcessManager/ProcessManager.csproj
+++ b/source/ProcessManager/ProcessManager.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.1.0-alpha-152" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />

--- a/source/ProcessManager/ProcessManager.csproj
+++ b/source/ProcessManager/ProcessManager.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0-alpha-461" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/source/ProcessManager/ProcessManager.csproj
+++ b/source/ProcessManager/ProcessManager.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.4.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="15.5.0-alpha-461" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/source/ProcessManager/Program.cs
+++ b/source/ProcessManager/Program.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
+using Energinet.DataHub.Core.App.Common.Identity;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.Builder;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.Messaging.Communication.Extensions.DependencyInjection;
@@ -32,9 +33,12 @@ var host = new HostBuilder()
         // Common
         services.AddApplicationInsightsForIsolatedWorker(TelemetryConstants.SubsystemName);
         services.AddHealthChecksForIsolatedWorker();
+        services.AddTokenCredentialProvider();
         services.AddNodaTimeForApplication();
         services.AddSubsystemAuthenticationForIsolatedWorker(context.Configuration);
-        services.AddServiceBusClientForApplication(context.Configuration);
+        services.AddServiceBusClientForApplication(
+            context.Configuration,
+            sp => sp.GetRequiredService<TokenCredentialProvider>().Credential);
         // => Feature management
         services
             .AddAzureAppConfiguration()

--- a/source/ProcessManager/Program.cs
+++ b/source/ProcessManager/Program.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Identity;
 using Energinet.DataHub.Core.App.Common.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.Builder;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.DependencyInjection;
@@ -30,8 +29,6 @@ using Microsoft.FeatureManagement;
 var host = new HostBuilder()
     .ConfigureServices((context, services) =>
     {
-        var azureCredential = new DefaultAzureCredential();
-
         // Common
         services.AddApplicationInsightsForIsolatedWorker(TelemetryConstants.SubsystemName);
         services.AddHealthChecksForIsolatedWorker();
@@ -44,7 +41,7 @@ var host = new HostBuilder()
             .AddFeatureManagement();
 
         // Api
-        services.AddNotifyOrchestrationInstance(azureCredential);
+        services.AddNotifyOrchestrationInstance();
 
         // ProcessManager
         services.AddProcessManagerCore();


### PR DESCRIPTION
## Description

- Use token credential functionality that is now available in App package.
- Update use of Messaging functionality, where we now have to use `tokenCredentialFactory` parameter when configuring Service Bus Client.
- Refactor tests that uses Process Manager http and messaging clients. Most of their configuration has been moved to the respective fixtures.

Deployed to `dev_002`:
- Core: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/15272196040
- Orchestrations: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/15272716640

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/402

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
