### PR TITLE
test: Added Net Consumption subsystem test

### DIFF
--- a/source/ProcessManager.SubsystemTests/Processes/BRS_021/NetConsumptionCalculation/V1/NetConsumptionCalculationScenario.cs
+++ b/source/ProcessManager.SubsystemTests/Processes/BRS_021/NetConsumptionCalculation/V1/NetConsumptionCalculationScenario.cs
@@ -1,0 +1,115 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.TestCommon.Xunit.Attributes;
+using Energinet.DataHub.Core.TestCommon.Xunit.Orderers;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.NetConsumptionCalculation.V1.Model;
+using Energinet.DataHub.ProcessManager.SubsystemTests.Fixtures;
+using Energinet.DataHub.ProcessManager.SubsystemTests.Fixtures.Extensions;
+using Energinet.DataHub.ProcessManager.SubsystemTests.Processes.Shared.V1;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.ProcessManager.SubsystemTests.Processes.BRS_021.NetConsumptionCalculation.V1;
+
+[TestCaseOrderer(
+    ordererTypeName: TestCaseOrdererLocation.OrdererTypeName,
+    ordererAssemblyName: TestCaseOrdererLocation.OrdererAssemblyName)]
+public class NetConsumptionCalculationScenario
+    : IClassFixture<ProcessManagerFixture<CalculationScenarioState>>,
+    IAsyncLifetime
+{
+    private readonly ProcessManagerFixture<CalculationScenarioState> _fixture;
+
+    public NetConsumptionCalculationScenario(
+        ProcessManagerFixture<CalculationScenarioState> fixture,
+        ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _fixture.SetTestOutputHelper(null);
+        return Task.CompletedTask;
+    }
+
+    [SubsystemFact]
+    [ScenarioStep(1)]
+    public async Task Given_ValidStartCalculationCommand()
+    {
+        // Warm up SQL warehouse, so it is ready for the sql queries at the end of the orchestration
+        await _fixture.StartDatabricksSqlWarehouseAsync();
+
+        _fixture.ScenarioState = new CalculationScenarioState(
+            startCommand: new StartNetConsumptionCalculationCommandV1(_fixture.UserIdentity));
+    }
+
+    [SubsystemFact]
+    [ScenarioStep(2)]
+    public async Task AndGiven_StartNewOrchestrationInstanceIsSent()
+    {
+        var orchestrationInstanceId = await _fixture.ProcessManagerHttpClient.StartNewOrchestrationInstanceAsync(
+            _fixture.ScenarioState.StartCommand,
+            CancellationToken.None);
+
+        _fixture.ScenarioState.OrchestrationInstanceId = orchestrationInstanceId;
+    }
+
+    [SubsystemFact]
+    [ScenarioStep(3)]
+    public async Task When_OrchestrationInstanceIsRunning()
+    {
+        Assert.True(_fixture.ScenarioState.OrchestrationInstanceId != Guid.Empty, "If orchestration instance id wasn't set earlier, end tests early.");
+
+        var (success, orchestrationInstance, _) = await _fixture.WaitForOrchestrationInstanceByIdAsync(
+            orchestrationInstanceId: _fixture.ScenarioState.OrchestrationInstanceId,
+            orchestrationInstanceState: OrchestrationInstanceLifecycleState.Running);
+
+        Assert.Multiple(
+            () => Assert.True(
+                success,
+                $"An orchestration instance for id \"{_fixture.ScenarioState.OrchestrationInstanceId}\" should be running."),
+            () => Assert.NotNull(orchestrationInstance));
+
+        _fixture.ScenarioState.OrchestrationInstance = orchestrationInstance;
+    }
+
+    [SubsystemFact]
+    [ScenarioStep(4)]
+    public async Task Then_OrchestrationInstanceIsTerminatedWithSuccess()
+    {
+        Assert.True(_fixture.ScenarioState.OrchestrationInstanceId != Guid.Empty, "If orchestration instance id wasn't set earlier, end tests early.");
+
+        // Wait up to 30 minutes for the orchestration instance to be terminated. If the databricks warehouse
+        // isn't currently running, it takes 5-20 minutes before the databricks query actually starts running.
+        var (success, orchestrationInstance, _) = await _fixture.WaitForOrchestrationInstanceByIdAsync(
+                orchestrationInstanceId: _fixture.ScenarioState.OrchestrationInstanceId,
+                orchestrationInstanceState: OrchestrationInstanceLifecycleState.Terminated,
+                timeoutInMinutes: 30);
+
+        _fixture.ScenarioState.OrchestrationInstance = orchestrationInstance;
+
+        Assert.Multiple(
+            () => Assert.True(success, "The orchestration instance should be terminated"),
+            () => Assert.Equal(OrchestrationInstanceLifecycleState.Terminated, orchestrationInstance?.Lifecycle.State),
+            () => Assert.Equal(OrchestrationInstanceTerminationState.Succeeded, orchestrationInstance?.Lifecycle.TerminationState));
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Added basic Net Consumption subsystem test.


## References

Link to assignment:
https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/team-mandalorian/774

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
