### PR TITLE
feat: Extend ForwardMeteredDataInputV1 with DataSource

### DIFF
--- a/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
+++ b/docs/ProcessManager.Orchestrations.Abstractions/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # ProcessManager.Orchestrations.Abstractions Release Notes
 
+## Version 2.4.0
+
+- Extend `ForwardMeteredDataInputV1` with property `DataSource` which by default is set to `ActorSystem`.
+
 ## Version 2.3.6
 
 - Update `RequestYearlyMeasurementsAcceptedV1` such that it contains a list of `AggregatedMeasurement`.

--- a/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
+++ b/source/ProcessManager.Orchestrations.Abstractions/ProcessManager.Orchestrations.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.ProcessManager.Orchestrations.Abstractions</PackageId>
-    <PackageVersion>2.3.6$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.4.0$(VersionSuffix)</PackageVersion>
     <Title>DH3 Process Manager Orchestrations Abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/ForwardMeteredDataInputV1.cs
+++ b/source/ProcessManager.Orchestrations.Abstractions/Processes/BRS_021/ForwardMeteredData/V1/Model/ForwardMeteredDataInputV1.cs
@@ -34,9 +34,26 @@ public record ForwardMeteredDataInputV1(
     string StartDateTime,
     string? EndDateTime,
     string GridAccessProviderNumber,
-    IReadOnlyCollection<ForwardMeteredDataInputV1.MeteredData> MeteredDataList)
+    IReadOnlyCollection<ForwardMeteredDataInputV1.MeteredData> MeteredDataList,
+    ForwardMeteredDataInputV1.DataSourceEnum DataSource = ForwardMeteredDataInputV1.DataSourceEnum.ActorSystem)
     : IInputParameterDto
 {
+    /// <summary>
+    /// Specifies the channel through which we received the data.
+    /// </summary>
+    public enum DataSourceEnum
+    {
+        /// <summary>
+        /// Data was send the traditional way, from the actor's system to EDI.
+        /// </summary>
+        ActorSystem = 0,
+
+        /// <summary>
+        /// Data was send by a trigger that listen's for data from the Migration subsystem.
+        /// </summary>
+        MigrationSubsystem = 1,
+    }
+
     public record MeteredData(
         string? Position,
         string? EnergyQuantity,


### PR DESCRIPTION
## Description

Extend the input with a DataSource property that we can use from EDI to tell where data originated from.

## References

Link to assignment: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/808

## Checklist

- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003)
  - `dev_002`: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/15554765858
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task
