### PR TITLE
 feat: added brs024 metering point validation rule

### DIFF
--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_024/V1/BusinessValidation/MeteringPointTypeValidationRuleTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_024/V1/BusinessValidation/MeteringPointTypeValidationRuleTests.cs
@@ -1,0 +1,95 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_024.V1.BusinessValidation;
+using FluentAssertions;
+using NodaTime;
+using MeteringPointId = Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData.Model.MeteringPointId;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_024.V1.BusinessValidation;
+
+public class MeteringPointTypeValidationRuleTests
+{
+    private readonly MeteringPointTypeValidationRule _sut = new();
+
+    public static TheoryData<MeteringPointType> ValidMeteringPointTypes => new()
+    {
+        MeteringPointType.Production,
+        MeteringPointType.Consumption,
+    };
+
+    public static TheoryData<MeteringPointType> InvalidMeteringPointTypes =>
+    [
+        ..EnumerationRecordType.GetAll<MeteringPointType>()
+            .Except(ValidMeteringPointTypes),
+    ];
+
+    [Fact]
+    public async Task Given_NoMasterData_When_Validate_Then_NoValidationError()
+    {
+        var input = new RequestYearlyMeasurementsInputV1Builder()
+            .Build();
+
+        var result = await _sut.ValidateAsync(
+            new(
+                input,
+                null));
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidMeteringPointTypes))]
+    public async Task Given_ValidMeteringPointType_When_Validate_Then_NoValidationError(MeteringPointType meteringPointType)
+    {
+        var input = new RequestYearlyMeasurementsInputV1Builder()
+            .Build();
+
+        var meteringPointMasterData = new MeteringPointMasterDataBuilder()
+            .BuildFromInput(
+                input,
+                meteringPointType: meteringPointType);
+
+        var result = await _sut.ValidateAsync(
+            new(
+                input,
+                meteringPointMasterData));
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidMeteringPointTypes))]
+    public async Task Given_InvalidMeteringPointType_When_Validate_Then_NoValidationError(MeteringPointType invalidMeteringPointType)
+    {
+        var input = new RequestYearlyMeasurementsInputV1Builder()
+            .Build();
+
+        var meteringPointMasterData = new MeteringPointMasterDataBuilder()
+            .BuildFromInput(
+                input,
+                meteringPointType: invalidMeteringPointType);
+
+        var result = await _sut.ValidateAsync(
+            new(
+                input,
+                meteringPointMasterData));
+
+        var validationError = Assert.Single(result);
+        Assert.Equal(MeteringPointTypeValidationRule.WrongMeteringPointError.First(), validationError);
+    }
+}

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_024/V1/BusinessValidation/RequestMeasurementsBusinessValidationTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_024/V1/BusinessValidation/RequestMeasurementsBusinessValidationTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Components.Extensions.DependencyInjection;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_024.V1.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_024.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_024.V1.Orchestration;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_024.V1.BusinessValidation;
+
+public class RequestMeasurementsBusinessValidationTests
+{
+    private readonly BusinessValidator<RequestYearlyMeasurementsBusinessValidatedDto> _sut;
+
+    public RequestMeasurementsBusinessValidationTests()
+    {
+        IServiceCollection services = new ServiceCollection();
+
+        var orchestrationsAssembly = typeof(OrchestrationDescriptionBuilder).Assembly;
+        var orchestrationsAbstractionsAssembly =
+            typeof(RequestYearlyMeasurementsBusinessValidatedDto).Assembly;
+        services.AddBusinessValidation(assembliesToScan: [orchestrationsAssembly, orchestrationsAbstractionsAssembly]);
+
+        var serviceProvider = services.BuildServiceProvider();
+        _sut = serviceProvider
+        .GetRequiredService<BusinessValidator<RequestYearlyMeasurementsBusinessValidatedDto>>();
+    }
+
+    [Fact]
+    public async Task Given_ValidForwardMeteredDataBusinessValidatedDto_When_Validate_Then_NoValidationError()
+    {
+        var input = new RequestYearlyMeasurementsInputV1Builder()
+            .Build();
+
+        var meteringPointMasterData = new MeteringPointMasterDataBuilder()
+            .BuildFromInput(input);
+
+        var result = await _sut.ValidateAsync(
+            new RequestYearlyMeasurementsBusinessValidatedDto(
+                Input: input,
+                MeteringPointMasterData: meteringPointMasterData));
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Given_InvalidMeteringPointType_When_Validate_Then_ValidationError()
+    {
+        var input = new RequestYearlyMeasurementsInputV1Builder()
+            .Build();
+
+        var invalidMeteringPointType = MeteringPointType.Exchange;
+        var meteringPointMasterData = new MeteringPointMasterDataBuilder()
+            .BuildFromInput(
+                input,
+                meteringPointType: invalidMeteringPointType);
+
+        var result = await _sut.ValidateAsync(
+            new RequestYearlyMeasurementsBusinessValidatedDto(
+                Input: input,
+                MeteringPointMasterData: meteringPointMasterData));
+
+        result.Should()
+            .ContainSingle()
+            .And.BeEquivalentTo(MeteringPointTypeValidationRule.WrongMeteringPointError);
+    }
+}

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_024/V1/MeteringPointMasterDataBuilder.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_024/V1/MeteringPointMasterDataBuilder.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData.Extensions;
+using Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_024.V1.Model;
+using NodaTime;
+using MeteringPointId = Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData.Model.MeteringPointId;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_024.V1;
+
+public class MeteringPointMasterDataBuilder
+{
+    public MeteringPointMasterData BuildFromInput(
+        RequestYearlyMeasurementsInputV1 input,
+        MeteringPointSubType? meteringPointSubType = null,
+        MeasurementUnit? measurementUnit = null,
+        string? gridAccessProvider = null,
+        MeteringPointType? meteringPointType = null,
+        ConnectionState? connectionState = null)
+    {
+        var end = InstantPatternWithOptionalSeconds.Parse(input.ReceivedAt).Value;
+        var start = end.Minus(Duration.FromDays(365));
+
+        return new MeteringPointMasterData(
+            MeteringPointId: new MeteringPointId(input.MeteringPointId!),
+            CurrentGridAreaCode: new GridAreaCode("804"),
+            CurrentGridAccessProvider: gridAccessProvider != null ? ActorNumber.Create(gridAccessProvider) : ActorNumber.Create("1111111111111"),
+            ConnectionState: connectionState ?? ConnectionState.Connected,
+            MeteringPointType: meteringPointType ?? MeteringPointType.Production,
+            MeteringPointSubType: meteringPointSubType ?? MeteringPointSubType.Physical,
+            MeasurementUnit: measurementUnit ?? MeasurementUnit.KilowattHour,
+            ValidFrom: start.ToDateTimeOffset(),
+            ValidTo: end.ToDateTimeOffset(),
+            CurrentNeighborGridAreaOwners: [],
+            Resolution: Resolution.QuarterHourly,
+            ProductId: "product",
+            ParentMeteringPointId: null,
+            EnergySupplier: ActorNumber.Create("1111111111112"));
+    }
+}

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_024/V1/RequestYearlyMeasurementsInputV1Builder.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_024/V1/RequestYearlyMeasurementsInputV1Builder.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_024.V1.Model;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_024.V1;
+
+public class RequestYearlyMeasurementsInputV1Builder
+{
+    private const string ActorMessageId = "MessageId";
+    private const string TransactionId = "TransactionId";
+    private const string ActorNumber = "1234567890123";
+    private const string MeteringPointId = "MeteringPointId";
+    private const string ReceivedAt = "2024-12-31T23:00Z";
+
+    private readonly string _actorRole = ActorRole.GridAccessProvider.Name;
+    private readonly string _businessReason = BusinessReason.PeriodicMetering.Name;
+
+    public RequestYearlyMeasurementsInputV1 Build()
+    {
+        return new RequestYearlyMeasurementsInputV1(
+            ActorMessageId: ActorMessageId,
+            TransactionId: TransactionId,
+            ActorNumber: ActorNumber,
+            ActorRole: _actorRole,
+            BusinessReason: _businessReason,
+            ReceivedAt: ReceivedAt,
+            MeteringPointId: MeteringPointId);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_024/V1/BusinessValidation/MeteringPointTypeValidationRule.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_024/V1/BusinessValidation/MeteringPointTypeValidationRule.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_024.V1.Model;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_024.V1.BusinessValidation;
+
+public class MeteringPointTypeValidationRule
+    : IBusinessValidationRule<RequestYearlyMeasurementsBusinessValidatedDto>
+{
+    public static IList<ValidationError> WrongMeteringPointError => [new(
+        Message: "I forbindelse med anmodning om årssum kan der kun anmodes om data for forbrug og produktion/when requesting yearly amounts it is only possible to request for production and consumption",
+        ErrorCode: "D18")];
+
+    private static IList<ValidationError> NoError => [];
+
+    private static IReadOnlyCollection<MeteringPointType> AllowedMeteringPointTypes => new[]
+    {
+        MeteringPointType.Production,
+        MeteringPointType.Consumption,
+    };
+
+    public Task<IList<ValidationError>> ValidateAsync(RequestYearlyMeasurementsBusinessValidatedDto subject)
+    {
+        if (subject.MeteringPointMasterData is null)
+        {
+            return Task.FromResult(NoError);
+        }
+
+        var masterDataMeteringPointType = subject.MeteringPointMasterData.MeteringPointType;
+        if (!AllowedMeteringPointTypes.Contains(masterDataMeteringPointType))
+        {
+            return Task.FromResult(WrongMeteringPointError);
+        }
+
+        return Task.FromResult(NoError);
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_024/V1/Model/RequestYearlyMeasurementsBusinessValidatedDto.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_024/V1/Model/RequestYearlyMeasurementsBusinessValidatedDto.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ProcessManager.Components.Abstractions.BusinessValidation;
+using Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_024.V1.Model;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_024.V1.Model;
+
+public record RequestYearlyMeasurementsBusinessValidatedDto(
+    RequestYearlyMeasurementsInputV1 Input,
+    MeteringPointMasterData? MeteringPointMasterData) : IBusinessValidatedDto;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Ensure measurements from the metering point types E17 and E18 are allowed to be requested.
 
## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/811

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task
