### PR TITLE
feat: Update Send Measurements handler to use Send Measurements Instance

### DIFF
--- a/source/ProcessManager.Core/Application/SendMeasurements/ISendMeasurementsInstanceRepository.cs
+++ b/source/ProcessManager.Core/Application/SendMeasurements/ISendMeasurementsInstanceRepository.cs
@@ -27,7 +27,7 @@ public interface ISendMeasurementsInstanceRepository
     IUnitOfWork UnitOfWork { get; }
 
     /// <summary>
-    /// Add the BRS-021 Send Measurements orchestration instance to the database, and upload the input to file storage.
+    /// Add the BRS-021 Send Measurements instance to the database, and upload the input to file storage.
     /// To commit changes use <see cref="UnitOfWork"/>.
     /// </summary>
     /// <param name="instance">The instance to add to the database.</param>
@@ -35,14 +35,21 @@ public interface ISendMeasurementsInstanceRepository
     Task AddAsync(SendMeasurementsInstance instance, Stream input);
 
     /// <summary>
-    /// Get existing orchestration instance by id.
+    /// Get existing instance by id.
     /// </summary>
     Task<SendMeasurementsInstance> GetAsync(SendMeasurementsInstanceId id);
 
     /// <summary>
-    /// Get existing orchestration instance by transaction id (used for idempotency key).
+    /// Get existing instance by transaction id (used for idempotency key).
     /// </summary>
     Task<SendMeasurementsInstance?> GetOrDefaultAsync(IdempotencyKey idempotencyKey);
 
+    /// <summary>
+    /// Download the input for an <see cref="SendMeasurementsInstance"/>, found by the given <paramref name="reference"/>.
+    /// </summary>
+    /// <remarks>The returned stream is only downloaded when it is read, and can only be read once.</remarks>
+    /// <param name="reference"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Returns a stream that is downloaded when it is read, and can only be read once.</returns>
     Task<ReadOnceStream> DownloadInputAsync(SendMeasurementsInputFileStorageReference reference, CancellationToken cancellationToken = default);
 }

--- a/source/ProcessManager.Core/Application/SendMeasurements/ISendMeasurementsInstanceRepository.cs
+++ b/source/ProcessManager.Core/Application/SendMeasurements/ISendMeasurementsInstanceRepository.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.ProcessManager.Core.Application.FileStorage;
 using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Core.Domain.SendMeasurements;
@@ -42,4 +43,6 @@ public interface ISendMeasurementsInstanceRepository
     /// Get existing orchestration instance by transaction id (used for idempotency key).
     /// </summary>
     Task<SendMeasurementsInstance?> GetOrDefaultAsync(IdempotencyKey idempotencyKey);
+
+    Task<ReadOnceStream> DownloadInputAsync(SendMeasurementsInputFileStorageReference reference, CancellationToken cancellationToken = default);
 }

--- a/source/ProcessManager.Core/Domain/SendMeasurements/SendMeasurementsInstance.cs
+++ b/source/ProcessManager.Core/Domain/SendMeasurements/SendMeasurementsInstance.cs
@@ -105,7 +105,7 @@ public class SendMeasurementsInstance
 
     public Instant? SentToEnqueueActorMessagesAt { get; private set; }
 
-    public bool IsSentToEnqueueActorMessagesAt => SentToEnqueueActorMessagesAt is not null;
+    public bool IsSentToEnqueueActorMessages => SentToEnqueueActorMessagesAt is not null;
 
     public Instant? ReceivedFromEnqueueActorMessagesAt { get; private set; }
 
@@ -151,6 +151,17 @@ public class SendMeasurementsInstance
             throw new InvalidOperationException($"Cannot mark instance as sent to measurements if business validation isn't succeeded (Id={Id.Value}).");
 
         SentToMeasurementsAt = sentToMeasurementsAt;
+    }
+
+    public void MarkAsReceivedFromMeasurements(Instant receivedFromMeasurementsAt)
+    {
+        if (ReceivedFromMeasurementsAt is not null)
+            throw new InvalidOperationException($"Cannot mark instance as received from Measurements (Id={Id.Value}, ReceivedFromMeasurementsAt={InstantPattern.General.Format(ReceivedFromMeasurementsAt.Value)}).");
+
+        if (!IsSentToMeasurements)
+            throw new InvalidOperationException($"Cannot mark instance as received from Measurements if it is not sent (Id={Id.Value}).");
+
+        ReceivedFromMeasurementsAt = receivedFromMeasurementsAt;
     }
 
     public void MarkAsSentToEnqueueActorMessages(Instant sentToEnqueueActorMessagesAt)

--- a/source/ProcessManager.Core/Domain/SendMeasurements/SendMeasurementsInstance.cs
+++ b/source/ProcessManager.Core/Domain/SendMeasurements/SendMeasurementsInstance.cs
@@ -103,6 +103,8 @@ public class SendMeasurementsInstance
 
     public Instant? ReceivedFromMeasurementsAt { get; private set; }
 
+    public bool IsReceivedFromMeasurements => ReceivedFromMeasurementsAt is not null;
+
     public Instant? SentToEnqueueActorMessagesAt { get; private set; }
 
     public bool IsSentToEnqueueActorMessages => SentToEnqueueActorMessagesAt is not null;

--- a/source/ProcessManager.Core/Infrastructure/Orchestration/SendMeasurementsInstanceRepository.cs
+++ b/source/ProcessManager.Core/Infrastructure/Orchestration/SendMeasurementsInstanceRepository.cs
@@ -53,4 +53,9 @@ internal class SendMeasurementsInstanceRepository(
         return _dbContext.SendMeasurementsInstances
             .SingleOrDefaultAsync(i => i.IdempotencyKey == idempotencyKey.ToHash());
     }
+
+    public Task<ReadOnceStream> DownloadInputAsync(SendMeasurementsInputFileStorageReference reference, CancellationToken cancellationToken)
+    {
+        return _fileStorageClient.DownloadAsync(reference, cancellationToken);
+    }
 }

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/ProcessManagerAzuriteCollection.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/ProcessManagerAzuriteCollection.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
+
+/// <summary>
+/// A xUnit collection fixture for ensuring tests don't run in parallel. <see cref="ProcessManagerAzuriteFixture"/> uses
+/// an <see cref="AzuriteManager"/>, which doesn't support parallel test execution.
+///
+/// xUnit documentation of collection fixtures:
+///  * https://xunit.net/docs/shared-context#collection-fixture
+/// </summary>
+[CollectionDefinition(nameof(ProcessManagerAzuriteCollection), DisableParallelization = true)]
+public class ProcessManagerAzuriteCollection : ICollectionFixture<ProcessManagerAzuriteFixture>;

--- a/source/ProcessManager.Orchestrations.Tests/Fixtures/ProcessManagerAzuriteFixture.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Fixtures/ProcessManagerAzuriteFixture.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;
+using Energinet.DataHub.ProcessManager.Shared.Tests.Fixtures.Extensions;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
+
+public class ProcessManagerAzuriteFixture : IAsyncLifetime
+{
+    public ProcessManagerAzuriteFixture()
+    {
+        AzuriteManager = new AzuriteManager(useOAuth: false, useSilentMode: true);
+    }
+
+    public AzuriteManager AzuriteManager { get; }
+
+    public async Task InitializeAsync()
+    {
+        AzuriteManager.CleanupAzuriteStorage();
+        AzuriteManager.StartAzurite();
+        await AzuriteManager.CreateRequiredContainersAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        AzuriteManager.CleanupAzuriteStorage();
+        AzuriteManager.Dispose();
+
+        await Task.CompletedTask;
+    }
+}

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeasurementsHandlerV1OldTests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeasurementsHandlerV1OldTests.cs
@@ -1,0 +1,455 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Energinet.DataHub.ProcessManager.Components.EnqueueActorMessages;
+using Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData;
+using Energinet.DataHub.ProcessManager.Core.Application.FileStorage;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationDescription;
+using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Core.Infrastructure.Database;
+using Energinet.DataHub.ProcessManager.Core.Infrastructure.Orchestration;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Handlers;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Fixtures;
+using Energinet.DataHub.ProcessManager.Orchestrations.Tests.Unit.Processes.BRS_021.ForwardMeteredData.V1;
+using Energinet.DataHub.ProcessManager.Shared.Api.Mappers;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
+using Moq;
+using NodaTime;
+using StepInstanceTerminationState = Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance.StepInstanceTerminationState;
+using TelemetryConfiguration = Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Tests.Integration.Processes.BRS_021.ForwardMeteredData.V1.Handlers;
+
+/// <summary>
+/// This is a copy of the existing <see cref="EnqueueMeasurementsHandlerV1Tests"/>, to test the "old"
+/// method of persisting the BRS-021 Send Measurements as an <see cref="OrchestrationInstance"/>. This class should
+/// be removed when the old way is also removed.
+/// </summary>
+public class EnqueueMeasurementsHandlerV1OldTests
+    : IClassFixture<ProcessManagerDatabaseFixture>, IAsyncLifetime
+{
+    private readonly ProcessManagerDatabaseFixture _fixture;
+    private readonly Mock<IClock> _clock = new();
+    private readonly Mock<IFeatureManager> _featureManager = new();
+    private readonly Mock<IEnqueueActorMessagesClient> _enqueueActorMessagesClient = new();
+    private readonly Mock<IFileStorageClient> _fileStorageClient = new();
+
+    private readonly Instant _now = Instant.FromUtc(2025, 06, 06, 13, 37);
+    private readonly MeteringPointId _meteringPointId = new("123456789012345678");
+    private readonly string _actorMessageId = Guid.NewGuid().ToString();
+    private readonly ActorNumber _gridAccessProvider = ActorNumber.Create("1111111111111");
+    private readonly ActorNumber _energySupplier = ActorNumber.Create("1111111111112");
+
+    public EnqueueMeasurementsHandlerV1OldTests(ProcessManagerDatabaseFixture fixture)
+    {
+        _fixture = fixture;
+
+        _clock.Setup(c => c.GetCurrentInstant()).Returns(_now);
+    }
+
+    [NotNull]
+    private ProcessManagerContext? DbContext { get; set; }
+
+    [NotNull]
+    private OrchestrationDescription? OrchestrationDescription { get; set; }
+
+    [NotNull]
+    private EnqueueMeasurementsHandlerV1? Sut { get; set; }
+
+    public async Task InitializeAsync()
+    {
+        DbContext = _fixture.DatabaseManager.CreateDbContext();
+
+        OrchestrationDescription = await CreateSendMeasurementsOrchestrationDescriptionAsync();
+
+        Sut = new EnqueueMeasurementsHandlerV1(
+            new OrchestrationInstanceRepository(DbContext),
+            new SendMeasurementsInstanceRepository(DbContext, _fileStorageClient.Object),
+            _clock.Object,
+            _enqueueActorMessagesClient.Object,
+            new MeteringPointReceiversProvider(DateTimeZone.Utc),
+            new TelemetryClient(new TelemetryConfiguration
+            {
+                TelemetryChannel = Mock.Of<ITelemetryChannel>(),
+            }),
+            _featureManager.Object);
+
+        await Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (DbContext != null) // DbContext can be null if InitializeAsync fails
+            await DbContext.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Given_RunningOrchestrationInstance_When_HandleAsync_Then_ActorMessagesAreEnqueued()
+    {
+        // Arrange
+        var orchestrationInstance = CreateRunningOrchestrationInstance();
+
+        await using (var setupContext = _fixture.DatabaseManager.CreateDbContext())
+        {
+            setupContext.OrchestrationInstances.Add(orchestrationInstance);
+            await setupContext.SaveChangesAsync();
+        }
+
+        // Act
+        await Sut.HandleAsync(orchestrationInstance.Id.Value);
+
+        // Assert
+        await using var assertionDbContext = _fixture.DatabaseManager.CreateDbContext();
+        var actualOrchestrationInstance = await assertionDbContext.OrchestrationInstances
+            .SingleAsync(oi => oi.Id == orchestrationInstance.Id);
+
+        var measurementsStep = actualOrchestrationInstance.GetStep(OrchestrationDescriptionBuilder.ForwardToMeasurementsStep);
+        var enqueueStep = actualOrchestrationInstance.GetStep(OrchestrationDescriptionBuilder.EnqueueActorMessagesStep);
+
+        // - ForwardToMeasurements step should be terminated with success.
+        // - EnqueueActorMessages step should be running.
+        Assert.Multiple(
+            () => Assert.Equal(StepInstanceLifecycleState.Terminated, measurementsStep.Lifecycle.State),
+            () => Assert.Equal(StepInstanceTerminationState.Succeeded, measurementsStep.Lifecycle.TerminationState),
+            () => Assert.Equal(_now, measurementsStep.Lifecycle.TerminatedAt),
+            () => Assert.Equal(StepInstanceLifecycleState.Running, enqueueStep.Lifecycle.State),
+            () => Assert.Equal(_now, enqueueStep.Lifecycle.StartedAt),
+            () => Assert.Null(enqueueStep.Lifecycle.TerminationState));
+
+        _enqueueActorMessagesClient.Verify(
+            client => client.EnqueueAsync(
+                Brs_021_ForwardedMeteredData.V1,
+                orchestrationInstance.Id.Value,
+                orchestrationInstance.Lifecycle.CreatedBy.Value.MapToDto(),
+                It.IsAny<Guid>(),
+                It.Is<ForwardMeteredDataAcceptedV1>(m =>
+                    m.MeteringPointId == _meteringPointId.Value &&
+                    m.OriginalActorMessageId == _actorMessageId &&
+                    HasCorrectReceivers(m))),
+            Times.Once);
+        _enqueueActorMessagesClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Given_RunningOrchestrationInstance_AndGiven_AlreadyHasEnqueueIdempotencyKey_When_HandleAsync_Then_ActorMessagesAreEnqueuedWithSameIdempotencyKey()
+    {
+        // Arrange
+        var orchestrationInstance = CreateRunningOrchestrationInstance();
+
+        var enqueueIdempotencyKey = Guid.NewGuid();
+        var enqueueStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilder.EnqueueActorMessagesStep);
+        enqueueStep.CustomState.SetFromInstance(
+            new EnqueueActorMessagesStepCustomStateV1(
+                IdempotencyKey: enqueueIdempotencyKey));
+
+        await using (var setupContext = _fixture.DatabaseManager.CreateDbContext())
+        {
+            setupContext.OrchestrationInstances.Add(orchestrationInstance);
+            await setupContext.SaveChangesAsync();
+        }
+
+        // Act
+        await Sut.HandleAsync(orchestrationInstance.Id.Value);
+
+        // Assert
+        _enqueueActorMessagesClient.Verify(
+            client => client.EnqueueAsync(
+                Brs_021_ForwardedMeteredData.V1,
+                orchestrationInstance.Id.Value,
+                orchestrationInstance.Lifecycle.CreatedBy.Value.MapToDto(),
+                enqueueIdempotencyKey,
+                It.IsAny<ForwardMeteredDataAcceptedV1>()),
+            Times.Once);
+        _enqueueActorMessagesClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Given_OrchestrationInstanceStuckAtEnqueueActorMessages_When_HandleAsync_Then_ActorMessagesAreEnqueued()
+    {
+        // Arrange
+        var orchestrationInstance = CreateRunningOrchestrationInstance();
+
+        // Simulate that the orchestration instance has terminated the ForwardToMeasurementsStep and
+        // is stuck at the EnqueueActorMessages step
+        orchestrationInstance.TransitionStepToTerminated(
+            sequence: OrchestrationDescriptionBuilder.ForwardToMeasurementsStep,
+            StepInstanceTerminationState.Succeeded,
+            _clock.Object);
+
+        orchestrationInstance.TransitionStepToRunning(
+            sequence: OrchestrationDescriptionBuilder.EnqueueActorMessagesStep,
+            _clock.Object);
+
+        await using (var setupContext = _fixture.DatabaseManager.CreateDbContext())
+        {
+            setupContext.OrchestrationInstances.Add(orchestrationInstance);
+            await setupContext.SaveChangesAsync();
+        }
+
+        // Act
+        await Sut.HandleAsync(orchestrationInstance.Id.Value);
+
+        // Assert
+        await using var assertionDbContext = _fixture.DatabaseManager.CreateDbContext();
+        var actualOrchestrationInstance = await assertionDbContext.OrchestrationInstances
+            .SingleAsync(oi => oi.Id == orchestrationInstance.Id);
+
+        var enqueueStep = actualOrchestrationInstance.GetStep(OrchestrationDescriptionBuilder.EnqueueActorMessagesStep);
+
+        // - EnqueueActorMessages step should still be running.
+        Assert.Multiple(
+            () => Assert.Equal(StepInstanceLifecycleState.Running, enqueueStep.Lifecycle.State),
+            () => Assert.Null(enqueueStep.Lifecycle.TerminationState),
+            () => Assert.Null(enqueueStep.Lifecycle.TerminatedAt));
+
+        // - Enqueue actor messages client should be called with the correct parameters.
+        _enqueueActorMessagesClient.Verify(
+            client => client.EnqueueAsync(
+                Brs_021_ForwardedMeteredData.V1,
+                orchestrationInstance.Id.Value,
+                orchestrationInstance.Lifecycle.CreatedBy.Value.MapToDto(),
+                It.IsAny<Guid>(),
+                It.Is<ForwardMeteredDataAcceptedV1>(m =>
+                    m.MeteringPointId == _meteringPointId.Value &&
+                    m.OriginalActorMessageId == _actorMessageId &&
+                    HasCorrectReceivers(m))),
+            Times.Once);
+        _enqueueActorMessagesClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Given_TerminatedOrchestrationInstance_When_HandleAsync_Then_NothingHappens()
+    {
+        // Arrange
+        var orchestrationInstance = CreateTerminatedOrchestrationInstance();
+
+        await using (var setupContext = _fixture.DatabaseManager.CreateDbContext())
+        {
+            setupContext.OrchestrationInstances.Add(orchestrationInstance);
+            await setupContext.SaveChangesAsync();
+        }
+
+        // Act
+        await Sut.HandleAsync(orchestrationInstance.Id.Value);
+
+        // Assert
+        await using var assertionDbContext = _fixture.DatabaseManager.CreateDbContext();
+        var actualOrchestrationInstance = await assertionDbContext.OrchestrationInstances
+            .SingleAsync(oi => oi.Id == orchestrationInstance.Id);
+
+        // - The orchestration instance should not be changed.
+        Assert.Equivalent(orchestrationInstance, actualOrchestrationInstance);
+
+        // - The enqueue actor messages client should not be called.
+        _enqueueActorMessagesClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Given_QueuedOrchestrationInstance_When_HandleAsync_Then_ThrowsException_AndThen_ActorMessagesNotEnqueued()
+    {
+        // Arrange
+        var orchestrationInstance = CreateOrchestrationInstance();
+        orchestrationInstance.Lifecycle.TransitionToQueued(_clock.Object);
+
+        await using (var setupContext = _fixture.DatabaseManager.CreateDbContext())
+        {
+            setupContext.OrchestrationInstances.Add(orchestrationInstance);
+            await setupContext.SaveChangesAsync();
+        }
+
+        // Act
+        var act = () => Sut.HandleAsync(orchestrationInstance.Id.Value);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+
+        await using var assertionDbContext = _fixture.DatabaseManager.CreateDbContext();
+        var actualOrchestrationInstance = await assertionDbContext.OrchestrationInstances
+            .SingleAsync(oi => oi.Id == orchestrationInstance.Id);
+
+        // - The orchestration instance should not be changed.
+        Assert.Equivalent(orchestrationInstance, actualOrchestrationInstance);
+
+        _enqueueActorMessagesClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Given_ForwardToMeasurementsStepNotRunning_When_HandleAsync_Then_ThrowsException_AndThen_ActorMessagesNotEnqueued()
+    {
+        // Arrange
+        var orchestrationInstance = CreateOrchestrationInstance();
+        orchestrationInstance.Lifecycle.TransitionToQueued(_clock.Object);
+        orchestrationInstance.Lifecycle.TransitionToRunning(_clock.Object);
+
+        orchestrationInstance.TransitionStepToRunning(
+            OrchestrationDescriptionBuilder.BusinessValidationStep,
+            _clock.Object);
+        orchestrationInstance.TransitionStepToTerminated(
+            OrchestrationDescriptionBuilder.BusinessValidationStep,
+            StepInstanceTerminationState.Succeeded,
+            _clock.Object);
+
+        // ForwardToMeasurements step is not transitioned to running.
+
+        await using (var setupContext = _fixture.DatabaseManager.CreateDbContext())
+        {
+            setupContext.OrchestrationInstances.Add(orchestrationInstance);
+            await setupContext.SaveChangesAsync();
+        }
+
+        // Act
+        var act = () => Sut.HandleAsync(orchestrationInstance.Id.Value);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+
+        await using var assertionDbContext = _fixture.DatabaseManager.CreateDbContext();
+        var actualOrchestrationInstance = await assertionDbContext.OrchestrationInstances
+            .SingleAsync(oi => oi.Id == orchestrationInstance.Id);
+
+        // - The orchestration instance should not be changed.
+        Assert.Equivalent(orchestrationInstance, actualOrchestrationInstance);
+
+        _enqueueActorMessagesClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Given_OrchestrationInstanceDoesntExist_When_HandleAsync_Then_ThrowsException()
+    {
+        // Act
+        var act = () => Sut.HandleAsync(Guid.NewGuid());
+
+        // Assert
+        await Assert.ThrowsAsync<NullReferenceException>(act);
+        _enqueueActorMessagesClient.VerifyNoOtherCalls();
+    }
+
+    private OrchestrationInstance CreateOrchestrationInstance()
+    {
+        var input = new ForwardMeteredDataInputV1Builder()
+            .WithMeteringPointId(_meteringPointId.Value)
+            .WithActorMessageId(_actorMessageId)
+            .WithMeteringPointType(MeteringPointType.Production.Name) // Used to determine the receivers
+            .Build();
+
+        var instance = OrchestrationInstance.CreateFromDescription(
+            identity: new ActorIdentity(Actor.From(input.ActorNumber, input.ActorRole)),
+            description: OrchestrationDescription,
+            skipStepsBySequence: [],
+            clock: _clock.Object,
+            meteringPointId: new MeteringPointId(input.MeteringPointId!),
+            actorMessageId: new ActorMessageId(input.ActorMessageId),
+            transactionId: new TransactionId(input.TransactionId),
+            idempotencyKey: IdempotencyKey.CreateNew());
+
+        instance.ParameterValue.SetFromInstance(input);
+
+        instance.CustomState.SetFromInstance(new ForwardMeteredDataCustomStateV2(
+            HistoricalMeteringPointMasterData: [
+                ForwardMeteredDataCustomStateV2.MasterData.FromMeteringPointMasterData(
+                    new MeteringPointMasterDataBuilder().BuildFromInput(
+                        input: input,
+                        gridAccessProvider: _gridAccessProvider,
+                        energySupplier: _energySupplier)),
+            ],
+            AdditionalRecipients: []));
+
+        return instance;
+    }
+
+    private OrchestrationInstance CreateRunningOrchestrationInstance()
+    {
+        var instance = CreateOrchestrationInstance();
+        instance.Lifecycle.TransitionToQueued(_clock.Object);
+        instance.Lifecycle.TransitionToRunning(_clock.Object);
+
+        instance.TransitionStepToRunning(
+            OrchestrationDescriptionBuilder.BusinessValidationStep,
+            _clock.Object);
+        instance.TransitionStepToTerminated(
+            OrchestrationDescriptionBuilder.BusinessValidationStep,
+            StepInstanceTerminationState.Succeeded,
+            _clock.Object);
+
+        instance.TransitionStepToRunning(
+            OrchestrationDescriptionBuilder.ForwardToMeasurementsStep,
+            _clock.Object);
+
+        return instance;
+    }
+
+    private OrchestrationInstance CreateTerminatedOrchestrationInstance()
+    {
+        var instance = CreateOrchestrationInstance();
+        instance.Lifecycle.TransitionToQueued(_clock.Object);
+        instance.Lifecycle.TransitionToRunning(_clock.Object);
+        instance.Lifecycle.TransitionToSucceeded(_clock.Object);
+
+        return instance;
+    }
+
+    private async Task<OrchestrationDescription> CreateSendMeasurementsOrchestrationDescriptionAsync()
+    {
+        await using var setupContext = _fixture.DatabaseManager.CreateDbContext();
+
+        // Disable all existing orchestration descriptions to ensure that only the one we add is used
+        var existingOrchestrationDescriptions = await setupContext.OrchestrationDescriptions
+            .ToListAsync();
+        existingOrchestrationDescriptions.ForEach(od => od.IsEnabled = false);
+
+        // Create a new orchestration description
+        var orchestrationDescription = new OrchestrationDescriptionBuilder().Build();
+        setupContext.OrchestrationDescriptions.Add(orchestrationDescription);
+
+        await setupContext.SaveChangesAsync();
+
+        return orchestrationDescription;
+    }
+
+    private bool HasCorrectReceivers(ForwardMeteredDataAcceptedV1 m)
+    {
+        // There is only one period in the test data, so there should only be one ReceiversWithMeteredData.
+        if (m.ReceiversWithMeteredData.Count != 1)
+            return false;
+
+        var receiversWithMeteredData = m.ReceiversWithMeteredData.Single();
+
+        // Metering point type is consumption, which means there should be two receivers (energy supplier and danish energy agency).
+        var hasEnergySupplier = receiversWithMeteredData.Actors.Any(
+            a =>
+                a.ActorNumber == _energySupplier &&
+                a.ActorRole == ActorRole.EnergySupplier);
+
+        var hasDanishEnergyAgency = receiversWithMeteredData.Actors.Any(
+            a =>
+                a.ActorNumber == ActorNumber.Create(DataHubDetails.DanishEnergyAgencyNumber) &&
+                a.ActorRole == ActorRole.DanishEnergyAgency);
+
+        // There should be exactly two actors in the ReceiversWithMeteredData, one for the energy supplier and one
+        // for the danish energy agency.
+        return receiversWithMeteredData.Actors.Count == 2 &&
+               hasEnergySupplier &&
+               hasDanishEnergyAgency;
+    }
+}

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeasurementsHandlerV1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeasurementsHandlerV1Tests.cs
@@ -380,11 +380,11 @@ public class EnqueueMeasurementsHandlerV1Tests
         var receiversWithMeteredData = acceptedMessage.ReceiversWithMeteredData.Single();
 
         // Metering point type is consumption, which means there should be two receivers (energy supplier and danish energy agency).
+        var hasCorrectActorsCount = receiversWithMeteredData.Actors.Count == 2;
         var hasEnergySupplier = receiversWithMeteredData.Actors.Any(
             a =>
                 a.ActorNumber == _energySupplier &&
                 a.ActorRole == ActorRole.EnergySupplier);
-
         var hasDanishEnergyAgency = receiversWithMeteredData.Actors.Any(
             a =>
                 a.ActorNumber == ActorNumber.Create(DataHubDetails.DanishEnergyAgencyNumber) &&
@@ -397,13 +397,15 @@ public class EnqueueMeasurementsHandlerV1Tests
         var hasCorrectDates = acceptedMessage.StartDateTime == InstantPatternWithOptionalSeconds.Parse(input.StartDateTime).Value.ToDateTimeOffset()
             && acceptedMessage.EndDateTime == InstantPatternWithOptionalSeconds.Parse(input.EndDateTime!).Value.ToDateTimeOffset();
 
-        // There should be exactly two actors in the ReceiversWithMeteredData, one for the energy supplier and one
-        // for the danish energy agency.
-        return receiversWithMeteredData.Actors.Count == 2 &&
-               hasEnergySupplier &&
-               hasDanishEnergyAgency &&
-               hasCorrectMeteredDataCount &&
-               hasCorrectMeteredDataQuantity &&
-               hasCorrectDates;
+        return
+            // Correct actors (receivers)
+            hasCorrectActorsCount &&
+            hasEnergySupplier &&
+            hasDanishEnergyAgency &&
+
+            // Correct metered data
+            hasCorrectMeteredDataCount &&
+            hasCorrectMeteredDataQuantity &&
+            hasCorrectDates;
     }
 }

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1Tests.cs
@@ -274,7 +274,7 @@ public class StartForwardMeteredDataHandlerV1Tests
 
         Assert.NotNull(sendMeasurementsInstance);
 
-        var inputFromFileStorage = await DownloadInputFromFileStorage(sendMeasurementsInstance.FileStorageReference);
+        var inputFromFileStorage = await DownloadInputFromFileStorageAsync(sendMeasurementsInstance.FileStorageReference);
 
         Assert.Equivalent(input, inputFromFileStorage);
     }
@@ -509,7 +509,7 @@ public class StartForwardMeteredDataHandlerV1Tests
             }));
     }
 
-    private async Task<ForwardMeteredDataInputV1> DownloadInputFromFileStorage(IFileStorageReference fileStorageReference)
+    private async Task<ForwardMeteredDataInputV1> DownloadInputFromFileStorageAsync(IFileStorageReference fileStorageReference)
     {
         var fileStorageClient = _serviceProvider.GetRequiredService<IFileStorageClient>();
         var stream = await fileStorageClient.DownloadAsync(fileStorageReference, CancellationToken.None);

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1Tests.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1Tests.cs
@@ -202,7 +202,7 @@ public class StartForwardMeteredDataHandlerV1Tests
             // Validation errors should be saved to the validation errors property
             () => Assert.NotEmpty(sendMeasurementsInstance.ValidationErrors.SerializedValue),
             () => Assert.False(sendMeasurementsInstance.IsSentToMeasurements, "Should not be sent to measurements when validation fails"),
-            () => Assert.True(sendMeasurementsInstance.IsSentToEnqueueActorMessagesAt, "Rejected actor message should be enqueued"));
+            () => Assert.True(sendMeasurementsInstance.IsSentToEnqueueActorMessages, "Rejected actor message should be enqueued"));
 
         // Enqueue actor messages client should be called once to enqueue the rejected message
         _enqueueActorMessagesClient.Verify(

--- a/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/ServiceBusResponseMocking.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Integration/Processes/BRS_021/ForwardMeteredData/V1/ServiceBusResponseMocking.cs
@@ -16,6 +16,7 @@ using System.Text.Json;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.ServiceBus.ListenerMock;
 using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
 using Energinet.DataHub.ProcessManager.Client;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1;
 using FluentAssertions;
@@ -34,7 +35,7 @@ public static class ServiceBusResponseMocking
             .When(
                 message =>
                 {
-                    if (message.Subject != EnqueueActorMessagesV1.BuildServiceBusMessageSubject(OrchestrationDescriptionBuilder.UniqueName))
+                    if (message.Subject != EnqueueActorMessagesV1.BuildServiceBusMessageSubject(Brs_021_ForwardedMeteredData.V1))
                         return false;
 
                     var body = EnqueueActorMessagesV1

--- a/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/ForwardMeteredDataInputV1Builder.cs
+++ b/source/ProcessManager.Orchestrations.Tests/Unit/Processes/BRS_021/ForwardMeteredData/V1/ForwardMeteredDataInputV1Builder.cs
@@ -22,8 +22,8 @@ public class ForwardMeteredDataInputV1Builder
 {
     private const string ActorNumber = "1234567890123";
 
-    private string _actorMessageId = "MessageId";
-    private string _transactionId = "TransactionId";
+    private string _actorMessageId = Guid.NewGuid().ToString();
+    private string _transactionId = Guid.NewGuid().ToString();
     private string _actorNumber = ActorNumber;
     private string _actorRole = ActorRole.GridAccessProvider.Name;
     private string _businessReason = BusinessReason.PeriodicMetering.Name; // Due to validation in EDI this can either be PeriodicMetering or PeriodicFlexMetering

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Extensions/ForwardMeteredDataInputSerializationExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Extensions/ForwardMeteredDataInputSerializationExtensions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json;
+using Energinet.DataHub.ProcessManager.Core.Application.FileStorage;
+using Energinet.DataHub.ProcessManager.Core.Domain.FileStorage;
+using Energinet.DataHub.ProcessManager.Core.Domain.SendMeasurements;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+
+namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Extensions;
+
+public static class ForwardMeteredDataInputSerializationExtensions
+{
+    public static async Task<MemoryStream> SerializeToStreamAsync(this ForwardMeteredDataInputV1 input)
+    {
+        var inputAsStream = new MemoryStream();
+        await JsonSerializer.SerializeAsync(inputAsStream, input).ConfigureAwait(false);
+
+        return inputAsStream;
+    }
+
+    public static async Task<ForwardMeteredDataInputV1> DeserializeForwardMeteredDataInputV1Async(
+        this ReadOnceStream inputStream,
+        IFileStorageReference fileStorageReference)
+    {
+        var input = await JsonSerializer.DeserializeAsync<ForwardMeteredDataInputV1>(inputStream.Stream)
+            .ConfigureAwait(false);
+
+        return input
+               ?? throw new InvalidOperationException($"Failed to deserialize input for SendMeasurementsInstance (Path={fileStorageReference.Path}, Container={fileStorageReference.Category}).");
+    }
+}

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Extensions/ForwardMeteredDataInputSerializationExtensions.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Extensions/ForwardMeteredDataInputSerializationExtensions.cs
@@ -20,7 +20,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Extensions;
 
-public static class ForwardMeteredDataInputSerializationExtensions
+internal static class ForwardMeteredDataInputSerializationExtensions
 {
     public static async Task<MemoryStream> SerializeToStreamAsync(this ForwardMeteredDataInputV1 input)
     {

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeasurementsHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeasurementsHandlerV1.cs
@@ -90,10 +90,7 @@ public class EnqueueMeasurementsHandlerV1(
         }
 
         var inputStream = await _sendMeasurementsInstanceRepository.DownloadInputAsync(instance.FileStorageReference).ConfigureAwait(false);
-        var input = await JsonSerializer.DeserializeAsync<ForwardMeteredDataInputV1>(inputStream.Stream).ConfigureAwait(false);
-
-        if (input is null)
-            throw new InvalidOperationException($"Failed to deserialize input for SendMeasurementsInstance (Id={instance.Id}).");
+        var input = await inputStream.DeserializeForwardMeteredDataInputV1Async(instance.FileStorageReference).ConfigureAwait(false);
 
         // Only valid data will be enqueued
         var forwardMeteredDataInput = ForwardMeteredDataValidInput.From(input);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeasurementsHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/EnqueueMeasurementsHandlerV1.cs
@@ -12,34 +12,99 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Text.Json;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Components.EnqueueActorMessages;
 using Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData;
 using Energinet.DataHub.ProcessManager.Components.MeteringPointMasterData.Model;
 using Energinet.DataHub.ProcessManager.Core.Application.Orchestration;
+using Energinet.DataHub.ProcessManager.Core.Application.SendMeasurements;
 using Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance;
+using Energinet.DataHub.ProcessManager.Core.Domain.SendMeasurements;
+using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.FeatureManagement;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Extensions;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Energinet.DataHub.ProcessManager.Shared.Api.Mappers;
 using Microsoft.ApplicationInsights;
+using Microsoft.FeatureManagement;
 using NodaTime;
+using OrchestrationInstanceLifecycleState = Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance.OrchestrationInstanceLifecycleState;
+using StepInstanceLifecycleState = Energinet.DataHub.ProcessManager.Core.Domain.OrchestrationInstance.StepInstanceLifecycleState;
 
 namespace Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Handlers;
 
 public class EnqueueMeasurementsHandlerV1(
     IOrchestrationInstanceProgressRepository progressRepository,
+    ISendMeasurementsInstanceRepository sendMeasurementsInstanceRepository,
     IClock clock,
     IEnqueueActorMessagesClient enqueueActorMessagesClient,
     MeteringPointReceiversProvider meteringPointReceiversProvider,
-    TelemetryClient telemetryClient)
+    TelemetryClient telemetryClient,
+    IFeatureManager featureManager)
 {
     private readonly IOrchestrationInstanceProgressRepository _progressRepository = progressRepository;
+    private readonly ISendMeasurementsInstanceRepository _sendMeasurementsInstanceRepository = sendMeasurementsInstanceRepository;
     private readonly IClock _clock = clock;
     private readonly IEnqueueActorMessagesClient _enqueueActorMessagesClient = enqueueActorMessagesClient;
     private readonly MeteringPointReceiversProvider _meteringPointReceiversProvider = meteringPointReceiversProvider;
     private readonly TelemetryClient _telemetryClient = telemetryClient;
+    private readonly IFeatureManager _featureManager = featureManager;
 
-    public async Task HandleAsync(OrchestrationInstanceId orchestrationInstanceId)
+    public async Task HandleAsync(Guid instanceId)
+    {
+        var useNewSendMeasurementsTable = await _featureManager.UseNewSendMeasurementsTable().ConfigureAwait(false);
+
+        if (useNewSendMeasurementsTable)
+        {
+            await HandleSendMeasurementsInstanceAsync(SendMeasurementsInstanceId.FromExisting(instanceId))
+                .ConfigureAwait(false);
+        }
+        else
+        {
+            await HandleOrchestrationInstanceAsync(new OrchestrationInstanceId(instanceId))
+                .ConfigureAwait(false);
+        }
+    }
+
+    public async Task HandleSendMeasurementsInstanceAsync(SendMeasurementsInstanceId sendMeasurementsInstanceId)
+    {
+        var instance = await _sendMeasurementsInstanceRepository
+            .GetAsync(sendMeasurementsInstanceId)
+            .ConfigureAwait(false);
+
+        // If the orchestration instance is terminated, do nothing (idempotency/retry check).
+        if (instance.Lifecycle.State is OrchestrationInstanceLifecycleState.Terminated)
+            return;
+
+        instance.MarkAsReceivedFromMeasurements(_clock.GetCurrentInstant());
+        await _sendMeasurementsInstanceRepository.UnitOfWork.CommitAsync().ConfigureAwait(false);
+
+        var inputStream = await _sendMeasurementsInstanceRepository.DownloadInputAsync(instance.FileStorageReference).ConfigureAwait(false);
+        var input = await JsonSerializer.DeserializeAsync<ForwardMeteredDataInputV1>(inputStream.Stream).ConfigureAwait(false);
+
+        if (input is null)
+            throw new InvalidOperationException($"Failed to deserialize input for SendMeasurementsInstance (Id={instance.Id}).");
+
+        // Only valid data will be enqueued
+        var forwardMeteredDataInput = ForwardMeteredDataValidInput.From(input);
+
+        var masterDataCustomState = instance.MasterData.AsType<ForwardMeteredDataCustomStateV2>();
+
+        // Start Step: Find receiver step
+        var receiversWithMeteredData = FindReceivers(masterDataCustomState, forwardMeteredDataInput);
+
+        // Start Step: Enqueue actor messages step
+        await EnqueueAcceptedActorMessagesAsync(
+                instance,
+                forwardMeteredDataInput,
+                masterDataCustomState,
+                receiversWithMeteredData)
+            .ConfigureAwait(false);
+    }
+
+    private async Task HandleOrchestrationInstanceAsync(OrchestrationInstanceId orchestrationInstanceId)
     {
         var orchestrationInstance = await _progressRepository
             .GetAsync(orchestrationInstanceId)
@@ -117,6 +182,17 @@ public class EnqueueMeasurementsHandlerV1(
         return receiversWithMeteredData;
     }
 
+    private IReadOnlyCollection<ReceiversWithMeteredDataV1> FindReceivers(
+        ForwardMeteredDataCustomStateV2 customState,
+        ForwardMeteredDataValidInput forwardMeteredDataValidInput)
+    {
+        var receiversWithMeteredData = CalculateReceiversWithMeasurements(
+            customState,
+            forwardMeteredDataValidInput);
+
+        return receiversWithMeteredData;
+    }
+
     /// <summary>
     /// Calculate receivers with measurements based on the metering point master data and the forward metered data input.
     /// <remarks>
@@ -167,7 +243,7 @@ public class EnqueueMeasurementsHandlerV1(
 
     private async Task EnqueueAcceptedActorMessagesAsync(
         OrchestrationInstance orchestrationInstance,
-        ForwardMeteredDataValidInput forwardMeteredDataInput,
+        ForwardMeteredDataValidInput input,
         IReadOnlyCollection<ReceiversWithMeteredDataV1> receivers)
     {
         var enqueueStep = orchestrationInstance.GetStep(OrchestrationDescriptionBuilder.EnqueueActorMessagesStep);
@@ -202,20 +278,60 @@ public class EnqueueMeasurementsHandlerV1(
 
         // Enqueue forward metered data actor messages
         var data = new ForwardMeteredDataAcceptedV1(
-            OriginalActorMessageId: forwardMeteredDataInput.ActorMessageId.Value,
-            MeteringPointId: forwardMeteredDataInput.MeteringPointId.Value,
-            MeteringPointType: forwardMeteredDataInput.MeteringPointType,
-            ProductNumber: forwardMeteredDataInput.ProductNumber,
-            RegistrationDateTime: forwardMeteredDataInput.RegistrationDateTime.ToDateTimeOffset(),
-            StartDateTime: forwardMeteredDataInput.StartDateTime.ToDateTimeOffset(),
-            EndDateTime: forwardMeteredDataInput.EndDateTime.ToDateTimeOffset(),
+            OriginalActorMessageId: input.ActorMessageId.Value,
+            MeteringPointId: input.MeteringPointId.Value,
+            MeteringPointType: input.MeteringPointType,
+            ProductNumber: input.ProductNumber,
+            RegistrationDateTime: input.RegistrationDateTime.ToDateTimeOffset(),
+            StartDateTime: input.StartDateTime.ToDateTimeOffset(),
+            EndDateTime: input.EndDateTime.ToDateTimeOffset(),
             ReceiversWithMeteredData: receivers,
             GridAreaCode: gridAreaCode.Value);
 
         await _enqueueActorMessagesClient.EnqueueAsync(
-                orchestration: OrchestrationDescriptionBuilder.UniqueName,
+                orchestration: Brs_021_ForwardedMeteredData.V1,
                 orchestrationInstanceId: orchestrationInstance.Id.Value,
                 orchestrationStartedBy: orchestrationInstance.Lifecycle.CreatedBy.Value.MapToDto(),
+                idempotencyKey: idempotencyKey,
+                data: data)
+            .ConfigureAwait(false);
+    }
+
+    private async Task EnqueueAcceptedActorMessagesAsync(
+        SendMeasurementsInstance instance,
+        ForwardMeteredDataValidInput input,
+        ForwardMeteredDataCustomStateV2 customState,
+        IReadOnlyCollection<ReceiversWithMeteredDataV1> receivers)
+    {
+        // If the step is already terminated (idempotency/retry check), do nothing.
+        if (instance.IsSentToEnqueueActorMessages)
+            return;
+
+        // Ensure always using the same idempotency key. Messages will only be enqueued once per instance,
+        // so we can use the instance id as the idempotency key.
+        var idempotencyKey = instance.Id.Value;
+
+        var gridAreaCode = customState.HistoricalMeteringPointMasterData.FirstOrDefault()?.GridAreaCode
+                           ?? throw new InvalidOperationException($"Grid area code is required to enqueue accepted message with id {instance.Id}");
+
+        // Enqueue forward metered data actor messages
+        var data = new ForwardMeteredDataAcceptedV1(
+            OriginalActorMessageId: input.ActorMessageId.Value,
+            MeteringPointId: input.MeteringPointId.Value,
+            MeteringPointType: input.MeteringPointType,
+            ProductNumber: input.ProductNumber,
+            RegistrationDateTime: input.RegistrationDateTime.ToDateTimeOffset(),
+            StartDateTime: input.StartDateTime.ToDateTimeOffset(),
+            EndDateTime: input.EndDateTime.ToDateTimeOffset(),
+            ReceiversWithMeteredData: receivers,
+            GridAreaCode: gridAreaCode.Value);
+
+        await _enqueueActorMessagesClient.EnqueueAsync(
+                orchestration: Brs_021_ForwardedMeteredData.V1,
+                orchestrationInstanceId: instance.Id.Value,
+                orchestrationStartedBy: new ActorIdentityDto(
+                    instance.CreatedByActorNumber,
+                    instance.CreatedByActorRole),
                 idempotencyKey: idempotencyKey,
                 data: data)
             .ConfigureAwait(false);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -323,7 +323,7 @@ public class StartForwardMeteredDataHandlerV1(
         // Creates an orchestration instance (if it doesn't exist) and transitions it to queued state.
         var orchestrationInstanceId = await _commands.StartNewOrchestrationInstanceAsync(
                 actorIdentity,
-                OrchestrationDescriptionBuilder.UniqueName.MapToDomain(),
+                Brs_021_ForwardedMeteredData.V1.MapToDomain(),
                 input,
                 skipStepsBySequence: [],
                 new IdempotencyKey(idempotencyKey),
@@ -637,7 +637,7 @@ public class StartForwardMeteredDataHandlerV1(
         var actorIdentity = ((ActorIdentity)orchestrationInstance.Lifecycle.CreatedBy.Value).Actor;
 
         await _enqueueActorMessagesClient.EnqueueAsync(
-                OrchestrationDescriptionBuilder.UniqueName,
+                Brs_021_ForwardedMeteredData.V1,
                 orchestrationInstance.Id.Value,
                 new ActorIdentityDto(
                     ActorNumber.Create(actorIdentity.Number.Value),
@@ -661,7 +661,7 @@ public class StartForwardMeteredDataHandlerV1(
         IReadOnlyCollection<ValidationError> validationErrors)
     {
         // If the step is already terminated (idempotency/retry check), do nothing.
-        if (instance.IsSentToEnqueueActorMessagesAt)
+        if (instance.IsSentToEnqueueActorMessages)
             return;
 
         // Ensure always using the same idempotency key. Messages will only be enqueued once per instance,
@@ -669,13 +669,13 @@ public class StartForwardMeteredDataHandlerV1(
         var idempotencyKey = instance.Id.Value;
 
         await _enqueueActorMessagesClient.EnqueueAsync(
-                OrchestrationDescriptionBuilder.UniqueName,
-                instance.Id.Value,
-                new ActorIdentityDto(
+                orchestration: Brs_021_ForwardedMeteredData.V1,
+                orchestrationInstanceId: instance.Id.Value,
+                orchestrationStartedBy: new ActorIdentityDto(
                     instance.CreatedByActorNumber,
                     instance.CreatedByActorRole),
-                idempotencyKey,
-                new ForwardMeteredDataRejectedV1(
+                idempotencyKey: idempotencyKey,
+                data: new ForwardMeteredDataRejectedV1(
                     forwardMeteredDataInput.ActorMessageId,
                     forwardMeteredDataInput.TransactionId,
                     ForwardedForActorRole: ActorRole.FromName(forwardMeteredDataInput.ActorRole),

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/Handlers/StartForwardMeteredDataHandlerV1.cs
@@ -31,6 +31,7 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 using Energinet.DataHub.ProcessManager.Orchestrations.FeatureManagement;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.Measurements;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.Measurements.Model;
+using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Extensions;
 using Energinet.DataHub.ProcessManager.Orchestrations.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Energinet.DataHub.ProcessManager.Shared.Api.Mappers;
 using Microsoft.ApplicationInsights;
@@ -373,8 +374,7 @@ public class StartForwardMeteredDataHandlerV1(
                 meteringPointId: meteringPointId is not null ? new MeteringPointId(meteringPointId) : null,
                 idempotencyKey: idempotencyKey);
 
-            using var inputAsStream = new MemoryStream();
-            await JsonSerializer.SerializeAsync(inputAsStream, input).ConfigureAwait(false);
+            using var inputAsStream = await input.SerializeToStreamAsync().ConfigureAwait(false);
 
             await _sendMeasurementsInstanceRepository.AddAsync(instance, inputAsStream)
                 .ConfigureAwait(false);

--- a/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/OrchestrationDescriptionBuilder.cs
+++ b/source/ProcessManager.Orchestrations/Processes/BRS_021/ForwardMeteredData/V1/OrchestrationDescriptionBuilder.cs
@@ -26,7 +26,6 @@ internal class OrchestrationDescriptionBuilder : IOrchestrationDescriptionBuilde
     public const int ForwardToMeasurementsStep = 2;
     public const int FindReceiversStep = 3;
     public const int EnqueueActorMessagesStep = 4;
-    public static readonly OrchestrationDescriptionUniqueNameDto UniqueName = new("Brs_021_ForwardMeteredData", 1);
 
     public OrchestrationDescription Build()
     {

--- a/source/Shared/Tests/Fixtures/OrchestrationsAppManager.cs
+++ b/source/Shared/Tests/Fixtures/OrchestrationsAppManager.cs
@@ -632,7 +632,7 @@ public class OrchestrationsAppManager : IAsyncDisposable
         {
             builder
                 .AddSubscription(Brs021ForwardMeteredDataSubscriptionName)
-                    .AddSubjectFilter(EnqueueActorMessagesV1.BuildServiceBusMessageSubject(OrchestrationDescriptionBuilder.UniqueName))
+                    .AddSubjectFilter(EnqueueActorMessagesV1.BuildServiceBusMessageSubject(Brs_021_ForwardedMeteredData.V1))
                 .AddSubscription(Brs023027SubscriptionName)
                     .AddSubjectFilter(EnqueueActorMessagesV1.BuildServiceBusMessageSubject(Brs_023_027.V1))
                 .AddSubscription(Brs024SubscriptionName)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

- Update `EnqueueMeasurementsHandlerV1` to use new `SendMeasurementsInstance` (if feature is enabled).
- Copy `EnqueueMeasurementsHandlerV1Tests` to `EnqueueMeasurementsHandlerV1OldTests` (DO NOT REVIEW THIS, it is just a copy of the existing tests).
- Update `EnqueueMeasurementsHandlerV1Tests` to test the new `SendMeasurementsInstance` flow, including adding `Azurite` (File Storage) support.
- Update `StartForwardMeteredDataHandlerV1Tests` to check for correct database & file storage values.
- Remove `OrchestrationDescriptionBuilder.UniqueName` property, since it was just a duplicate of `Brs_021_ForwardedMeteredData.V1`.
- Update `EnqueueMeteredDataTrigger_Brs_021_ForwardMeteredData_V1` to support both `OrchestrationInstanceId` and `SendMeasurementsInstanceId`.

## References

- Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/819
- d002 run: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/15557294139/job/43801908043

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
